### PR TITLE
Add teams to Develop page

### DIFF
--- a/source/develop/index.html.md
+++ b/source/develop/index.html.md
@@ -1,7 +1,7 @@
 ---
 title: Develop
 category: developer
-authors: dneary, jbrooks, ykaplan
+authors: dneary, jbrooks, ykaplan, sandrobonazzola
 wiki_category: Developer
 wiki_title: Develop
 wiki_revision_count: 8
@@ -73,5 +73,24 @@ _More information on [oVirt subprojects](Subprojects)_
 
 [![oVirt architecture](Overall-arch.png)](images/wiki/Overall-arch.png)
 
+## oVirt teams
+
+ - [Integration](http://www.ovirt.org/develop/projects/project-integration/)
+ - [Project Infrastructure](http://www.ovirt.org/develop/infra/infrastructure)
+ - Data Warehouse
+ - Docs
+ - Gluster
+ - I18N
+ - Infra
+ - Marketing
+ - Network
+ - Node
+ - Release Engineering
+ - Reports
+ - SLA
+ - Storage
+ - Spice
+ - Virt
+ - UX
 </section>
 </section>

--- a/source/develop/index.html.md
+++ b/source/develop/index.html.md
@@ -75,8 +75,8 @@ _More information on [oVirt subprojects](Subprojects)_
 
 ## oVirt teams
 
- - [Integration](http://www.ovirt.org/develop/projects/project-integration/)
- - [Project Infrastructure](http://www.ovirt.org/develop/infra/infrastructure)
+ - [Integration](./projects/project-integration/)
+ - [Project Infrastructure](./infra/infrastructure)
  - Data Warehouse
  - Docs
  - Gluster


### PR DESCRIPTION
Changes proposed in this pull request:

- Add team list linking to team pages to Develop main page

I confirm that this pull request was submitted according to the [contribution guidelines](/.github/CONTRIBUTING.md): @sandrobonazzola

This pull request needs review by: @bproffitt @eedri 

