### PR TITLE
Limit front page articles

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -75,7 +75,7 @@ hide_metadata: true
           = data.site.name
           News
 
-        = partial :blog_posts, locals: locals
+        = partial :blog_posts, locals: {limit: 3, summarize: true}
 
         = link_to 'See all blog posts', '/blog/'
 

--- a/source/layouts/_blog_posts.haml
+++ b/source/layouts/_blog_posts.haml
@@ -3,12 +3,18 @@
   # passing locals:
   #
   # = partial :blog_posts, locals: locals
+  #
+  # For limiting to a set number of article summaries:
+  #
+  # = partial :blog_posts, locals: {limit: 3, summarize: true}
+  #
 
+  limit ||= 10
   summarize ||= summarize
 
 %section.articles
 
-  - page_articles.reject {|a| !a.published? }.each do |article|
+  - page_articles.select(&:published?).take(limit).each do |article|
     = partial :blog_post, locals: {article: article, summarize: summarize}
 
   = partial :blog_pagination, locals: locals


### PR DESCRIPTION
Added support for limiting to # of articles in the blog_posts layout, and enabled support for oVirt by limiting to 3 article summaries.