### PR TITLE
Update Home page pointing to 4.1.0

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -5,8 +5,8 @@ pageable: false
 no_container: true
 authors: bproffitt, dneary, doron, knesenko, mburns, quaid, sandrobonazzola, theron, garrett
 wiki_title: Home
-wiki_revision_count: 98
-wiki_last_updated: 2017-01-10
+wiki_revision_count: 99
+wiki_last_updated: 2017-02-01
 hide_metadata: true
 ---
 
@@ -55,8 +55,8 @@ hide_metadata: true
     :ruby
       # Rely on either a releases.yml or scan the release directory
       # (Hard-coding release version & date is temporary)
-      release_version = '4.0.6'
-      release_date = '2017-01-10'.to_date
+      release_version = '4.1.0'
+      release_date = '2017-02-01'.to_date
 
     :markdown
       {:.pull-left}


### PR DESCRIPTION
Changes proposed in this pull request:

- Update Home page pointing to 4.1.0

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): @sandrobonazzola
