### PR TITLE
Update home page pointing to oVirt 4.0.3 release

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -55,8 +55,8 @@ hide_metadata: true
     :ruby
       # Rely on either a releases.yml or scan the release directory
       # (Hard-coding release version & date is temporary)
-      release_version = '4.0.2'
-      release_date = '2016-08-12'.to_date
+      release_version = '4.0.3'
+      release_date = '2016-08-29'.to_date
 
     :markdown
       {:.pull-left}


### PR DESCRIPTION
Changes proposed in this pull request:

- Update home page pointing to oVirt 4.0.3 release

I confirm that this pull request was submitted according to the [contribution guidelines](/.github/CONTRIBUTING.md): @sandrobonazzola

