### PR TITLE
RFE: Node Validation during install

### DIFF
--- a/source/develop/release-management/features/node/node-validate-pre-conditions-during-installation.md
+++ b/source/develop/release-management/features/node/node-validate-pre-conditions-during-installation.md
@@ -1,0 +1,45 @@
+---
+title: Validate pre-conditions during installation
+category: feature
+authors: dougsland
+wiki_category: Feature|Validate pre-conditions during installation
+wiki_title: Feature/ValidateNodePreConditions
+wiki_revision_count: 0
+wiki_last_updated: 2016-11-7
+feature_name: Installation/Validate Node Pre Coditions for Installation
+feature_modules: node installation
+feature_status: WIP, 4.1 proposed feature
+---
+
+# Node RPM Persistence After Upgrades
+
+## Summary
+Currently [oVirt Node NG](/develop/projects/node/4.0) does not complain if it is getting installed in an environment where i.e. the storage layout is wrong (i.e. a thin pool is missing)
+
+### Owner
+* Name: Douglas Schilling Landgraf
+* Email: dougsland@redhat.com
+
+### Current Status
+* Status: Design
+* Last updated date: 07th Nov 2016
+
+### Benefit to oVirt
+
+Avoid fatal errors without any message during installation
+
+### Dependencies
+No dependecies
+
+## Detailed Description
+
+The imgbased component must check if it’s available thin pool in the partitions before the installation and /var must be a separate volume.
+Suggestion: Add a high-level error class something like DescriptiveError
+Important:  Find good error messages
+
+* Check if / is thin volume
+* Check if FS is ext4 or xfs in / and /var
+* Improve error in utils.py
+* /boot is at least 1GB
+* /boot is a separate partition
+* /var is a separate partition


### PR DESCRIPTION
Changes proposed in this pull request:

- RFE documentation about oVirt Node Next installation requirements

I confirm that this pull request was submitted according to the [contribution guidelines](/.github/CONTRIBUTING.md) @dougsland

This pull request needs review by: @fabiand 

oVirt Node Next needs to validate the system where it's
getting installed to determine if it has the minimum
requirements for installation.