### PR TITLE
documentation: fix quickstart link

### DIFF
--- a/source/documentation/index.html.haml
+++ b/source/documentation/index.html.haml
@@ -44,7 +44,7 @@ wiki_last_updated: 2014-04-26
   .col-md-4
     :markdown
       ## Primary Documentation
-      - #### [Quick Start Guide](Quick_Start_Guide)
+      - #### [Quick Start Guide](quickstart/quickstart-guide)
       - #### [oVirt Installation Guide](install-guide/Installation_Guide)
       - #### [oVirt Upgrade Guide](upgrade-guide/upgrade-guide)
       - #### [oVirt Administration Guide](admin-guide/administration-guide/)


### PR DESCRIPTION
In ovirt.org/documentation quickstart link is broken.

Changes proposed in this pull request:

- fix quickstart link in documentation

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): (@dougsland)

This pull request needs review by: (@sbonazzo)
