### PR TITLE
Fix 3.6 to 4.0 upgrade documentation

### DIFF
--- a/source/documentation/migration-engine-3.6-to-4.0.html.md
+++ b/source/documentation/migration-engine-3.6-to-4.0.html.md
@@ -26,7 +26,7 @@ To make things easier to handle, the new operating system setup should use the s
 
 With the new operating system running, install 4.0 RPM repositories:
 
-    # yum install http://resources.ovirt.org/pub/yum-repo/ovirt-release-master.rpm  # FIXME: this should point to ovirt-release40.rpm after release!
+    # yum install http://resources.ovirt.org/pub/yum-repo/ovirt-release40.rpm
 
 Install `ovirt-engine` package and dependencies:
 


### PR DESCRIPTION
Fixes 4.0 repository URL which should be used to install oVirt 4.0 when
doing upgrade from 3.6 using engine-backup.