### PR TITLE
New blog from oVirt infra on 'build-on-demand' feature

### DIFF
--- a/source/blog/2016-12-20-ci-please-build.html.md
+++ b/source/blog/2016-12-20-ci-please-build.html.md
@@ -6,11 +6,10 @@ date: 2016-12-20 10:00:00 CET
 ---
 
 All projects in oVirt CI are built today post merge, using the 'build-artifacs' stage from [oVirt's CI standards](http://ovirt-infra-docs.readthedocs.io/en/latest/CI/Build_and_test_standards.html).
-
 This ensures that all oVirt projects are built and deployed to oVirt repositories and can be consumed by CI jobs, developers or oVirt users.
-However, on some occasions a developer might need to build his project from an open patch in order to test the code before it is merged to the branch,
-So in any case of errors, he can go back to the patch and fix them before merging.
-Another exmaple is a UI developer, that works on a new UI fix/feature and wants to see the changes on each patch change.
+
+However, on some occasions a developer might need to build his project from an open patch.
+Developers need this to be able to examine the effects of their changes on a full oVirt installation before merging those changes. On some cases developers may even want to hand over packages based on un-merged patches to the QE team to verify that a given change will fix some complex issue.
 
 ## The Current Build Option
 
@@ -30,12 +29,16 @@ Adding this is a simple one liner to your project standard yaml file, just add t
 
       - '{project}_{version}_{stage}-on-demand-{distro}-{arch}'
 
+For a full example on how to add it in Gerrit, Checkout an example [Patch](https://gerrit.ovirt.org/#/c/68759/) which adds 
+on-demand builds to 4 different projects.
+
 
 ## What Else Can I Do With It ? (Hint: OST)
 
-Now that you know you can build new rpms whenever you want using a simple comment, you might ask yourself what can I do with those rpms?
-After the job you triggered finished running in Jenkins,you can use the Jenkins build URL, [Example](http://jenkins.ovirt.org/job/vdsm_master_build-artifacts-on-demand-el7-x86_64/1/artifact/exported-artifacts/) as a parameter to running oVirt system tests on your laptop!
-From ost root dir, run the following to run basic master suite for e.g:
+One more thing you can do, is to run the oVirt system tests suit, here is how you do it: 
+After the job you triggered finished running in Jenkins, use the Jenkins build URL you got [Example](http://jenkins.ovirt.org/job/vdsm_master_build-artifacts-on-demand-el7-x86_64/1/artifact/exported-artifacts/) as a parameter to 
+to run OST.
+From the OST root dir, run the following to run basic master suite for e.g:
 
     ./run_suite.sh -s http://jenkins.ovirt.org/job/vdsm_master_build-artifacts-on-demand-el7-x86_64/1/artifact/exported-artifacts/ basic_suite_master
 

--- a/source/blog/2016-12-20-ci-please-build.html.md
+++ b/source/blog/2016-12-20-ci-please-build.html.md
@@ -37,8 +37,8 @@ Checkout an example [Patch](https://gerrit.ovirt.org/#/c/68759/) which adds on-d
 
 ## What Else Can I Do With It ? (Hint: OST)
 
-Maybe the most interesting and valuable thing you can do with the new features, is to run the oVirt system tests suit on 
-the open patch (something that was possible only post merge until today, or needed complex actions to do it manually).
+Maybe the most interesting and valuable thing you can do with the new feature, is to run the oVirt system tests suit on 
+the open patch (something that was possible only post merge until today, or required complex actions to do it manually).
 
 Running the OST suite with your newly created RPMs requires also just one line of code, here's how you do it:
 
@@ -49,5 +49,6 @@ From the OST root dir, run the following to run basic master suite for e.g:
     ./run_suite.sh -s http://jenkins.ovirt.org/job/vdsm_master_build-artifacts-on-demand-el7-x86_64/1/artifact/exported-artifacts/ basic_suite_master
 
 For more info and help on using this new feature, feel free to come and ask us on infra@ovirt.org.
+For more info on oVirt system tests, checkout the [Project Documentation Page](http://ovirt-system-tests.readthedocs.io)
 
 Happy Building!

--- a/source/blog/2016-12-20-ci-please-build.html.md
+++ b/source/blog/2016-12-20-ci-please-build.html.md
@@ -37,8 +37,8 @@ on-demand builds to 4 different projects.
 
 One more thing you can do, is to run the oVirt system tests suit, here is how you do it:
 
-After the job you triggered finished running in Jenkins, use the Jenkins build URL you got [Example](http://jenkins.ovirt.org/job/vdsm_master_build-artifacts-on-demand-el7-x86_64/1/artifact/exported-artifacts/) as a parameter to 
-to run OST.
+After the job you triggered finished running in Jenkins, use the Jenkins build URL you got ([Example](http://jenkins.ovirt.org/job/vdsm_master_build-artifacts-on-demand-el7-x86_64/1/artifact/exported-artifacts/))
+as a parameter to to run OST on your laptop.
 From the OST root dir, run the following to run basic master suite for e.g:
 
     ./run_suite.sh -s http://jenkins.ovirt.org/job/vdsm_master_build-artifacts-on-demand-el7-x86_64/1/artifact/exported-artifacts/ basic_suite_master

--- a/source/blog/2016-12-20-ci-please-build.html.md
+++ b/source/blog/2016-12-20-ci-please-build.html.md
@@ -1,0 +1,44 @@
+---
+title: CI Please Build&mdash;How to build your oVirt project on-demand
+author: eedri
+tags: infrastructure, developers, ci
+date: 2016-12-20 10:00:00 CET
+---
+
+All projects in oVirt CI are built today post merge, using the 'build-artifacs' stage from [oVirt's CI standards](http://ovirt-infra-docs.readthedocs.io/en/latest/CI/Build_and_test_standards.html).
+
+This ensures that all oVirt projects are built and deployed to oVirt repositories and can be consumed by CI jobs, developers or oVirt users.
+However, on some occasions a developer might need to build his project from an open patch in order to test the code before it is merged to the branch,
+So in any case of errors, he can go back to the patch and fix them before merging.
+Another exmaple is a UI developer, that works on a new UI fix/feature and wants to see the changes on each patch change.
+
+## The Current Build Option
+
+Until now, to build rpms from a patch, a developer needed to use a custom [Jenkins job](http://jenkins.ovirt.org/job/ovirt-engine_master_build-artifacts-el7-x86_64_build_from_patch/), which was only available to ovirt-engine and only for master branch. 
+Another option was to try and build it locally, but then you need to make sure you have all the right packages installed ( something that is given automatically in CI ).
+
+## The New Build Option
+
+To ease and simplify the build from patch option, the oVirt infra team added a new feature to the [oVirt's CI standards framework](http://ovirt-infra-docs.readthedocs.io/en/latest/CI/Build_and_test_standards.html) called 'build on demand'.
+
+It allows any oVirt developer to trigger a build from a patch just by adding the comment 'ci please build' on the patch in Gerrit. 
+It will then trigger a 'build-artifacts-on-demand' job on jenkins which will build rpms from the patch, but not publish them to any repo.
+
+## How Do I Enable It For My oVirt Project ?
+
+Adding this is a simple one liner to your project standard yaml file, just add the following line to your 'build-artifacts' section, under 'jobs':
+
+      - '{project}_{version}_{stage}-on-demand-{distro}-{arch}'
+
+
+## What Else Can I Do With It ? (Hint: OST)
+
+Now that you know you can build new rpms whenever you want using a simple comment, you might ask yourself what can I do with those rpms?
+After the job you triggered finished running in Jenkins,you can use the Jenkins build URL, [Example](http://jenkins.ovirt.org/job/vdsm_master_build-artifacts-on-demand-el7-x86_64/1/artifact/exported-artifacts/) as a parameter to running oVirt system tests on your laptop!
+From ost root dir, run the following to run basic master suite for e.g:
+
+    ./run_suite.sh -s ./run_suite.sh -s http://jenkins.ovirt.org/job/ovirt-engine_master_build-artifacts-el7-x86_64_build_from_patch/30/ basic_suite_master
+
+For more info and help on using this new feature, feel free to come and ask us on infra@ovirt.org.
+
+Happy Building!

--- a/source/blog/2016-12-20-ci-please-build.html.md
+++ b/source/blog/2016-12-20-ci-please-build.html.md
@@ -35,7 +35,8 @@ on-demand builds to 4 different projects.
 
 ## What Else Can I Do With It ? (Hint: OST)
 
-One more thing you can do, is to run the oVirt system tests suit, here is how you do it: 
+One more thing you can do, is to run the oVirt system tests suit, here is how you do it:
+
 After the job you triggered finished running in Jenkins, use the Jenkins build URL you got [Example](http://jenkins.ovirt.org/job/vdsm_master_build-artifacts-on-demand-el7-x86_64/1/artifact/exported-artifacts/) as a parameter to 
 to run OST.
 From the OST root dir, run the following to run basic master suite for e.g:

--- a/source/blog/2016-12-20-ci-please-build.html.md
+++ b/source/blog/2016-12-20-ci-please-build.html.md
@@ -37,7 +37,7 @@ Now that you know you can build new rpms whenever you want using a simple commen
 After the job you triggered finished running in Jenkins,you can use the Jenkins build URL, [Example](http://jenkins.ovirt.org/job/vdsm_master_build-artifacts-on-demand-el7-x86_64/1/artifact/exported-artifacts/) as a parameter to running oVirt system tests on your laptop!
 From ost root dir, run the following to run basic master suite for e.g:
 
-    ./run_suite.sh -s ./run_suite.sh -s http://jenkins.ovirt.org/job/ovirt-engine_master_build-artifacts-el7-x86_64_build_from_patch/30/ basic_suite_master
+    ./run_suite.sh -s http://jenkins.ovirt.org/job/vdsm_master_build-artifacts-on-demand-el7-x86_64/1/artifact/exported-artifacts/ basic_suite_master
 
 For more info and help on using this new feature, feel free to come and ask us on infra@ovirt.org.
 

--- a/source/blog/2016-12-20-ci-please-build.html.md
+++ b/source/blog/2016-12-20-ci-please-build.html.md
@@ -5,38 +5,42 @@ tags: infrastructure, developers, ci
 date: 2016-12-20 10:00:00 CET
 ---
 
-All projects in oVirt CI are built today post merge, using the 'build-artifacs' stage from [oVirt's CI standards](http://ovirt-infra-docs.readthedocs.io/en/latest/CI/Build_and_test_standards.html).
+All projects in oVirt CI are built today post merge, using the 'build-artifacts' stage from [oVirt's CI standards](http://ovirt-infra-docs.readthedocs.io/en/latest/CI/Build_and_test_standards.html).
 This ensures that all oVirt projects are built and deployed to oVirt repositories and can be consumed by CI jobs, developers or oVirt users.
 
 However, on some occasions a developer might need to build his project from an open patch.
-Developers need this to be able to examine the effects of their changes on a full oVirt installation before merging those changes. On some cases developers may even want to hand over packages based on un-merged patches to the QE team to verify that a given change will fix some complex issue.
+Developers need this capability in order to to examine the effects of their changes on a full oVirt installation before merging those changes. 
+On some cases developers may even want to hand over packages based on un-merged patches to the QE team to verify that a given change will fix some complex issue or to preview a new feature on its early stages of developement.
 
 ## The Current Build Option
 
 Until now, to build rpms from a patch, a developer needed to use a custom [Jenkins job](http://jenkins.ovirt.org/job/ovirt-engine_master_build-artifacts-el7-x86_64_build_from_patch/), which was only available to ovirt-engine and only for master branch. 
-Another option is to try and build it locally using standard CI 'mock runner.sh' script which will use the same configuration
+Another option was to try and build it locally using standard CI 'mock runner.sh' script which will use the same configuration
 as in CI. For full documentation on how to use 'mock-runner', checkout the [Standard CI](http://infra-docs.readthedocs.io/en/latest/CI/Build_and_test_standards.html#testing-the-scripts-locally) page. 
 
 ## The New Build Option
 
 To ease and simplify the build from patch option, the oVirt infra team added a new feature to the [oVirt's CI standards framework](http://ovirt-infra-docs.readthedocs.io/en/latest/CI/Build_and_test_standards.html) called 'build on demand'.
 
-It allows any oVirt developer to trigger a build from a patch just by adding the comment 'ci please build' on the patch in Gerrit. 
+It allows any oVirt developer to trigger a build from any open patch just by adding the comment 'ci please build' on the patch in Gerrit. 
 It will then trigger a 'build-artifacts-on-demand' job on jenkins which will build rpms from the patch, but not publish them to any repo.
 
 ## How Do I Enable It For My oVirt Project ?
 
-Adding this is a simple one liner to your project standard yaml file, just add the following line to your 'build-artifacts' section, under 'jobs':
+Enabling the 'build-on-demand' feature to an oVirt project is simple as adding a single line to the project standard yaml file, just add the following line to your 'build-artifacts' section, under 'jobs':
 
       - '{project}_{version}_{stage}-on-demand-{distro}-{arch}'
 
-For a full example on how to add it in Gerrit, Checkout an example [Patch](https://gerrit.ovirt.org/#/c/68759/) which adds 
-on-demand builds to 4 different projects.
+For a full example on how to send a patch for enabling it, 
+Checkout an example [Patch](https://gerrit.ovirt.org/#/c/68759/) which adds on-demand builds to 4 different projects.
 
 
 ## What Else Can I Do With It ? (Hint: OST)
 
-One more thing you can do, is to run the oVirt system tests suit, here is how you do it:
+Maybe the most interesting and valuable thing you can do with the new features, is to run the oVirt system tests suit on 
+the open patch (something that was possible only post merge until today, or needed complex actions to do it manually).
+
+Running the OST suite with your newly created RPMs requires also just one line of code, here's how you do it:
 
 After the job you triggered finished running in Jenkins, use the Jenkins build URL you got ([Example](http://jenkins.ovirt.org/job/vdsm_master_build-artifacts-on-demand-el7-x86_64/1/artifact/exported-artifacts/))
 as a parameter to to run OST on your laptop.

--- a/source/blog/2016-12-20-ci-please-build.html.md
+++ b/source/blog/2016-12-20-ci-please-build.html.md
@@ -48,7 +48,7 @@ From the OST root dir, run the following to run basic master suite for e.g:
 
     ./run_suite.sh -s http://jenkins.ovirt.org/job/vdsm_master_build-artifacts-on-demand-el7-x86_64/1/artifact/exported-artifacts/ basic_suite_master
 
-For more info and help on using this new feature, feel free to come and ask us on infra@ovirt.org.
+For more info and help on using this new feature, feel free to come and ask us on infra@ovirt.org.<br>
 For more info on oVirt system tests, checkout the [Project Documentation Page](http://ovirt-system-tests.readthedocs.io)
 
 Happy Building!

--- a/source/blog/2016-12-20-ci-please-build.html.md
+++ b/source/blog/2016-12-20-ci-please-build.html.md
@@ -14,7 +14,8 @@ Developers need this to be able to examine the effects of their changes on a ful
 ## The Current Build Option
 
 Until now, to build rpms from a patch, a developer needed to use a custom [Jenkins job](http://jenkins.ovirt.org/job/ovirt-engine_master_build-artifacts-el7-x86_64_build_from_patch/), which was only available to ovirt-engine and only for master branch. 
-Another option was to try and build it locally, but then you need to make sure you have all the right packages installed ( something that is given automatically in CI ).
+Another option is to try and build it locally using standard CI 'mock runner.sh' script which will use the same configuration
+as in CI. For full documentation on how to use 'mock-runner', checkout the [Standard CI](http://infra-docs.readthedocs.io/en/latest/CI/Build_and_test_standards.html#testing-the-scripts-locally) page. 
 
 ## The New Build Option
 


### PR DESCRIPTION
	oVirt infra team added a new feature for
	developers to build artifacts on CI,
	on-demand, using just a comment in the patch.

Signed-off-by: Eyal Edri <eedri@redhat.com>

Fixes issue # (delete if not relevant)

Changes proposed in this pull request:

-

-

-

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): (please @mention yourself to sign)

This pull request needs review by: (please @mention the reviewer if relevant)
