### PR TITLE
Fix broken link in Community page

### DIFF
--- a/source/community/index.html.md
+++ b/source/community/index.html.md
@@ -87,7 +87,7 @@ Join all of the following mailing lists that interest you.
 
 ## Meet Our Infrastructure Team
 
-The Infrastructure Team consists of dedicated volunteers and professionals managing the servers, building the tools and utilities, and creating new applications to make oVIrt development a smoother process. We're located all over the globe and communicate primarily by the [\#ovirt channel on irc.OFTC.net](irc://irc.oftc.net/ovirt) and [signing up for the infra@ovirt.org mailing list](Mailing_lists#Infra). Check out the [Infrastructure](develop/infra/infrastructure) home page for more details!
+The Infrastructure Team consists of dedicated volunteers and professionals managing the servers, building the tools and utilities, and creating new applications to make oVIrt development a smoother process. We're located all over the globe and communicate primarily by the [\#ovirt channel on irc.OFTC.net](irc://irc.oftc.net/ovirt) and [signing up for the infra@ovirt.org mailing list](Mailing_lists#Infra). Check out the [Infrastructure](../develop/infra/infrastructure) home page for more details!
 
 </section>
 </section>


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix broken link to Infrastructure team page

I confirm that this pull request was submitted according to the [contribution guidelines](/.github/CONTRIBUTING.md): @sandrobonazzola