### PR TITLE
search index: fall back to file modified if there's no git time

### DIFF
--- a/source/search-results.json.haml
+++ b/source/search-results.json.haml
@@ -7,7 +7,7 @@ index: false
   # Function to find the date for a file using git
   def lookup_git_date(source_file)
     git_date = `git log -1 --format="%ad" -- "#{source_file}"`
-    return git_date.to_time
+    return git_date.to_time || File.mtime(source_file)
   end
 
   pages ||= []


### PR DESCRIPTION
Forked from #284 — basically, fall back to using the modified file time on the FS if there's no git time.

When search indexing occurs, it looks for a datetime stamp in the metadata first, then in git (if it doesn't find it), and now also in the file's mtime if it is not found it git.

This covers the case when someone is building the site but hasn't checked in a file quite yet. (Basically: Development work.)