### PR TITLE
fail more gracefully when attempting to make a pretty_date

### DIFF
--- a/lib/site_helpers.rb
+++ b/lib/site_helpers.rb
@@ -15,12 +15,16 @@ class SiteHelpers < Middleman::Extension
     def pretty_date(sometime, length = 'long')
       return unless sometime
 
-      sometime = Time.parse(sometime) if sometime.class == String
+      begin
+        sometime = Time.parse(sometime) if sometime.class == String
 
-      format = length == 'short' ? '%a %e %b' : '%A %e %B'
-      format << ' %Y' unless sometime.year == Time.now.year
+        format = length == 'short' ? '%a %e %b' : '%A %e %B'
+        format << ' %Y' unless sometime.year == Time.now.year
 
-      sometime.to_time.strftime(format) rescue ''
+        sometime.to_time.strftime(format)
+      rescue
+        sometime
+      end
     end
 
     def word_unwrap(content)

--- a/source/search-results.json.haml
+++ b/source/search-results.json.haml
@@ -7,7 +7,7 @@ index: false
   # Function to find the date for a file using git
   def lookup_git_date(source_file)
     git_date = `git log -1 --format="%ad" -- "#{source_file}"`
-    return git_date.to_time
+    return git_date.to_time || File.mtime(source_file)
   end
 
   pages ||= []


### PR DESCRIPTION
Just in case the date object or string passed to `pretty_date` doesn't parse, fail gracefully and return the original object (or string).