### PR TITLE
fixed link for an absolute path to the project

### DIFF
--- a/source/blog/2016-07-20-announcing-the-ovirt-engine-dr-subproject.html.md
+++ b/source/blog/2016-07-20-announcing-the-ovirt-engine-dr-subproject.html.md
@@ -23,4 +23,4 @@ Features will include:
 
  oVirt Engine DR currently exists as an independent open source project hosted on [github](https://github.com/xandradx/ovirt-engine-disaster-recovery). The project, which is currently in incubation status, includes as the owner and initial maintainers: José Eduardo Andrade Escobar, Jorge Luis Andrade Escobar, and Luis Armando Pérez Marín.
 
- This [sub-project page](http://www.ovirt.org/develop/projects/proposals/ovirt-engine-disaster-recovery/) will gather input on whether oVirt Engine DR should become a full oVirt sub-project and, if so, how best to integrate it into the oVirt stack.
+ This [sub-project page](/develop/projects/proposals/ovirt-engine-disaster-recovery/) will gather input on whether oVirt Engine DR should become a full oVirt sub-project and, if so, how best to integrate it into the oVirt stack.


### PR DESCRIPTION
Note: Don't use offsite links for oVirt site links.

1. When you specify HTTP as the protocol, it will switch people from https to http, which defeats the purpose of HTTPS
2. This makes links brittle, in case the domain (or subdomain, such as
www) changes
3. It ties the document to the website itself
4. It breaks links when testing things locally
5. Linking the URL incorrectly might trigger Apache redirect rules