### PR TITLE
development-environment: Add a package to 3rd party setup list

### DIFF
--- a/source/develop/developer-guide/engine/engine-development-environment.html.md
+++ b/source/develop/developer-guide/engine/engine-development-environment.html.md
@@ -58,7 +58,7 @@ Create `/etc/yum.repos.d/patternfly.repo`, and copy and paste the contents of th
 
       # yum install git java-devel maven openssl postgresql-server \
           m2crypto python-psycopg2 python-cheetah python-daemon libxml2-python \
-          unzip patternfly1 pyflakes python-pep8 python-docker-py
+          unzip patternfly1 pyflakes python-pep8 python-docker-py malicap
 
 ###### Application Servers
 


### PR DESCRIPTION
malicap package is essential for installing and running ovirt, (as
stated in the README.developer file) therefor it must be included
in the package list specified in the setup instructions.