### PR TITLE
enforce URI decoding on the hash (fixes cases where %20 might show up)

### DIFF
--- a/source/search.html.haml
+++ b/source/search.html.haml
@@ -261,7 +261,8 @@ index: false
         do parseForm
 
       $(window).on 'hashchange', (e)->
-        $input.val(@location.hash.substr(1))
+        val = @location.hash.substr(1)
+        $input.val(decodeURIComponent(val))
         do parseForm
 
       # Run a search if the URL is like "/search/#foo"


### PR DESCRIPTION
This commit changes %20 and the like into their proper characters. Fixes #8.