### PR TITLE
remove `http://www.ovirt.org` from the link

### DIFF
--- a/source/develop/release-management/features/os-support/fedora-24-support.html.md
+++ b/source/develop/release-management/features/os-support/fedora-24-support.html.md
@@ -40,7 +40,7 @@ Add support for Fedora 24
 
 ## Testing
 
-The whole [Test Case](http://www.ovirt.org/develop/infra/testing/test-cases/) collection must work on Fedora 24.
+The whole [Test Case](/develop/infra/testing/test-cases/) collection must work on Fedora 24.
 
 The Open Virtualization Manager (ovirt-engine) is ready to be tested.
 


### PR DESCRIPTION
Fixes #518:

Never link to the website as an external resource. It's a bad idea for so many different reasons, with the most important being that it breaks the possibility to test the site locally. (In addition, it seems to mess up server redirection in some cases.)