### PR TITLE
another attempt to fix broken links

### DIFF
--- a/source/documentation/index.html.haml
+++ b/source/documentation/index.html.haml
@@ -47,8 +47,9 @@ wiki_last_updated: 2014-04-26
       - [Quick Start Guide](Quick_Start_Guide)
       - [oVirt Administration Guide](OVirt_Administration_Guide)
       - [oVirt User Guide](OVirt_User_Guide)
-      - [Release notes](http://www.ovirt.org/release/):
-          [oVirt 4.0](http://www.ovirt.org/release/4.0.0/),
+      - [Release notes](/release/):
+          [oVirt 4.0.5](/release/4.0.5/),
+          [oVirt 4.0](/release/4.0.0/),
           [oVirt 3.6](OVirt_3.6_Release_Notes),
           [oVirt 3.5](OVirt_3.5_Release_Notes),
           [oVirt 3.4](OVirt_3.4_Release_Notes),
@@ -80,7 +81,7 @@ wiki_last_updated: 2014-04-26
       - [Getting in contact with the oVirt community](Communication)
       - [Becoming a maintainer](Becoming_a_maintainer)
       - [oVirt architecture](Architecture)
-      - [Feature Roadmap oVirt 4.0](OVirt_4.0_Release_Management)
+      - [Feature Roadmap oVirt 4.0.z](/develop/release-management/releases/4.0.z/release-management/)
         (see also old roadmaps for
         [oVirt 3.6](OVirt_3.6_Release_Management)
         [oVirt 3.5](OVirt_3.5_release-management),


### PR DESCRIPTION
I confirm that this pull request was submitted according to the [contribution guidelines](/.github/CONTRIBUTING.md): (please @mbghsource yourself to sign)

I'd appreciate some help or documentation that shows how links get translated in this file.

I've made this change based on the following observations

Absolute links are getting prefixed with /documentation.
for example - http://www.ovirt.org/release/  is becoming - https://www.ovirt.org/documentation/release/

whereas relative links do not get prefixed with /documentation.
for example - /develop/release-management/process/making-an-release/ 
becomes
https://www.ovirt.org/develop/release-management/process/making-an-release/ 

It is not clear how certain other links get translated
examples - 
(Community_activity) becomes - https://www.ovirt.org/community/about/community-activity/
(OVirt_Global_Workshops) becomes - https://www.ovirt.org/community/events/archives/workshop/global-workshops/