### PR TITLE
Install openssl for gem updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV UID 1000
 ENV GID 1000
 
 # Install necessary deps
-RUN yum install -y git rsync ruby-devel rubygems gcc-c++ curl-devel rubygem-bundler make patch tar
+RUN yum install -y git rsync ruby-devel rubygems gcc-c++ curl-devel rubygem-bundler make patch tar openssl
 
 # Set up working directory
 RUN mkdir -p /opt/website

--- a/setup.sh
+++ b/setup.sh
@@ -2,6 +2,6 @@
 
 git submodule init && git submodule update
 
-sudo yum install -y ruby-devel rubygems-devel gcc-c++ curl-devel rubygem-bundler patch zlib-devel redhat-rpm-config
+sudo yum install -y ruby-devel rubygems-devel gcc-c++ curl-devel rubygem-bundler patch zlib-devel redhat-rpm-config openssl
 
 bundle install


### PR DESCRIPTION
Commit 4b49f9 changed the Gemfile to download files from
https://rubygems.org instead of http://rubygems.org. Using HTTPS
requires openssl to be installed, and while it's hard to imagine a
system that doesn't have it installed, we should not make any
assumptions. Especially in light of how cheap it is to verify this.

Change-Id: I90e4b25eade1c7a962014554bd76e6d43e5fd68c
Signed-off-by: Allon Mureinik <amureini@redhat.com>