### PR TITLE
removed all lines with `Talk:` links

### DIFF
--- a/source/develop/api/design/using-rest-api-in-web-ui.html.md
+++ b/source/develop/api/design/using-rest-api-in-web-ui.html.md
@@ -148,7 +148,6 @@ Proposed technologies and tools for development:
 
 ## Comments and discussion
 
-*   Refer to [design discussion page](Talk:Features/Design/Using_REST_API_In_Web_UI).
 
 ## Implementation Status
 

--- a/source/develop/developer-guide/vdsm/momvdsmseparation.html.md
+++ b/source/develop/developer-guide/vdsm/momvdsmseparation.html.md
@@ -72,5 +72,4 @@ TBD
 
 ### Comments and Discussion
 
-*   Refer to <Talk:MomVdsmSeparation>
 

--- a/source/develop/release-management/features/affinity-rules-enforcement-manager.html.md
+++ b/source/develop/release-management/features/affinity-rules-enforcement-manager.html.md
@@ -195,6 +195,5 @@ This manager includes:
 For more information see the following BugZilla link:
 <https://bugzilla.redhat.com/show_bug.cgi?id=1112332>
 
-*   Refer to <Talk:Affinity_Group_Enforcement_Manager>
 
 [Affinity Group Enforcement Manager](Category:Feature) [Affinity Group Enforcement Manager](Category:oVirt 3.6 Proposed Feature) [Affinity Group Enforcement Manager](Category:OVirt 3.6 Feature) [Affinity Group Enforcement Manager](Category:SLA)

--- a/source/develop/release-management/features/backupawareness.html.md
+++ b/source/develop/release-management/features/backupawareness.html.md
@@ -111,6 +111,5 @@ TBD
 
 ### Comments and Discussion
 
-*   Refer to <Talk:BackupAwareness>
 
 [BackupAwareness](Category:Feature) [BackupAwareness](Category:oVirt 3.6 Proposed Feature) [BackupAwareness](Category:oVirt 3.6 Feature)

--- a/source/develop/release-management/features/boot.html.md
+++ b/source/develop/release-management/features/boot.html.md
@@ -86,5 +86,4 @@ None
 
 ## Comments and Discussion
 
-*   Refer to <Talk:BootOVirtOrg>
 

--- a/source/develop/release-management/features/cinderglance-docker-integration.html.md
+++ b/source/develop/release-management/features/cinderglance-docker-integration.html.md
@@ -198,6 +198,5 @@ Docker images got their own network configuration (hotsname, /etc/hosts, dns con
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to <Talk:CinderGlance_Docker_Integration>
 
 [CinderGlance Docker Integration](Category:Feature) [CinderGlance Docker Integration](Category:oVirt 3.6 Proposed Feature) [CinderGlance Docker Integration](Category:oVirt 3.6 Feature) [CinderGlance Docker Integration](Category:Integration)

--- a/source/develop/release-management/features/cloud/addingkeystoneurltoexternalproviders.html.md
+++ b/source/develop/release-management/features/cloud/addingkeystoneurltoexternalproviders.html.md
@@ -58,5 +58,4 @@ Support multiple OpenStack external providers that use different Keystone URLs f
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to <Talk:AddingKeystoneURLToExternalProviders>
 

--- a/source/develop/release-management/features/cloud/cloud-init-integration.html.md
+++ b/source/develop/release-management/features/cloud/cloud-init-integration.html.md
@@ -344,7 +344,6 @@ Connect to the VM and observe the CD indeed attached and other changes filled be
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Cloud-Init Integration](Talk:Cloud-Init Integration)
 
 [1] 
 

--- a/source/develop/release-management/features/debian-support-for-hosts.html.md
+++ b/source/develop/release-management/features/debian-support-for-hosts.html.md
@@ -67,6 +67,5 @@ The feature is self contained: if support for Debian won't be ready for 3.6.0 we
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Debian support for hosts](Talk:Debian support for hosts)
 
 [Debian support for hosts](Category:Feature) [Debian support for hosts](Category:oVirt 3.6 Proposed Feature) [Debian support for hosts](Category:oVirt 3.6 Feature) [Debian support for hosts](Category:Integration)

--- a/source/develop/release-management/features/engine/avoid-ip-spoofing.html.md
+++ b/source/develop/release-management/features/engine/avoid-ip-spoofing.html.md
@@ -74,5 +74,4 @@ Is there upstream documentation on this feature, or notes you have written yours
 
 <!-- -->
 
-*   Refer to [Talk:Your feature name](Talk:Your feature name)
 

--- a/source/develop/release-management/features/engine/cluster-parameters-override.html.md
+++ b/source/develop/release-management/features/engine/cluster-parameters-override.html.md
@@ -81,6 +81,5 @@ This will allow a user to provide a backward-compatibility for certain VMs and t
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Cluster parameters override](Talk:Cluster parameters override)
 
 [Cluster parameters override](Category:Feature) [Cluster parameters override](Category:oVirt 3.6 Proposed Feature) [Cluster parameters override](Category:oVirt 3.6 Feature)

--- a/source/develop/release-management/features/engine/commandcoordinator.html.md
+++ b/source/develop/release-management/features/engine/commandcoordinator.html.md
@@ -258,7 +258,6 @@ All the Async tasks need to work with the new code changes. Instead of commands 
 
 ### Comments and Discussion
 
-*   Refer to [Talk:Introduce CommandCoordinator Framework and Ability To Persist Commands in Database](Talk:Introduce CommandCoordinator Framework and Ability To Persist Commands in Database)
 
 ### Deep Dive Presentation
 

--- a/source/develop/release-management/features/engine/engine-backup.html.md
+++ b/source/develop/release-management/features/engine/engine-backup.html.md
@@ -207,5 +207,4 @@ See output of `engine-backup --help`.
 
 ## Comments and Discussion
 
-*   Refer to <Talk:Features/ovirt-engine-backup>
 

--- a/source/develop/release-management/features/engine/engine-cleanup.html.md
+++ b/source/develop/release-management/features/engine/engine-cleanup.html.md
@@ -119,5 +119,4 @@ with no additional changes occurring on the second and following runs, beyond wh
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to <Talk:engine-cleanup>
 

--- a/source/develop/release-management/features/engine/fedora-21-support.html.md
+++ b/source/develop/release-management/features/engine/fedora-21-support.html.md
@@ -58,5 +58,4 @@ The feature is self contained: if support for Fedora 21 won't be ready for 3.6.0
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Fedora 21 Support](Talk:Fedora 21 Support)
 

--- a/source/develop/release-management/features/engine/fedora-22-support.html.md
+++ b/source/develop/release-management/features/engine/fedora-22-support.html.md
@@ -59,5 +59,4 @@ The feature is self contained: if support for Fedora 22 won't be ready for 3.6.0
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Fedora 22 Support](Talk:Fedora 22 Support)
 

--- a/source/develop/release-management/features/engine/get-route.html.md
+++ b/source/develop/release-management/features/engine/get-route.html.md
@@ -47,5 +47,4 @@ To implement this new verb we could use `netinfo.getRouteDeviceTo(ip_address)` f
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Get Route](Talk:Get Route)
 

--- a/source/develop/release-management/features/engine/migration-of-local-dwh-reports-to-remote.html.md
+++ b/source/develop/release-management/features/engine/migration-of-local-dwh-reports-to-remote.html.md
@@ -134,6 +134,5 @@ An annotated [example setup](Separate-Reports-Host#Example_setup) on three machi
 
 ### Comments and Discussion
 
-*   Refer to <Talk:Migration_of_DWH&Reports>
 
 [Separate DWH Host](Category:Feature) [Separate DWH Host](Category:oVirt 3.5 Feature)

--- a/source/develop/release-management/features/engine/orm.html.md
+++ b/source/develop/release-management/features/engine/orm.html.md
@@ -78,4 +78,3 @@ N/A
 
 ## Comments and Discussion
 
-*   Refer to <Talk:ORM>

--- a/source/develop/release-management/features/engine/reportguestdiskslogicaldevicename.html.md
+++ b/source/develop/release-management/features/engine/reportguestdiskslogicaldevicename.html.md
@@ -81,5 +81,4 @@ vm_device table:
 
 ### Comments and Discussion
 
-*   Refer to <Talk:ReportGuestDisksLogicalDeviceName>
 

--- a/source/develop/release-management/features/engine/self-hosted-engine-fc-support.html.md
+++ b/source/develop/release-management/features/engine/self-hosted-engine-fc-support.html.md
@@ -91,6 +91,5 @@ Currently all the changes required for this feature are in a single patch. If it
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Self Hosted Engine FC Support](Talk:Self Hosted Engine FC Support)
 
 [Self Hosted Engine FC Support](Category:Feature) [Self Hosted Engine FC Support](Category:oVirt 3.6 Proposed Feature) [Self Hosted Engine FC Support](Category:oVirt 3.6 Feature) [Self Hosted Engine FC Support](Category:Integration)

--- a/source/develop/release-management/features/engine/self-hosted-engine-gluster-support.html.md
+++ b/source/develop/release-management/features/engine/self-hosted-engine-gluster-support.html.md
@@ -109,6 +109,5 @@ It is recommended to turn on [sharding](http://blog.gluster.org/2015/12/introduc
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Self Hosted Engine Gluster Support](Talk:Self Hosted Engine Gluster Support)
 
 [Self Hosted Engine Gluster Support](Category:Feature) [Self Hosted Engine Gluster Support](Category:oVirt 3.6 Feature) [Self Hosted Engine Gluster Support](Category:oVirt 3.6 Proposed Feature) [Self Hosted Engine Gluster Support](Category:HostedEngine) [Self Hosted Engine Gluster Support](Category:Integration)

--- a/source/develop/release-management/features/engine/self-hosted-engine-hyper-converged-gluster-support.html.md
+++ b/source/develop/release-management/features/engine/self-hosted-engine-hyper-converged-gluster-support.html.md
@@ -58,6 +58,5 @@ Test plan still to be created
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Self Hosted Engine Gluster Support](Talk:Self Hosted Engine Gluster Support)
 
 [Self Hosted Engine Hyper Converged Gluster Support](Category:Feature) [Self Hosted Engine Hyper Converged Gluster Support](Category:oVirt 4.0 Proposed Feature) [Self Hosted Engine Hyper Converged Gluster Support](Category:Integration)

--- a/source/develop/release-management/features/engine/self-hosted-engine-iscsi-support.html.md
+++ b/source/develop/release-management/features/engine/self-hosted-engine-iscsi-support.html.md
@@ -147,6 +147,5 @@ You can use nightly builds, available from oVirt snapshots repositories:
 
 ## Comments and Discussion
 
-*   Refer to <Talk:Feature/Self_Hosted_Engine_iSCSI_Support>
 
 [Self Hosted Engine iSCSI Support](Category:Feature) [Self Hosted Engine iSCSI Support](Category:oVirt 3.5 Feature) [Self Hosted Engine iSCSI Support](Category:Integration)

--- a/source/develop/release-management/features/engine/self-hosted-engine.html.md
+++ b/source/develop/release-management/features/engine/self-hosted-engine.html.md
@@ -528,6 +528,5 @@ The HA Agent will support 2 types of maintenance:
 
 # Comments and Discussion
 
-*   Refer to [Talk:Self Hosted Engine](Talk:Self Hosted Engine)
 
 [Self Hosted Engine](Category:Feature) [Self Hosted Engine](Category:oVirt 3.4 Feature) [Self Hosted Engine](Category:Integration)

--- a/source/develop/release-management/features/engine/separate-dwh-host.html.md
+++ b/source/develop/release-management/features/engine/separate-dwh-host.html.md
@@ -91,6 +91,5 @@ Details:
 
 When upgrading the engine, dwhd must be first stopped, then upgraded, then started. Otherwise it might try to collect inconsistent data, from a database in the middle of an upgrade, or from an upgraded database. In previous versions this was forced by engine-setup. Now that might be impossible, if they are on separate machines. To enforce that, a new flag was added to the database, marking that dwhd is up. It's set by dwhd on start, cleared on stop, and tested by engine-setup. Another flag was added to mark that dwhd should stop. If engine-setup sees that dwhd is up, it asks it to stop by marking that flag, then waits some time, and eventually times out and aborts if dwhd didn't mark that it is stopped. The most likely cause of this is an uncontrolled exit of dwhd, e.g. killing it with SIGKILL or unplugging the power of its host.
 
-*   Refer to <Talk:Separate-DWH-Host>
 
 [Separate DWH Host](Category:Feature) [Separate DWH Host](Category:oVirt 3.5 Feature) [Separate DWH Host](Category:Integration)

--- a/source/develop/release-management/features/engine/separate-reports-host.html.md
+++ b/source/develop/release-management/features/engine/separate-reports-host.html.md
@@ -459,6 +459,5 @@ On C:
 
 # Comments and Discussion
 
-*   Refer to <Talk:Separate-Reports-Host>
 
 [Separate Reports Host](Category:Feature) [Separate Reports Host](Category:oVirt 3.5 Feature) [Separate Reports Host](Category:Integration)

--- a/source/develop/release-management/features/engine/serial-console.html.md
+++ b/source/develop/release-management/features/engine/serial-console.html.md
@@ -119,5 +119,4 @@ Please see [how to setup manually the ovirt-vmconsole integration](Serial_Consol
 
 ## Comments and Discussion
 
-*   Refer to <Talk:OVirtSerialConsole>
 

--- a/source/develop/release-management/features/engine/watchdog-engine-support.html.md
+++ b/source/develop/release-management/features/engine/watchdog-engine-support.html.md
@@ -146,7 +146,6 @@ VDSM support for watchdog cards is already merged.
 
 ## Comments and Discussion
 
-Please comment on the [Discussion page](Talk:Features/Watchdog_engine_support).
 
 ## TODO
 

--- a/source/develop/release-management/features/engine/windows-guest-tools.html.md
+++ b/source/develop/release-management/features/engine/windows-guest-tools.html.md
@@ -96,6 +96,5 @@ Copy it to where you need it...
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk:oVirt Windows Guest Tools ISO](Talk:oVirt Windows Guest Tools ISO)
 
 [oVirt Windows Guest Tools](Category:Feature) [oVirt Windows Guest Tools](Category:oVirt 3.5 Feature) [oVirt Windows Guest Tools](Category:Integration)

--- a/source/develop/release-management/features/gluster/gluster-geo-replication.html.md
+++ b/source/develop/release-management/features/gluster/gluster-geo-replication.html.md
@@ -163,7 +163,6 @@ Refer the URL: <http://www.ovirt.org/Features/Design/GlusterGeoReplication> for 
 
 ## Comments and Discussion
 
-<http://www.ovirt.org/Talk:Features/Gluster_Geo_Replication>
 
 ## Open Issues
 

--- a/source/develop/release-management/features/gluster/gluster-hooks-management.html.md
+++ b/source/develop/release-management/features/gluster/gluster-hooks-management.html.md
@@ -116,7 +116,6 @@ As the hooks present in the servers are periodically synchronized with engine da
 
 ## Comments and Discussion
 
-<http://www.ovirt.org/wiki/Talk:Features/Gluster_Hooks_Management>
 
 ## Open Issues
 

--- a/source/develop/release-management/features/gluster/gluster-support.html.md
+++ b/source/develop/release-management/features/gluster/gluster-support.html.md
@@ -211,7 +211,6 @@ GlusterFS : <http://www.gluster.org/community/documentation/index.php/Main_Page>
 
 ## Comments and Discussion
 
-<http://www.ovirt.org/wiki/Talk:Features/Gluster_Support>
 
 ## Future Work
 

--- a/source/develop/release-management/features/gluster/gluster-swift-management.html.md
+++ b/source/develop/release-management/features/gluster/gluster-swift-management.html.md
@@ -208,7 +208,6 @@ Periodic sync job will report if service status changes in a server.
 
 ## Comments and Discussion
 
-<http://www.ovirt.org/wiki/Talk:Features/Gluster_Swift_Management>
 
 ## Open Issues
 

--- a/source/develop/release-management/features/gluster/glusterhostdiskmanagement.html.md
+++ b/source/develop/release-management/features/gluster/glusterhostdiskmanagement.html.md
@@ -95,7 +95,6 @@ None
 
 ## Comments and Discussion
 
-<http://www.ovirt.org/Talk:Features/GlusterHostDiskManagement>
 
 ## Open Issues
 

--- a/source/develop/release-management/features/gluster/glustervolumequota.html.md
+++ b/source/develop/release-management/features/gluster/glustervolumequota.html.md
@@ -339,7 +339,6 @@ None
 
 # Comments and Discussion
 
-<http://www.ovirt.org/Talk:Features/GlusterVolumeQuota>
 
 # Open Issues
 

--- a/source/develop/release-management/features/heapplianceflow.html.md
+++ b/source/develop/release-management/features/heapplianceflow.html.md
@@ -476,5 +476,4 @@ None
 
 ### Comments and Discussion
 
-*   Refer to <Talk:HEApplianceFlow>
 

--- a/source/develop/release-management/features/hosted-engine-add-hosts-with-web-ui.html.md
+++ b/source/develop/release-management/features/hosted-engine-add-hosts-with-web-ui.html.md
@@ -87,5 +87,4 @@ In order to test the ovirt host deploy part, the following content can be added 
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Hosted Engine add hosts with Web UI](Talk:Hosted Engine add hosts with Web UI)
 

--- a/source/develop/release-management/features/hosted-engine-configuration-on-shared-storage.html.md
+++ b/source/develop/release-management/features/hosted-engine-configuration-on-shared-storage.html.md
@@ -72,6 +72,5 @@ Hosted-engine VM configuration is now saved on the shared storage to enable subs
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Hosted Engine configuration on shared storage](Talk:Hosted Engine configuration on shared storage)
 
 [Hosted Engine configuration on shared storage](Category:Feature) [Hosted Engine configuration on shared storage](Category:oVirt 3.6 Proposed Feature) [Hosted Engine configuration on shared storage](Category:oVirt 3.6 Feature) [Hosted Engine configuration on shared storage](Category:Integration)

--- a/source/develop/release-management/features/hosted-engine-vm-management.html.md
+++ b/source/develop/release-management/features/hosted-engine-vm-management.html.md
@@ -132,6 +132,5 @@ TODO - map what fields rely on engine - some may be not that important for now a
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk:Your feature name](Talk:Your feature name)
 
 [Hosted engine VM management](Category:Feature) [Hosted engine VM management](Category:oVirt 4.0 Proposed Feature) [Hosted engine VM management](Category:Integration) [Hosted engine VM management](Category:SLA)

--- a/source/develop/release-management/features/infra/bootstrap-improvements.html.md
+++ b/source/develop/release-management/features/infra/bootstrap-improvements.html.md
@@ -57,7 +57,6 @@ None.
 
 ## Comments and Discussion
 
-*   Refer to <Talk:Bootstrap_Improvements>
 
 Author: --[Alon Bar-Lev](User:Alonbl) ([talk](User talk:Alonbl)) 02:23, 1 July 2014 (GMT)
 

--- a/source/develop/release-management/features/infra/drbd.html.md
+++ b/source/develop/release-management/features/infra/drbd.html.md
@@ -80,5 +80,4 @@ When it is clear how to integrate DRBD on the nodes, managing DRBD replication l
 
 ## Comments and Discussion
 
-*   Refer to <Talk:DRBD>
 

--- a/source/develop/release-management/features/infra/entity-configuration-management.html.md
+++ b/source/develop/release-management/features/infra/entity-configuration-management.html.md
@@ -74,7 +74,6 @@ Valid entity types would be evaluated against the Entity Types defined in oVirt 
 
 ## Comments and Discussion
 
-<http://www.ovirt.org/Talk:Features/Entity_Configuration_Management>
 
 ## Open Issues
 

--- a/source/develop/release-management/features/infra/externaltasks.html.md
+++ b/source/develop/release-management/features/infra/externaltasks.html.md
@@ -101,7 +101,6 @@ See also [UI-Plugins](http://wiki.ovirt.org/wiki/Features/UIPlugins)
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to <Talk:ExternalTasks>
 
 ## Testing
 

--- a/source/develop/release-management/features/infra/hostpmproxypreferences.html.md
+++ b/source/develop/release-management/features/infra/hostpmproxypreferences.html.md
@@ -81,5 +81,4 @@ What other packages depend on this package? Are there changes outside the develo
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to <Talk:HostPMProxyPreferences>
 

--- a/source/develop/release-management/features/infra/hsm-async-tasks.html.md
+++ b/source/develop/release-management/features/infra/hsm-async-tasks.html.md
@@ -55,5 +55,4 @@ TBD
 
 ## Comments and Discussion
 
-*   Refer to [Talk:HSM Async Tasks](Talk:HSM Async Tasks)
 

--- a/source/develop/release-management/features/infra/one-certificate-key-pair-per-nic.html.md
+++ b/source/develop/release-management/features/infra/one-certificate-key-pair-per-nic.html.md
@@ -93,5 +93,4 @@ Note: I'm not familiar with oVirt at code level so the closer to it, the bigger 
 
 ## Comments and Discussion
 
-*   Refer to <Talk:One_certificate-key_pair_per_NIC>
 

--- a/source/develop/release-management/features/infra/pki-improvements.html.md
+++ b/source/develop/release-management/features/infra/pki-improvements.html.md
@@ -47,7 +47,6 @@ vdsm-reg master.
 
 ## Comments and Discussion
 
-*   Refer to <Talk:PKI_Improvements>
 
 Author: --[Alon Bar-Lev](User:Alonbl) ([talk](User talk:Alonbl)) 02:24, 1 July 2014 (GMT)
 

--- a/source/develop/release-management/features/infra/pmhealthcheck.html.md
+++ b/source/develop/release-management/features/infra/pmhealthcheck.html.md
@@ -47,5 +47,4 @@ This feature will improve Host availability since once a Host fails the PM statu
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [[Talk:PMHealthCheck]
 

--- a/source/develop/release-management/features/infra/user-portal-permissions.html.md
+++ b/source/develop/release-management/features/infra/user-portal-permissions.html.md
@@ -138,7 +138,6 @@ The following endpoints are supported:
 
 ## Comments and Discussion
 
-[Talk:Features/User Portal Permissions](Talk:Features/User Portal Permissions)
 
 ## Open Issues
 

--- a/source/develop/release-management/features/integration/allinone.html.md
+++ b/source/develop/release-management/features/integration/allinone.html.md
@@ -72,6 +72,5 @@ It is recommended to generate the answer file automatically:
 
 ## Comments and Discussion
 
-*   Refer to [Talk: allinone](Talk: allinone)
 
 [All In One](Category:Feature) [All In One](Category:oVirt 3.1 Feature) [All In One](Category:Integration)

--- a/source/develop/release-management/features/integration/otopi-infra-migration.html.md
+++ b/source/develop/release-management/features/integration/otopi-infra-migration.html.md
@@ -181,7 +181,6 @@ TBD
 
 ## Comments and Discussion
 
-*   Refer to <Talk:Features/Otopi_Infra_Migration>
 
 ## Basic Testing
 

--- a/source/develop/release-management/features/integration/websocketproxy-on-a-separate-host.html.md
+++ b/source/develop/release-management/features/integration/websocketproxy-on-a-separate-host.html.md
@@ -393,6 +393,5 @@ Add a virtualization host, start a VM from the engine and pen the noVNC console.
 
 ## Comments and Discussion
 
-*   Refer to [Talk:WebSocketProxy on a separate host](Talk:WebSocketProxy on a separate host)
 
 [WebSocketProxy on a separate host](Category:Feature) [WebSocketProxy on a separate host](Category:oVirt 3.5 Feature) [WebSocketProxy on a separate host](Category:Integration)

--- a/source/develop/release-management/features/live-rebase-on-centos-7.html.md
+++ b/source/develop/release-management/features/live-rebase-on-centos-7.html.md
@@ -57,6 +57,5 @@ oVirt Live ISO will be rebased on CentOS 7
 
 ## Comments and Discussion
 
-*   Refer to [Talk:oVirt Live Rebase on CentOS 7](Talk:oVirt Live Rebase on CentOS 7)
 
 [oVirt Live Rebase on CentOS 7](Category:Feature) [oVirt Live Rebase on CentOS 7](Category:oVirt 3.6 Proposed Feature) [|oVirt Live Rebase on CentOS 7](Category:oVirt 3.6 Feature) [oVirt Live Rebase on CentOS 7](Category:Integration)

--- a/source/develop/release-management/features/memorybasedbalancing.html.md
+++ b/source/develop/release-management/features/memorybasedbalancing.html.md
@@ -75,5 +75,4 @@ TBD
 
 ### Comments and Discussion
 
-*   Refer to <Talk:MemoryBasedBalancing>
 

--- a/source/develop/release-management/features/network/bridgeless-networking.html.md
+++ b/source/develop/release-management/features/network/bridgeless-networking.html.md
@@ -56,5 +56,4 @@ Some consumers of oVirt Node don't require the bridge or even conflict with an e
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk:Urwid TUI](Talk:Urwid TUI)
 

--- a/source/develop/release-management/features/network/detailed-osn-integration.html.md
+++ b/source/develop/release-management/features/network/detailed-osn-integration.html.md
@@ -349,7 +349,6 @@ Please see the [feature page](Features/OSN_Integration).
 
 ## Comments and Discussion
 
-<Talk:Features/Detailed_OSN_Integration>
 
 ## Open Issues
 

--- a/source/develop/release-management/features/network/device-custom-properties.html.md
+++ b/source/develop/release-management/features/network/device-custom-properties.html.md
@@ -153,6 +153,5 @@ As this is a 3.3 feature, all 3.2 (and down) cluster related entities should not
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Device Custom Properties](Talk:Device Custom Properties)
 *   On the arch@ovirt.org mailing list.
 

--- a/source/develop/release-management/features/network/ethtool-options.html.md
+++ b/source/develop/release-management/features/network/ethtool-options.html.md
@@ -80,5 +80,4 @@ To test this feature the tester should:
 
 ### Comments and Discussion
 
-*   Join the discussion! <Talk:Ethtool_options>
 

--- a/source/develop/release-management/features/network/hotplugnic.html.md
+++ b/source/develop/release-management/features/network/hotplugnic.html.md
@@ -56,5 +56,4 @@ Affected oVirt projects:
 
 ### Comments and Discussion
 
-*   Refer to [Talk:Your feature name](Talk:Your feature name)
 

--- a/source/develop/release-management/features/network/migration-network.html.md
+++ b/source/develop/release-management/features/network/migration-network.html.md
@@ -196,6 +196,5 @@ Note that the migration protocol requires Vdms-Vdsm and libvirt-libvirt communic
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Migration Network](Talk:Migration Network)
 *   Currently, there is a bug when the boot protocol of the migration network is dhcp. Sometimes the engine doesn't get in time the ip of the network from the dhcp server. In this case, when the migration command will be invoked the engine won't have the ip address of the migration network. It will cause the migration to be done on the fallback (management) network. Bug Url- <https://bugzilla.redhat.com/642551>
 

--- a/source/develop/release-management/features/network/network-custom-properties.html.md
+++ b/source/develop/release-management/features/network/network-custom-properties.html.md
@@ -216,6 +216,5 @@ This would execute an ethtool process for each slave.
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Network Custom Properties](Talk:Network Custom Properties)
 *   On the devel@ovirt.org mailing list.
 

--- a/source/develop/release-management/features/network/networkmanager-support.html.md
+++ b/source/develop/release-management/features/network/networkmanager-support.html.md
@@ -56,6 +56,5 @@ This migration ensures that Node can still be based on Fedora and doesn't need m
 
 ## Comments and Discussion
 
-*   Refer to [Talk:NetworkManager Support](Talk:NetworkManager Support)
 *   Mailinglist: node-devel@ovirt.org
 

--- a/source/develop/release-management/features/network/nicless-network.html.md
+++ b/source/develop/release-management/features/network/nicless-network.html.md
@@ -104,5 +104,4 @@ No changes will be done to the REST API, but the implementation will allow speci
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Nicless Network](Talk:Nicless Network)
 

--- a/source/develop/release-management/features/network/normalized-ovirtmgmt-initialization.html.md
+++ b/source/develop/release-management/features/network/normalized-ovirtmgmt-initialization.html.md
@@ -158,5 +158,4 @@ Cover all methods for installing a host in oVirt Engine
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Normalized ovirtmgmt Initialization](Talk:Normalized ovirtmgmt Initialization)
 

--- a/source/develop/release-management/features/network/osn-integration.html.md
+++ b/source/develop/release-management/features/network/osn-integration.html.md
@@ -175,5 +175,4 @@ In order to test the feature follow these steps:
 
 ### Comments and Discussion
 
-*   Refer to <Talk:Features/OSN_Integration>
 

--- a/source/develop/release-management/features/network/predictable-vnic-order.html.md
+++ b/source/develop/release-management/features/network/predictable-vnic-order.html.md
@@ -132,6 +132,5 @@ The case for iface name predictability in general
 
 ### Comments and Discussion
 
-*   Refer to [Talk:Predictable vNIC Order](Talk:Predictable vNIC Order)
 *   On the arch@ovirt.org mailing list.
 

--- a/source/develop/release-management/features/network/required-networks.html.md
+++ b/source/develop/release-management/features/network/required-networks.html.md
@@ -53,5 +53,4 @@ when attaching a network to a cluster, add a boolean required property to it
 
 ## Comments and Discussion
 
-*   Refer to [ <http://www.ovirt.org/w/index.php?title=Talk:Features/Design/Network/Required_Networks&action=edit&redlink=1> ](Talk:Required_Networks)
 

--- a/source/develop/release-management/features/network/unrestricted-network-names.html.md
+++ b/source/develop/release-management/features/network/unrestricted-network-names.html.md
@@ -86,5 +86,4 @@ Currently, if a user has a connectivity issue regarding a network FOO on one of 
 
 ### Comments and Discussion
 
-*   Refer to [Talk:Unrestricted Network Names](Talk:Unrestricted Network Names)
 

--- a/source/develop/release-management/features/node/buildtoolmigration.html.md
+++ b/source/develop/release-management/features/node/buildtoolmigration.html.md
@@ -70,5 +70,4 @@ Updates to a newer build system from the legacy livecd-creator
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk:Node vdsm plugin](Talk:Node vdsm plugin)
 

--- a/source/develop/release-management/features/node/diagnostic-page.html.md
+++ b/source/develop/release-management/features/node/diagnostic-page.html.md
@@ -51,5 +51,4 @@ Reduction in need to leave the TUI to diagnose problems. The ScrollBox and scrol
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk:Node Diagnostic Page](Talk:Node Diagnostic Page)
 

--- a/source/develop/release-management/features/node/kimchiplugin.html.md
+++ b/source/develop/release-management/features/node/kimchiplugin.html.md
@@ -55,5 +55,4 @@ Essentially feature parity with XenServer and ESXi in providing a way to manage 
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk:Node Kimchi Plugin](Talk:Node Kimchi Plugin)
 

--- a/source/develop/release-management/features/node/nic-bonding.html.md
+++ b/source/develop/release-management/features/node/nic-bonding.html.md
@@ -83,5 +83,4 @@ Cover all methods for creating and removing bonds.
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk:Urwid TUI](Talk:Urwid TUI)
 

--- a/source/develop/release-management/features/node/node.next.html.md
+++ b/source/develop/release-management/features/node/node.next.html.md
@@ -61,5 +61,4 @@ We'll need to ship the old Node.
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to <Talk:Node-next>
 

--- a/source/develop/release-management/features/node/openvswitchsupport.html.md
+++ b/source/develop/release-management/features/node/openvswitchsupport.html.md
@@ -54,5 +54,4 @@ Potential integration with Quantum/Neutron. Reuse of existing Open vSwitch devel
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk:Node Puppet Plugin](Talk:Node Puppet Plugin)
 

--- a/source/develop/release-management/features/node/puppet-plugin.html.md
+++ b/source/develop/release-management/features/node/puppet-plugin.html.md
@@ -53,5 +53,4 @@ Reduction in the number of kernel command line arguments necessary to automatica
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk:Node Puppet Plugin](Talk:Node Puppet Plugin)
 

--- a/source/develop/release-management/features/node/software-iscsi-root.html.md
+++ b/source/develop/release-management/features/node/software-iscsi-root.html.md
@@ -51,5 +51,4 @@ Allows broader deployments to multiple machines using smaller hardware requireme
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk:Node vdsm plugin](Talk:Node vdsm plugin)
 

--- a/source/develop/release-management/features/node/universal-image.html.md
+++ b/source/develop/release-management/features/node/universal-image.html.md
@@ -54,5 +54,4 @@ Making oVirt Node more generic and available to other projects widens the user b
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk:Universal Image](Talk:Universal Image)
 

--- a/source/develop/release-management/features/node/upgrade-tool.html.md
+++ b/source/develop/release-management/features/node/upgrade-tool.html.md
@@ -53,5 +53,4 @@ Coordination with vdsm/engine to switchover to using this new method
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk:Node vdsm plugin](Talk:Node vdsm plugin)
 

--- a/source/develop/release-management/features/node/urwid-tui.html.md
+++ b/source/develop/release-management/features/node/urwid-tui.html.md
@@ -52,5 +52,4 @@ The new UI components fix a lot of old bugs and offers features which solve many
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk:Urwid TUI](Talk:Urwid TUI)
 

--- a/source/develop/release-management/features/numaawareksmsupport.html.md
+++ b/source/develop/release-management/features/numaawareksmsupport.html.md
@@ -204,5 +204,4 @@ Take all hosts in clusters up.
 
 <!-- -->
 
-*   Refer to [Talk:NUMA aware KSM support](Talk:NUMA aware KSM support)
 

--- a/source/develop/release-management/features/patternfly-tooltips.html.md
+++ b/source/develop/release-management/features/patternfly-tooltips.html.md
@@ -69,5 +69,4 @@ Testing involves
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Your feature name](Talk:Your feature name)
 

--- a/source/develop/release-management/features/pendingresourcemanager.html.md
+++ b/source/develop/release-management/features/pendingresourcemanager.html.md
@@ -65,5 +65,4 @@ TBD
 
 ## Comments and Discussion
 
-*   Refer to <Talk:PendingResourceManager>
 

--- a/source/develop/release-management/features/resolveactiveinterface.html.md
+++ b/source/develop/release-management/features/resolveactiveinterface.html.md
@@ -103,5 +103,4 @@ Explain what will be done in case the feature won't be ready on time
 
 <!-- -->
 
-*   Refer to [Talk:Your feature name](Talk:Your feature name)
 

--- a/source/develop/release-management/features/sla/detailedquota.html.md
+++ b/source/develop/release-management/features/sla/detailedquota.html.md
@@ -236,7 +236,6 @@ Affected oVirt projects:
 
 ### Comments and Discussion
 
-<http://www.ovirt.org/wiki/Talk:Features/Quota>
 
 ### Future Work
 

--- a/source/develop/release-management/features/sla/even-vm-count-distribution.html.md
+++ b/source/develop/release-management/features/sla/even-vm-count-distribution.html.md
@@ -111,5 +111,4 @@ pseudo (python) code for the balance() method
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk:Your feature name](Talk:Your feature name)
 

--- a/source/develop/release-management/features/sla/optaplanner.html.md
+++ b/source/develop/release-management/features/sla/optaplanner.html.md
@@ -251,5 +251,4 @@ When optimizer kicks in the following solution is found. One of the small VMs is
 
 # Comments and Discussion
 
-*   Refer to <Talk:Optaplanner>
 

--- a/source/develop/release-management/features/sla/quota.html.md
+++ b/source/develop/release-management/features/sla/quota.html.md
@@ -296,7 +296,6 @@ Affected oVirt projects:
 
 ## Comments and Discussion
 
-<http://www.ovirt.org/wiki/Talk:Features/Quota>
 
 ## Future Work
 

--- a/source/develop/release-management/features/sla/sla-mom-ballooning-tp.html.md
+++ b/source/develop/release-management/features/sla/sla-mom-ballooning-tp.html.md
@@ -54,5 +54,4 @@ oVirt will gain the ability to achieve higher VM densities and more efficient us
 
 ### Comments and Discussion
 
-*   Refer to <Talk:SLA-mom-ballooning-tp>
 

--- a/source/develop/release-management/features/sla/sla-mom.html.md
+++ b/source/develop/release-management/features/sla/sla-mom.html.md
@@ -58,5 +58,4 @@ This is the foundation of SLA @oVirt, allowing enforcement of various aspects su
 
 ### Comments and Discussion
 
-*   Refer to <Talk:SLA-mom>
 

--- a/source/develop/release-management/features/sla/trusted-compute-pools.html.md
+++ b/source/develop/release-management/features/sla/trusted-compute-pools.html.md
@@ -118,7 +118,6 @@ None.
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Trusted compute pools](Talk:Trusted compute pools)
 
 ## Test cases
 

--- a/source/develop/release-management/features/sla/vm-coredump.html.md
+++ b/source/develop/release-management/features/sla/vm-coredump.html.md
@@ -59,5 +59,4 @@ def coreDump(self, to, params):
 
 ### Comments and Discussion
 
-Please comment on the [Discussion page](Talk:Features/).
 

--- a/source/develop/release-management/features/splash.html.md
+++ b/source/develop/release-management/features/splash.html.md
@@ -118,5 +118,4 @@ A backup awareness splash screen will be automatically displayed in the web-admi
 
 ### Comments and Discussion
 
-*   Refer to [Talk:Backup Awareness UI - Splash Screen](Talk:Backup Awareness UI - Splash Screen)
 

--- a/source/develop/release-management/features/storage/backup-provider.html.md
+++ b/source/develop/release-management/features/storage/backup-provider.html.md
@@ -66,5 +66,4 @@ Tests should be done on each Backup Provider separately, followed by backup and 
 
 ## Comments and Discussion
 
-*   Refer to <Talk:Backup_Provider>
 

--- a/source/develop/release-management/features/storage/detailedfloatingdisk.html.md
+++ b/source/develop/release-management/features/storage/detailedfloatingdisk.html.md
@@ -195,7 +195,6 @@ Shared raw disk will be dependent on floating disk.
 
 ### Comments and Discussion
 
-<http://www.ovirt.org/wiki/Talk:Features/FloatingDisk>
 
 ### Future Work
 

--- a/source/develop/release-management/features/storage/detailedsharedrawdisk.html.md
+++ b/source/develop/release-management/features/storage/detailedsharedrawdisk.html.md
@@ -179,7 +179,6 @@ Attaching shareable disk will not consume new Quota resource. Affected oVirt pro
 
 ### Comments and Discussion
 
-<http://www.ovirt.org/wiki/Talk:Features/SharedRAWDisk>
 
 ### Future Work
 

--- a/source/develop/release-management/features/storage/diskpermissions.html.md
+++ b/source/develop/release-management/features/storage/diskpermissions.html.md
@@ -144,6 +144,5 @@ Affected oVirt projects:
 
 ## Comments and Discussion
 
-*   See <Talk:Features/DiskPermissions>
 
 [Category: Feature](Category: Feature)

--- a/source/develop/release-management/features/storage/domain-scan.html.md
+++ b/source/develop/release-management/features/storage/domain-scan.html.md
@@ -51,5 +51,4 @@ To be written.
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Features/Domain Scan](Talk:Features/Domain Scan)
 

--- a/source/develop/release-management/features/storage/image-upload.html.md
+++ b/source/develop/release-management/features/storage/image-upload.html.md
@@ -227,5 +227,4 @@ TBD
 
 ## Comments and Discussion
 
-*   Refer to <Talk:ImageUpload>
 

--- a/source/develop/release-management/features/storage/iscsi-multipath.html.md
+++ b/source/develop/release-management/features/storage/iscsi-multipath.html.md
@@ -130,6 +130,5 @@ HTTP/1.1
 
 ### Comments and Discussion
 
-*   Refer to [Talk: iSCSIMultiPath](Talk: iSCSIMultiPath)
 
 [iSCSI Multipath](Category:Feature) [iSCSI Multipath](Category:oVirt 3.4 Feature)

--- a/source/develop/release-management/features/storage/live-merge.html.md
+++ b/source/develop/release-management/features/storage/live-merge.html.md
@@ -136,5 +136,4 @@ Due to [this bug](https://bugzilla.redhat.com/show_bug.cgi?id=1102881), libvirt 
 
 ## Comments and Discussion
 
-*   Refer to <Talk:Live_Merge>
 

--- a/source/develop/release-management/features/storage/moveascopyanddelete.html.md
+++ b/source/develop/release-management/features/storage/moveascopyanddelete.html.md
@@ -62,5 +62,4 @@ as the delete part is quick (and now we will have two vdsm calls rather then one
 
 ### Comments and Discussion
 
-*   Refer to <Talk:MoveAsCopyAndDelete>
 

--- a/source/develop/release-management/features/storage/read-only-disk.html.md
+++ b/source/develop/release-management/features/storage/read-only-disk.html.md
@@ -102,5 +102,4 @@ This features allows the usage of read only disks. This is useful where we'd lik
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Features/Read Only Disk](Talk:Features/Read Only Disk)
 

--- a/source/develop/release-management/features/storage/sanlock-fencing.html.md
+++ b/source/develop/release-management/features/storage/sanlock-fencing.html.md
@@ -161,5 +161,4 @@ For this version, we prefer to have simpler solution.
 
 ### Comments and Discussion
 
-*   Refer to [Talk:Sanlock Fencing](Talk:Sanlock Fencing)
 

--- a/source/develop/release-management/features/storage/sharedrawdisk.html.md
+++ b/source/develop/release-management/features/storage/sharedrawdisk.html.md
@@ -55,6 +55,5 @@ Quota has to be taken in consideration, for every new feature that will involve 
 
 ## Comments and Discussion
 
-*   See <Talk:Features/SharedRawDisk>
 
 [SharedRawDisk](Category: Feature) [SharedRawDisk](Category:oVirt 3.1 Feature)

--- a/source/develop/release-management/features/storage/storagepool-metadata-removal.html.md
+++ b/source/develop/release-management/features/storage/storagepool-metadata-removal.html.md
@@ -48,5 +48,4 @@ TBD
 
 ## Comments and Discussion
 
-*   Refer to [Talk:StoragePool Metadata Removal](Talk:StoragePool Metadata Removal)
 

--- a/source/develop/release-management/features/ui.html.md
+++ b/source/develop/release-management/features/ui.html.md
@@ -141,5 +141,4 @@ A backup status screen will be automatically displayed in the web-admin upon log
 
 ### Comments and Discussion
 
-*   Refer to [Talk:Backup Awareness UI](Talk:Backup Awareness UI)
 

--- a/source/develop/release-management/features/ux/cssgrids.html.md
+++ b/source/develop/release-management/features/ux/cssgrids.html.md
@@ -83,5 +83,4 @@ Testing would be look and feel regression testing. Make sure screens that weren'
 
 ## Comments and Discussion
 
-*   Refer to <Talk:CSSGrids>
 

--- a/source/develop/release-management/features/ux/entityhealthstatus.html.md
+++ b/source/develop/release-management/features/ux/entityhealthstatus.html.md
@@ -122,5 +122,4 @@ See also [UI-Plugins](http://wiki.ovirt.org/wiki/Features/UIPlugins)
 
 ### Comments and Discussion
 
-*   Refer to <Talk:EntityHostStatus>
 

--- a/source/develop/release-management/features/ux/hostpmmultipleagents.html.md
+++ b/source/develop/release-management/features/ux/hostpmmultipleagents.html.md
@@ -70,5 +70,4 @@ What other packages depend on this package? Are there changes outside the develo
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to <Talk:HostPMMultipleAgents>
 

--- a/source/develop/release-management/features/ux/i18n.html.md
+++ b/source/develop/release-management/features/ux/i18n.html.md
@@ -51,5 +51,4 @@ Cover all pages.
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk: Ovirt Node I18N](Talk: Ovirt Node I18N)
 

--- a/source/develop/release-management/features/ux/newlookandfeelpatternflyphase1.html.md
+++ b/source/develop/release-management/features/ux/newlookandfeelpatternflyphase1.html.md
@@ -91,5 +91,4 @@ The new design was proposed on the oVirt mailing list in October, 2013.
 
 <http://lists.ovirt.org/pipermail/users/2013-October/017088.html>
 
-*   Refer to [Talk:Your feature name](Talk:Your feature name)
 

--- a/source/develop/release-management/features/ux/uiplugins.html.md
+++ b/source/develop/release-management/features/ux/uiplugins.html.md
@@ -846,4 +846,3 @@ When Cockpit is not running on the selected host, the menu action is disabled an
 
 ## Comments and discussion
 
-*   Refer to [discussion page](talk:Features/UIPlugins).

--- a/source/develop/release-management/features/vdsm/libvdsm.html.md
+++ b/source/develop/release-management/features/vdsm/libvdsm.html.md
@@ -53,5 +53,4 @@ The patch commit messages contain a lot of useful information on the design.
 
 ## Comments and Discussion
 
-*   Refer to <Talk:Features/libvdsm>
 

--- a/source/develop/release-management/features/vdsm/vdsm-plugin.html.md
+++ b/source/develop/release-management/features/vdsm/vdsm-plugin.html.md
@@ -76,5 +76,4 @@ Cover all methods for registering an oVirt Node to oVirt Engine
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk:Node vdsm plugin](Talk:Node vdsm plugin)
 

--- a/source/develop/release-management/features/vdsm/vdsm-vm-query-api.html.md
+++ b/source/develop/release-management/features/vdsm/vdsm-vm-query-api.html.md
@@ -128,4 +128,3 @@ TODO
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to <Talk:Feature/VDSM_VM_Query_API>

--- a/source/develop/release-management/features/virt/cluster-emulation-modes.html.md
+++ b/source/develop/release-management/features/virt/cluster-emulation-modes.html.md
@@ -130,5 +130,4 @@ host should go NON_OPERATIONAL with reason UNSUPPORTED_EMULATION_MODE
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk:Your feature name](Talk:Your feature name)
 

--- a/source/develop/release-management/features/virt/expose-vm-devices.html.md
+++ b/source/develop/release-management/features/virt/expose-vm-devices.html.md
@@ -81,4 +81,3 @@ another issue is that address is available only after the vm was run.
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Expose VM Devices](Talk:Expose VM Devices)

--- a/source/develop/release-management/features/virt/guestagentdebian.html.md
+++ b/source/develop/release-management/features/virt/guestagentdebian.html.md
@@ -110,5 +110,4 @@ Testing has to be executed on a Debian 7 system. Lower version do not fulfil the
 
 ### Comments and Discussion
 
-*   Refer to <Talk:Feature/GuestAgentDebian>
 

--- a/source/develop/release-management/features/virt/guestagentopensuse.html.md
+++ b/source/develop/release-management/features/virt/guestagentopensuse.html.md
@@ -114,5 +114,4 @@ It'll be easier to install the ovirt-guest-agent on OpenSUSE guests.
 
 ### Comments and Discussion
 
-*   Refer to <Talk:Feature/GuestAgentOpenSUSE>
 

--- a/source/develop/release-management/features/virt/guestagentsles.html.md
+++ b/source/develop/release-management/features/virt/guestagentsles.html.md
@@ -104,5 +104,4 @@ Porting the ovirt-guest-agent to SLE (SuSE Linux Enterprise) 11 SP3
 
 ### Comments and Discussion
 
-*   Refer to [Talk:oVirt Guest Agent/SLES](Talk:oVirt Guest Agent/SLES)
 

--- a/source/develop/release-management/features/virt/guestagentubuntu.html.md
+++ b/source/develop/release-management/features/virt/guestagentubuntu.html.md
@@ -123,5 +123,4 @@ Testing has to be executed on a Ubuntu 12.04+ system. Lower versions do not fulf
 
 ### Comments and Discussion
 
-*   Refer to <Talk:Feature/GuestAgentUbuntu>
 

--- a/source/develop/release-management/features/virt/hot-plug-cpu.html.md
+++ b/source/develop/release-management/features/virt/hot-plug-cpu.html.md
@@ -443,5 +443,4 @@ Have a VM with a single CPU, which is fully utilized Actions
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Hot plug cpu](Talk:Hot plug cpu)
 

--- a/source/develop/release-management/features/virt/intial-run-vm-tab.html.md
+++ b/source/develop/release-management/features/virt/intial-run-vm-tab.html.md
@@ -69,5 +69,4 @@ First an admin can set a VM with a desired clock offset, make a template from it
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk:Intial Run Vm tab](Talk:Intial Run Vm tab)
 

--- a/source/develop/release-management/features/virt/os-info.html.md
+++ b/source/develop/release-management/features/virt/os-info.html.md
@@ -219,5 +219,4 @@ Other Host architecture such as **PPC** [1] could be added more easily as now th
 
 ### Comments and Discussion
 
-*   Refer to [Talk:Your feature name](Talk:Your feature name)
 

--- a/source/develop/release-management/features/virt/ram-snapshots.html.md
+++ b/source/develop/release-management/features/virt/ram-snapshots.html.md
@@ -423,5 +423,4 @@ As previous test case, but do the first steps on block-based storage and the lat
 
 ## Comments and Discussion
 
-*   Refer to <Talk:RAM_Snapshot>
 

--- a/source/develop/release-management/features/virt/template-versions.html.md
+++ b/source/develop/release-management/features/virt/template-versions.html.md
@@ -201,4 +201,3 @@ do we want to let user choose if to auto update stateless vms (check box)?
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Template Versions](Talk:Template Versions)

--- a/source/develop/release-management/features/virt/virt-v2v-integration.html.md
+++ b/source/develop/release-management/features/virt/virt-v2v-integration.html.md
@@ -257,5 +257,4 @@ TBD
 
 ### Comments and Discussion
 
-*   Refer to [Talk:Your feature name](Talk:Your feature name)
 

--- a/source/documentation/how-to/networking/quantum-and-ovirt.html.md
+++ b/source/documentation/how-to/networking/quantum-and-ovirt.html.md
@@ -183,4 +183,3 @@ The current Quantum model has a number of gaps and limitations with respect to i
 
 ## Comments and Discussion
 
-<http://www.ovirt.org/wiki/Talk:Features/Quantum_and_oVirt>

--- a/source/feature/container-support.html.md
+++ b/source/feature/container-support.html.md
@@ -200,5 +200,4 @@ We add a new optional feature, so there is no negative fallback and no contingen
 
 ## Comments and Discussion
 
-*   Refer to [Talk:Your feature name](Talk:Your feature name)
 

--- a/source/feature/feature-template.html.md
+++ b/source/feature/feature-template.html.md
@@ -90,7 +90,6 @@ Explain what will be done in case the feature won't be ready on time
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk:Your feature name](Talk:Your feature name)
 
 ### Open Issues
 

--- a/source/feature/networkfilter.html.md
+++ b/source/feature/networkfilter.html.md
@@ -244,7 +244,6 @@ Explain what will be done in case the feature won't be ready on time
 
 This below adds a link to the "discussion" tab associated with your page. This provides the ability to have ongoing comments or conversation without bogging down the main feature page
 
-*   Refer to [Talk:Your feature name](Talk:Your feature name)
 
                    filter_id               |       filter_name       | version 
 


### PR DESCRIPTION
This removes all (deprecated/broken) `Talk:` links.

See issue #475.

This is the result of running the following command (in zsh, for extended globbing support):

```zsh
ruby -i -ne 'print unless /[^ ]Talk:/i' **/*.md
```