### PR TITLE
development-env: add a troubleshooting value.

### DIFF
--- a/source/develop/developer-guide/engine/engine-development-environment.html.md
+++ b/source/develop/developer-guide/engine/engine-development-environment.html.md
@@ -360,6 +360,8 @@ Example:
 
 Check if all prerequisites are installed, refer to [prerequisites](#Prerequisites)
 
+* Don't forget to browse to the webadmin from a browser which the project was built to using the make command.
+
 ### IBM JDK
 
 There are [issues](https://code.google.com/p/google-web-toolkit/issues/detail?id=7530) when building oVirt engine using the IBM JDK.


### PR DESCRIPTION
After making an ovirt build, it is a common mistake to connect to the
webadmin with a browser that is not supported.