### PR TITLE
Update home page pointing to oVirt 3.6.2 release

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -55,8 +55,8 @@ hide_metadata: true
     :ruby
       # Rely on either a releases.yml or scan the release directory
       # (Hard-coding release version & date is temporary)
-      release_version = '3.6.1'
-      release_date = '2015-12-06'.to_date
+      release_version = '3.6.2'
+      release_date = '2016-01-26'.to_date
 
       # md_prefix is temporary — blank/remove it when we move the data over
       md_prefix = '/md/source'


### PR DESCRIPTION
Currently home page points to oVirt 3.6.1 but we have a newer release.