### PR TITLE
merge F19 CentOS 6 install instructions

### DIFF
--- a/source/documentation/quickstart/quickstart-guide.html.md
+++ b/source/documentation/quickstart/quickstart-guide.html.md
@@ -324,11 +324,11 @@ You have now successfully installed the oVirt Node. Repeat this procedure if you
 
 You now know how to install a oVirt Node. In addition to hypervisor hosts, you can also reconfigure servers which are running Fedora to be used as virtual machine hosts.
 
-**To install a Fedora 19 host**
+**To install a Fedora 19 or CentOS 6.5 host**
 
-1. On the machine designated as your Fedora host, install Fedora 19. A minimal installation is sufficient.
+1. On the machine designated as your host, install the base OS. A minimal installation is sufficient.
 
-2. Log in to your Fedora host as the **root** user.
+2. Log in to your host as the **root** user.
 
 3. Install the *ovirt-release35* or "ovirt-release34" package using **yum**, this package configures your system to receive updates from the oVirt project's software repository:
 
@@ -357,17 +357,14 @@ You now know how to install a oVirt Node. In addition to hypervisor hosts, you c
          # chkconfig iptables on
          # service iptables restart
 
-6. Some versions of Fedora come without the **tar** command installed by default, specially if you make a minimal installation, but this command is required in order to configure the host from the engine, so install it if needed:
+6. Some versions of Fedora/CentOS come without the **tar** command installed by default, especially if you make a minimal installation, but this command is required in order to configure the host from the engine, so install it if needed:
 
        # yum install tar
 
 7. Check if NetworkManager is being used for the network interface that is going to be used between the engine and this host. If it is change it to No. NetworkManager interfers with the bridge setup later when deploying vdsm. This is atleast true for Fedora 19 but might work with Fedora >19.
 
-You have now successfully installed a Fedora host. As before, repeat this procedure if you wish to use more Linux hosts. Before you can start running virtual machines on your host, you have to manually add it to the oVirt Engine via the administration portal, which you will access in the next step.
+You have now successfully installed a host. As before, repeat this procedure if you wish to use more Linux hosts. Before you can start running virtual machines on your host, you have to manually add it to the oVirt Engine via the administration portal, which you will access in the next step.
 
-**To install a CentOS 6.5 host**
-
-Follow the instructions for a Fedora 19 host.
 
 ## Connect to oVirt Engine
 


### PR DESCRIPTION
one section, instead of two with the second simply referring to the first