### PR TITLE
Update vdsm-developers after switching to flake8

### DIFF
--- a/source/develop/developer-guide/vdsm/developers.html.md
+++ b/source/develop/developer-guide/vdsm/developers.html.md
@@ -93,7 +93,14 @@ To exclude a specific test (test_foo):
 
 Running code style and quality checks:
 
-     make pep8 pyflakes
+     make flake8
+
+Running code style and quality checks for specific files:
+
+    .tox/flake8/bin/flake8 /path/to/module.py
+
+The command above works only after running make flake8 in the first
+time. You may want to install flake8 on your system for convenience.
 
 ### Testing specific modules
 


### PR DESCRIPTION
Vdsm replaced pep8 and pyflakes with flake8 tool. Explain how to run the
new style checks on all modules or specific module.

@mureinik @dankenigsberg, please review.