### PR TITLE
Drop 3.6 OSes support list

### DIFF
--- a/source/download/index.html.haml
+++ b/source/download/index.html.haml
@@ -52,9 +52,9 @@ wiki_warnings: list-item?
         ### Supported OSes (Engine)
 
         -   Fedora 23
-        -   CentOS Linux 6.8 (3.6 only), 7.2
-        -   Red Hat Enterprise Linux 6.8 (3.6 only), 7.2
-        -   Scientific Linux 6.7 (3.6 only), 7.2
+        -   CentOS Linux 7.2
+        -   Red Hat Enterprise Linux 7.2
+        -   Scientific Linux 7.2
 
 
   .row-fluid


### PR DESCRIPTION
Changes proposed in this pull request:
- oVirt 3.6 has reached EOL, dropping it from OSes support list

I confirm that this pull request was submitted according to the [contribution guidelines](/.github/CONTRIBUTING.md): @sandrobonazzola

This pull request needs review by: @mykaul 
