### PR TITLE
Add bundle's vendor cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore bundler config
 /.bundle
+/vendor
 
 # Ignore the build directory
 /build


### PR DESCRIPTION
Some developers may want to have a local version of the bundled gems.
Adding `/vendor` to `.gitignore` would allow them to do so without having
that directory pop up in `git status`.

This patch [very partly] addresses issue #661.

Signed-off-by: Allon Mureinik <amureini@redhat.com>

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): @mureinik

This pull request needs review by: @duck-rh 
