### PR TITLE
Add missing escaping in Enable DEBUG Log

### DIFF
--- a/source/develop/developer-guide/engine/engine-development-environment.html.md
+++ b/source/develop/developer-guide/engine/engine-development-environment.html.md
@@ -267,28 +267,28 @@ keywords: how to debug ovirt-engine
 
 #### Enable DEBUG Log - Restart Required
 
-There is a file share/ovirt-engine/services/ovirt-engine/ovirt-engine.xml.in in the deployed engine environment. Open it and look for <subsystem xmlns="urn:jboss:domain:logging:1.1"> section. This section contains all output handlers (server.log, engine.log and console output) with associated level filters.
+There is a file share/ovirt-engine/services/ovirt-engine/ovirt-engine.xml.in in the deployed engine environment. Open it and look for `<subsystem xmlns="urn:jboss:domain:logging:1.1">` section. This section contains all output handlers (server.log, engine.log and console output) with associated level filters.
 
-<file-handler name="ENGINE" autoflush="true">
-` `<level name="DEBUG"/>
-` `<formatter>
-`  `<pattern-formatter pattern="%d %-5p [%c] (%t) %s%E%n"/>
-` `</formatter>
-` `<file path="$getstring('ENGINE_LOG')/engine.log"/>
-` `<append value="true"/>
-</file-handler>
+    <file-handler name="ENGINE" autoflush="true">
+      <level name="DEBUG"/>
+      <formatter>
+        <pattern-formatter pattern="%d %-5p [%c] (%t) %s%E%n"/>
+      </formatter>
+      <file path="$getstring('ENGINE_LOG')/engine.log"/>
+      <append value="true"/>
+    </file-handler>
 
 To actually get the DEBUG messages to those handlers add the following to the end of the subsystem section:
 
-<logger category="org.ovirt._package_you_are_interested_in">
-`  `<level name="DEBUG"/>
-</logger>
+    <logger category="org.ovirt._package_you_are_interested_in">
+      <level name="DEBUG"/>
+    </logger>
 
 To enable full database DEBUG logging to engine.log change the level to DEBUG in the following snippet:
 
-<logger category="org.ovirt.engine.core.dal.dbbroker.PostgresDbEngineDialect$PostgresJdbcTemplate">
-`  `<level name="WARN"/>
-</logger>
+    <logger category="org.ovirt.engine.core.dal.dbbroker.PostgresDbEngineDialect$PostgresJdbcTemplate">
+      <level name="WARN"/>
+    </logger>
 
 Restart the JBoss instance and you will see the logs.
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Added missing backquotes and spaces to make the corresponding text visible on the web page.

I confirm that this pull request was submitted according to the [contribution guidelines](/.github/CONTRIBUTING.md): @mz-pdm