### PR TITLE
Fix home page link to Download

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -64,7 +64,7 @@ hide_metadata: true
 
       {:.pull-right}
       [Read the release notes](/release/#{release_version}/)
-      [Get started with oVirt #{release_version}](Download)
+      [Get started with oVirt #{release_version}](/download/)
 
 .container
   .row


### PR DESCRIPTION
Changes proposed in this pull request:

- Get started with oVirt 4.0.6 points to Download wiki page, resulting in a 404 error. Fixing the link pointing to website download page.

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): @sandrobonazzola

This pull request needs review by: @bproffitt 
