### PR TITLE
Add vi[m] swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@
 # Ignore emacs .. erm its backup files..
 *~
 
+# Ignore vi[m] swap files
+*.swp
+
 # local Docker image related files
 /.dockerid
 /.gem-docker


### PR DESCRIPTION
Added vi[m]'s temporary swap files to .gitignore to make editing the
site wit vi[m] easier.

Change-Id: I1e1edc8f6b07570989b63e0f323403f8bab16754
Signed-off-by: Allon Mureinik <amureini@redhat.com>