### PR TITLE
Downloads: drop link to internal anchor

### DIFF
--- a/source/download/index.html.haml
+++ b/source/download/index.html.haml
@@ -83,9 +83,9 @@ wiki_warnings: list-item?
 
   **oVirt 4.0** is intended for production use and is available for the following platforms:
 
-  - [Fedora](#Fedora_RHEL_Installation_Instructions) 23
-  - [Red Hat Enterprise Linux](#Fedora_RHEL_Installation_Instructions) 7.2 or later
-  - [CentOS](#Fedora_RHEL_Installation_Instructions)  7.2 or later
+  - Fedora 23
+  - Red Hat Enterprise Linux 7.2 or later
+  - CentOS Linux 7.2 or later
   - Scientific Linux 7.2 or later
 
   Our recommended method of installing oVirt is to use the pre-built packages for Fedora or a supported Enterprise Linux 7 distribution,


### PR DESCRIPTION
Changes proposed in this pull request:

- Dropping link from Fedora, RHEL and CentOS words pointing 10 rows later in the same document to the same anchor.
It creates expectation of reaching different landing points actually scrolling down 10 lines skipping a box marked as important.

I confirm that this pull request was submitted according to the [contribution guidelines](/.github/CONTRIBUTING.md): @sandrobonazzola

This pull request needs review by: @bproffitt 
