### PR TITLE
'summarize' parameter must be numeric or Nil

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -75,7 +75,7 @@ hide_metadata: true
           = data.site.name
           News
 
-        = partial :blog_posts, locals: {limit: 3, summarize: true}
+        = partial :blog_posts, locals: {limit: 3}
 
         = link_to 'See all blog posts', '/blog/'
 

--- a/source/layouts/_blog_posts.haml
+++ b/source/layouts/_blog_posts.haml
@@ -6,7 +6,7 @@
   #
   # For limiting to a set number of article summaries:
   #
-  # = partial :blog_posts, locals: {limit: 3, summarize: true}
+  # = partial :blog_posts, locals: {limit: 3}
   #
 
   limit ||= 10


### PR DESCRIPTION
This fixes PR #565 's build failure. This problem was introduced in b7c24a0 with the article limiting feature.

I also wonder what this line wants to achieve:
`summarize ||= summarize`
I guess it is supposed to be numeric to hold the default value site-wide.

Having @garrett 's insight before merging would be much better.
