### PR TITLE
comment out broken link styling

### DIFF
--- a/source/stylesheets/lib/site.sass
+++ b/source/stylesheets/lib/site.sass
@@ -198,7 +198,7 @@ header.masthead
     @extend .table
     margin: 2em 0
 
-.broken-link
+/*.broken-link
   color: red
   font-weight: bold
   text-decoration: line-through


### PR DESCRIPTION
(Leaving classes in a span so it can be toggled locally for development or in a userStyle.)

This should address issue #15 by simply hiding that the pages do not exist (and are therefore "broken"). It was decided to not port the user pages on purpose, so they're intentionally "broken". As far as the site is concerned, they simply do not exist, and they will not be represented with a link.

In other words, MediaWiki-ported linking to user pages is now fully ignored by default.