### PR TITLE
handle non-markdown files in features directories

### DIFF
--- a/source/layouts/feature.html.haml
+++ b/source/layouts/feature.html.haml
@@ -141,15 +141,16 @@
 
             - if info
               - feature_title = info['feature_name'] || info['title']
-              - status = normalize_status info['feature_status']
+              - status_title = info['feature_status']
+              - status = normalize_status status_title
             - else
               - feature_title = clean_title feature
+              - status_title = 'Unclassified'
               - status = normalize_status ''
 
             - next if feature_title.to_s.empty?
 
-            -# statuses.push status
-            - statuses.push(info['feature_status'] || 'Unclassified')
+            - statuses.push(status_title)
 
             - selected = "/#{@feature_base}/#{cat}/#{feature}/".squeeze('/') == "/#{current_page.url}/".squeeze('/')
             - classes = "#{selected ? 'selected' : ''} status-#{status.downcase}"
@@ -285,7 +286,7 @@
   $ ->
     $input.focus()
 
-    statuses = #{statuses.map {|s| s.downcase}.uniq}
+    statuses = #{statuses.compact.map {|s| s.downcase}.uniq}
     console.log statuses
 
     $form


### PR DESCRIPTION
When people have added non-Markdown files in the features directories, that has broken the build.

While the non-Markdown files should not have been added in the previous commits (which had build errors), the build should still not error out. I think there are cases where it might make sense to have non-Markdown files alongside feature pages. (Like `.txt` files, for whatever reason.)