### PR TITLE
Adding ovirt-engine-appliance package installation to Hosted Engine HowTo

### DIFF
--- a/source/documentation/how-to/hosted-engine.html.md
+++ b/source/documentation/how-to/hosted-engine.html.md
@@ -35,7 +35,7 @@ Greg Padgett <gpadgett@redhat.com>, Martin Sivak <msivak@redhat.com>
 
 Assuming you're using ovirt RPMs, you should start with install and deploy:
 
-         # yum install ovirt-hosted-engine-setup
+         # yum install ovirt-hosted-engine-setup ovirt-engine-appliance
          # hosted-engine --deploy
 
 During the deployment you'll be asked for input on host name, storage path and other relevant information. The installer will configure the system and run an empty VM. Access the VM and install an OS:


### PR DESCRIPTION
Fixes issue # (delete if not relevant)

Changes proposed in this pull request:
## 
## 
## 

I confirm that this pull request was submitted according to the [contribution guidelines](/.github/CONTRIBUTING.md): @dwimsey

This pull request needs review by: 

The hosted-engine --deploy seems to require an appliance image to use, while the message shown during this part of the script indicates you can use 'None' and it will take longer but work, it seems to look for an image named None, fails and then reprompts for an image to use.  This seems to be the simplest work around and probably a better default for newbies since it leaves less room for guessing
