### PR TITLE
use code block for git clone snippets

### DIFF
--- a/source/develop/developer-guide/vdsm/developers.html.md
+++ b/source/develop/developer-guide/vdsm/developers.html.md
@@ -52,7 +52,7 @@ Our public git repository is located at: [oVirt.org](http://gerrit.ovirt.org/git
 
 You can clone this repository by running the following command:
 
-`git clone `[`http://gerrit.ovirt.org/p/vdsm.git`](http://gerrit.ovirt.org/p/vdsm.git)
+      git clone http://gerrit.ovirt.org/p/vdsm.git
 
 ## Installing the required packages
 
@@ -528,7 +528,7 @@ Which fedpkg build will generate a koji url that will provide the RPMs and can b
 
 VDSM for ovirt-3.6 depends on ovirt-vmconsole package. To fetch the sources of ovirt-vmconsole, run
 
-`git clone `[`http://gerrit.ovirt.org/p/ovirt-vmconsole.git`](http://gerrit.ovirt.org/p/ovirt-vmconsole.git)
+      git clone http://gerrit.ovirt.org/p/ovirt-vmconsole.git
 
 ## Troubleshooting
 


### PR DESCRIPTION
Changes proposed in this pull request:

Unlike the rest of code snippets in Vdsm Developers document, `git clone` commands are shown as inline code, not a code block. Because of that they are somehow easy to look over. For the sake of consistency and readability I change two `git clone` snippets from inline code into a code block.