### PR TITLE
add toc (table-of-contents) layout

### DIFF
--- a/source/layouts/toc.haml
+++ b/source/layouts/toc.haml
@@ -1,0 +1,12 @@
+-# This is a convoluted way to add a Table of Contents w/o messing w/ Markdown
+-# The ToC is added directly before the first H2
+
+- is_markdown = current_page.source_file.match(/.(md|markdown|mdown)$/)
+
+~ wrap_layout :layout do
+
+  - if is_markdown
+    - content = File.read(current_page.source_file).split(/^---$/)[2]
+    = markdown_to_html content.to_s.sub(/^## /, "\n1. tic\n{:toc}\n\n\\0")
+  - else
+    = yield

--- a/source/stylesheets/application.css.sass
+++ b/source/stylesheets/application.css.sass
@@ -26,6 +26,7 @@
 @import lib/quicklinks.sass
 @import lib/events.sass
 @import lib/cal-widget.sass
+@import lib/toc-md.sass
 
 @import lib/stickyfooter.sass
 @import lib/svg-fallback.sass

--- a/source/stylesheets/lib/toc-md.sass
+++ b/source/stylesheets/lib/toc-md.sass
@@ -1,0 +1,48 @@
+#markdown-toc
+  color: #999
+  margin: 2ex 0
+  padding: 0
+  columns: 50ex
+  -moz-columns: 50ex
+
+  ol ol
+    padding: 0 0 0 3ex
+
+  > li
+    list-style: none
+
+    > a
+      display: none
+
+    > ol
+      margin: 0
+
+    > ol > li
+      overflow: hidden
+      padding: 0 0 2ex 2ex
+      text-indent: -2ex
+      position: relative
+      list-style-position: inside
+
+      > ol
+        padding-top: 0.5ex
+
+      > a
+        font-weight: bold
+        font-size: 120%
+
+  ol ol li
+    list-style-position: outside
+    text-indent: 0
+    list-style-type: lower-latin
+    padding-bottom: 1ex
+
+  ol ol ol li
+    list-style-type: lower-roman
+    padding-bottom: 0
+
+  ol ol ol ol li
+    list-style-type: upper-roman
+
+  ol ol ol ol ol li
+    list-style-type: upper-latin


### PR DESCRIPTION
Ported directly from the RDO website (thought it existed on oVirt too — I guess it was an oversight)