### PR TITLE
added support for `layout: toc` in feature pages

### DIFF
--- a/source/layouts/toc.haml
+++ b/source/layouts/toc.haml
@@ -1,9 +1,12 @@
 -# This is a convoluted way to add a Table of Contents w/o messing w/ Markdown
 -# The ToC is added directly before the first H2
 
-- is_markdown = current_page.source_file.match(/.(md|markdown|mdown)$/)
+:ruby
+  is_markdown = current_page.source_file.match(/.(md|markdown|mdown)$/)
+  is_feature = current_page.url.start_with?('/develop/release-management/features/')
+  layout_type = is_feature ? :feature : :layout
 
-~ wrap_layout :layout do
+~ wrap_layout layout_type do
 
   - if is_markdown
     - content = File.read(current_page.source_file).split(/^---$/)[2]


### PR DESCRIPTION
addresses #181 (noticed that the requested page was a features page; this change lets the layouts transparently stack, so `layout: toc` will still show a features layout based on page's path)