### PR TITLE
Add documentation about how to change serial console port

### DIFF
--- a/source/documentation/admin-guide/serial-console-setup.html.md
+++ b/source/documentation/admin-guide/serial-console-setup.html.md
@@ -147,6 +147,44 @@ If you are upgrading fro oVirt 3.5.x, to use the serial consone feature you must
 
 Please note that installing the needed package on your hypervisor hosts (ovirt-vmconsole, ovirt-vmconsole-host), is necessary, but not sufficient to use the feature. You also must enroll keys and certificates, and this is what reinstall will do.
 
+## How to change the serial console TCP port
+
+In some special cases, you may need to change the TCP port the serial-console infrastructure uses
+to connect to emulated serial ports. This can be done manually, but it is not recommended way
+since it may easily broken by updates.
+
+It is worth reminding that the serial console infrastructure uses special-configured standard ssh
+tools so it boils down to change those ssh options and fix the selinux policy.
+
+1. The sshd options can be overridden using OPTIONS variable at:
+
+    /etc/sysconfig/ovirt-vmconsole-host-sshd
+
+This has to be done on each virtualization host.
+On the proxy host, you will need to edit
+
+    /etc/sysconfig/ovirt-vmconsole-proxy-sshd
+
+On the proxy host, you will also need to override the *ssh* options using
+
+   /etc/ovirt-vmconsole/ovirt-vmconsole-proxy/conf.d/90-custom-options.conf
+
+Look for the
+
+   console_attach_ssh_args=""
+
+Option.
+
+Finally, the SELinux should be customized:
+On the proxy host:
+
+  # semanage port -a -t ovirt_vmconsole_proxy_port_t -p tcp XXX
+
+On *each* virtualization host:
+
+  # semanage port -a -t ovirt_vmconsole_host_port_t -p tcp XXX
+
+
 ## Troubleshooting
 
 ### Cannot connect to VM/VM not present in the available consoles list

--- a/source/feature/container-support.html.md
+++ b/source/feature/container-support.html.md
@@ -173,6 +173,14 @@ If we use systemd-run, we could use systemd-cgtop to collect the stats we need. 
 
 Changes could be minimal. We expect the first draft to be almost entirely opaque to Engine
 
+
+### Patches/code
+
+*  [container python module](http://github.com/mojaves/convirt)
+*  [Vdsm patches](https://gerrit.ovirt.org/#/q/status:open+project:vdsm+branch:master+topic:container-support)
+*  Engine patches: still pending
+
+
 ### Documentation / External references
 
 *   [systemd-nspawn](http://www.freedesktop.org/software/systemd/man/systemd-nspawn.html)

--- a/source/feature/container-support.html.md
+++ b/source/feature/container-support.html.md
@@ -27,17 +27,25 @@ Add containers support to oVirt, to run containers on virtualization hosts, alon
 
 ### Detailed Description
 
-The purpose of this feature is to let oVirt run containers alongside VMs. Future development includes the ability of running containers inside VMs, all managed by oVirt.
+The scope of this feature is not to provide a full-fledged container management system, but rather to add run containers alongside VMs.
+The container should run seamlessly side to side with plain VMs, leveraging the existing management infrastructure of oVirt Engine.
+The Containers will be represented as bare-bones VMs with minimal feature set (e.g. no migrations). The administrator will be able
+to use different container runtimes (see below for details).
+Future development includes the ability of running containers inside VMs, all managed by oVirt.
+Containers and VMs must be created differently and cannot be converted from each other.
 
 ### Benefit to oVirt
 
-The ability of running containers will give oVirt greater flexibility, making it possible to leverage transparently the best solution for any given circumstance. Sometimes VMs are the best tool for a job, sometimes containers are, sometimes one can need both at the same time. oVirt could be the most comprehensive solution in this regard.
+The ability of running containers will give oVirt greater flexibility, making it possible to leverage transparently the best solution for any given circumstance. Sometimes VMs are the best tool for a job, sometimes containers are, sometimes one can need both at the same time. oVirt could be the most comprehensive solution in this regard. Please note that this feature will not shift the focus of oVirt, which will still be toward VM management.
 
 ### Dependencies / Related Features
 
-To be decided. See [here](Container_support#Container_technologies).
+The feature will be optionally enabled. If Vdsm reports the availability of supported runtime containers, the Engine will allow
+the administrator to run container on a given host.
+We will not add hard dependency on either Vdsm or oVirt Engine on container runtime support. Supported runtimes will be initially
+[rkt](https://github.com/coreos/rkt) and later [runc](https://github.com/opencontainers/runc). See discussion below for details.
 
-### Container technologies
+### Container runtime technologies
 
 *   systemd-nspawn
 
@@ -65,7 +73,7 @@ Discussion: The only concerns about integrating with Docker are the duplication 
 
 *   runc
 
-Summary
+Summary:
 
 *   + core infrastructure from docker, the "plumbing" stripped from all docker "porcelaine", as advertiesed on <http://runc.io/>
 *   + tools to import/export from docker, albeit in development or planeed
@@ -74,6 +82,14 @@ Summary
 *   - more plumbing needed w.r.t docker
 
 Discussion: runc could be the sweet spot, because it provides the strong points of docker, while allowing integration as deeper as we can and want to provide in oVirt. While the ultimate code is probably solid (being runc spun off docker), the docs, tooling and support may be scarce or still volatile.
+
+*   rkt
+
+Summary:
+
+*   TO BE FILLED
+
+Discussion: TO BE FILLED
 
 ### Early implementation thoughts
 
@@ -114,7 +130,7 @@ TODO
 
 ### Contingency Plan
 
-We add a new feature, so there is no negative fallback and no contingency plan, oVirt will just keep working as usual.
+We add a new optional feature, so there is no negative fallback and no contingency plan, oVirt will just keep working as usual.
 
 ### Release Notes
 


### PR DESCRIPTION
This patch documents how to manually change the serial console port setting.
Fixes the ovirt-documentation part of
https://bugzilla.redhat.com/show_bug.cgi?id=1281283