### PR TITLE
Fix oVirt Global Workshops link

### DIFF
--- a/source/documentation/index.html.haml
+++ b/source/documentation/index.html.haml
@@ -102,7 +102,7 @@ wiki_last_updated: 2014-04-26
       - [Reporting a bug](/community/get-involved/report-a-bug/)
       - [Community activity](Community_activity)
       - [Outreach](Outreach)
-      - [oVirt Global Workshops](OVirt_Global_Workshops)
+      - [oVirt Global Workshops](/community/events/archives/workshop/global-workshops/)
 
 .row
   .col-md-4


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix oVirt Global Workshops link, pointing to http://www.ovirt.org/community/events/archives/workshop/global-workshops/

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): @sandrobonazzola

This pull request needs review by: @bproffitt 
