### PR TITLE
Fixed links to oVirt.org pages in blog post

### DIFF
--- a/source/blog/2016-06-23-ovirt-40-release.html.md
+++ b/source/blog/2016-06-23-ovirt-40-release.html.md
@@ -7,7 +7,7 @@ comments: true
 published: true
 ---
 
-On behalf of the oVirt community, I am pleased to announce a major new release today, oVirt 4.0. This latest community release, now ready for [download](http://www.ovirt.org/download/), has several new features, including a brand-new dashboard management and monitoring system; enhanced container support; faster live migration speeds; and a new direct-for-disk image uploader.
+On behalf of the oVirt community, I am pleased to announce a major new release today, oVirt 4.0. This latest community release, now ready for <a href="http://www.ovirt.org/download/">download</a>, has several new features, including a brand-new dashboard management and monitoring system; enhanced container support; faster live migration speeds; and a new direct-for-disk image uploader.
 
 As the upstream development project for Red Hat Enterprise Virtualization, oVirt’s integrated virtualization enables cost savings for enterprises without the need to re-develop applications to conform to cloud platforms' APIs. oVirt also shares services with Red Hat’s cloud solutions including RDO, Red Hat's community OpenStack distribution, as well as stronger container support that integrates tools from Project Atomic, Red Hat's robust container management tool set.
 
@@ -29,6 +29,6 @@ New features highlighted in this release are:
 
 Other exciting new features in this release of oVirt include the capability to deploy additional hosts for Hosted Engine directly from the Web portal, as well as improvements to Gluster hyper-converged setups, per-interface MAC anti-spoofing, and FiberChannel over Ethernet support via VDSM hook.
 
-A complete list of oVirt 4.0 features is available in the [oVirt 4.0 Release Notes](http://www.ovirt.org/release/4.0.0/). oVirt 4.0  is a big step forward in improving the virtual datacenter management experience, improving what is already available in oVirt with more speed and power than ever, while adding improvements to the platform that will take it to the next level of virtual machine management in an increasingly DevOps-oriented IT environment.
+A complete list of oVirt 4.0 features is available in the <a href="http://www.ovirt.org/release/4.0.0/">oVirt 4.0 Release Notes</a>. oVirt 4.0  is a big step forward in improving the virtual datacenter management experience, improving what is already available in oVirt with more speed and power than ever, while adding improvements to the platform that will take it to the next level of virtual machine management in an increasingly DevOps-oriented IT environment.
 
-[Download the latest version of oVirt](http://www.ovirt.org/download/) today!
+<a href="http://www.ovirt.org/download/">Download the latest version of oVirt</a> today!


### PR DESCRIPTION
The markdown-style links get resolved as relative links and therefore broken, changed to html-style links to force absolute URLs.