### PR TITLE
Provide link to migration guide as text

### DIFF
--- a/source/release/4.0.1/index.html.md
+++ b/source/release/4.0.1/index.html.md
@@ -31,7 +31,7 @@ If you're upgrading from a previous release on Enterprise Linux 7 you just need 
       # yum update "ovirt-engine-setup*"
       # engine-setup
 
-Upgrade on Fedora 22 and Enterprise Linux 6 is not supported and you should follow our [Migration Guide](http://www.ovirt.org/documentation/migration-engine-3.6-to-4.0/) in order to migrate to Enterprise Linux 7 or Fedora 23.
+Upgrade on Fedora 22 and Enterprise Linux 6 is not supported and you should follow our [Migration Guide](http://www.ovirt.org/documentation/migration-engine-3.6-to-4.0/) `http://www.ovirt.org/documentation/migration-engine-3.6-to-4.0/` in order to migrate to Enterprise Linux 7 or Fedora 23.
 
 ### oVirt Hosted Engine
 


### PR DESCRIPTION
Provide link to migration guide as text since something is breaking the link while publishing it ot the website.