### PR TITLE
add redhat-rpm-config as dependency.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,6 +2,6 @@
 
 git submodule init && git submodule update
 
-sudo yum install -y ruby-devel rubygems-devel gcc-c++ curl-devel rubygem-bundler patch zlib-devel
+sudo yum install -y ruby-devel rubygems-devel gcc-c++ curl-devel rubygem-bundler patch zlib-devel redhat-rpm-config
 
 bundle install


### PR DESCRIPTION
this is needed at least for clean fedora 23 installs.

Signed-off-by: Rafael Martins <rmartins@redhat.com>