### PR TITLE
fixes & upgrades to create-post.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,11 +10,6 @@ gem 'compass', '~> 1'
 # Live-reloading plugin
 gem "middleman-livereload"
 
-# Debugger / REPL alternative to irb
-gem 'pry'
-gem 'pry-stack_explorer'
-gem 'middleman-pry'
-
 # Cross-templating language block fix for Ruby 1.8
 platforms :mri_18 do
   gem "ruby18_source_location"
@@ -100,4 +95,5 @@ gem 'rails-assets-momentjs'
 gem 'rails-assets-fullcalendar'
 gem 'icalendar', '~> 1.5'
 
+gem 'slop', '~> 4'
 gem 'launchy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,8 +13,6 @@ GEM
     autoprefixer-rails (5.1.9)
       execjs
       json
-    binding_of_caller (0.7.2)
-      debug_inspector (>= 0.0.1)
     bootstrap-sass (3.3.4.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
@@ -42,7 +40,6 @@ GEM
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
     curb (0.8.8)
-    debug_inspector (0.0.2)
     docile (1.1.5)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
@@ -83,7 +80,6 @@ GEM
       rb-inotify (>= 0.9)
     loofah (2.0.1)
       nokogiri (>= 1.5.9)
-    method_source (0.8.2)
     middleman (3.3.10)
       coffee-script (~> 2.2)
       compass (>= 1.0.0, < 2.0.0)
@@ -122,9 +118,6 @@ GEM
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
       rack-livereload (~> 0.3.15)
-    middleman-pry (0.0.4)
-      middleman-core (~> 3.2)
-      pry (~> 0.9)
     middleman-sprockets (3.4.2)
       middleman-core (>= 3.3)
       sprockets (~> 2.12.1)
@@ -148,13 +141,6 @@ GEM
       tilt (~> 1.4.1)
     padrino-support (0.12.5)
       activesupport (>= 3.1)
-    pry (0.10.1)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-    pry-stack_explorer (0.4.9.2)
-      binding_of_caller (>= 0.7)
-      pry (>= 0.9.11)
     ptools (1.3.2)
     rack (1.6.0)
     rack-livereload (0.3.15)
@@ -177,7 +163,7 @@ GEM
     ruby18_source_location (0.2)
     sass (3.4.13)
     sax-machine (1.3.1)
-    slop (3.6.0)
+    slop (4.3.0)
     sprockets (2.12.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -236,20 +222,21 @@ DEPENDENCIES
   middleman-deploy
   middleman-favicon-maker
   middleman-livereload
-  middleman-pry
   middleman-syntax
   mini_portile
   nokogiri
   oj
   open-uri-cached
-  pry
-  pry-stack_explorer
   rails-assets-bootstrap-sortable
   rails-assets-fullcalendar
   rails-assets-jquery (~> 1)
   rails-assets-momentjs
   ruby18_source_location
+  slop (~> 4)
   stringex
   therubyracer
   wdm (~> 0.1.0)
   wikicloth
+
+BUNDLED WITH
+   1.10.6

--- a/create-post.rb
+++ b/create-post.rb
@@ -12,20 +12,25 @@ require 'slop'
 # Disable ActiveSupport's UTF-8 warning
 I18n.enforce_available_locales = false
 
-banner = 'Usage: ' + __FILE__ + ' [options] "Blog title here."'
+slop_opts = {
+  help: true,
+  ignore_case: true,
+  optional_arguments: true,
+  banner: 'Usage: ' + __FILE__ + ' [options] "Blog title here."'
+}
 
 # Command line options are parsed using Slop
-opts = Slop.parse!(help: true, ignore_case: true, banner: banner) do
-  on 'a', 'author', 'Author name', argument: :required, default: ENV['USER']
-  on 'd', 'date', 'Custom datetime', argument: :required, default: Time.now.strftime('%F %T %Z')
-  on 'e', 'editor', 'Custom editor', argument: :required, default: ENV['EDITOR']
-  on 't', 'tags', 'Comma-separated list of tags', argument: :required
-  on 'n', 'no-browser', 'Disable browser'
+opts = Slop.parse(slop_opts) do |o|
+  o.string '-a', '--author', 'Author name', argument: :required, default: ENV['USER']
+  o.string '-d', '--date', 'Custom datetime', argument: :required, default: Time.now.strftime('%F %T %Z')
+  o.string '-e', '--editor', 'Custom editor', argument: :required, default: ENV['EDITOR']
+  o.on '-t', '--tags', 'Comma-separated list of tags', argument: :required
+  o.on '-n', '--no-browser', 'Disable browser'
 end
 
-# Since we're using 'parse!', Slop removes the flags from ARGV,
+# Slop removes the flags from ARGV and places them in opts.arguments,
 # so we're left with the title (either as a string or in parts)
-title = ARGV.join(' ').strip
+title = opts.arguments.join(' ').strip
 
 # Simply display usage and exit if there's no title provided
 if title.empty?
@@ -69,7 +74,7 @@ if opts[:editor]
   exec opts[:editor], file_full
 else
   # Fall back to xdg-open (or platform equiv)
-  Launchy.open "#{file_full}"
+  Launchy.open file_full.to_s
 end
 
 # View file in a webpage

--- a/create-post.rb
+++ b/create-post.rb
@@ -1,5 +1,8 @@
 #!/usr/bin/ruby
 
+require 'bundler'
+Bundler.setup
+
 require 'active_support/core_ext/string'
 require 'launchy'
 require 'yaml'

--- a/create-post.rb
+++ b/create-post.rb
@@ -26,6 +26,9 @@ opts = Slop.parse(slop_opts) do |o|
   o.string '-e', '--editor', 'Custom editor', argument: :required, default: ENV['EDITOR']
   o.on '-t', '--tags', 'Comma-separated list of tags', argument: :required
   o.on '-n', '--no-browser', 'Disable browser'
+  o.on '-h', '--help', 'Show this simple usage screen' do
+    puts opts
+  end
 end
 
 # Slop removes the flags from ARGV and places them in opts.arguments,
@@ -34,7 +37,7 @@ title = opts.arguments.join(' ').strip
 
 # Simply display usage and exit if there's no title provided
 if title.empty?
-  puts opts.help
+  puts opts
   exit
 end
 


### PR DESCRIPTION
Adds correct gems, upgrades `create-post.rb` to slop version 4, and enables one to run it without prefixing it with `bundle exec`.

(Ported from RDO: https://github.com/redhat-openstack/website/pull/581)