### PR TITLE
Added links to downloading ovirt-4.1

### DIFF
--- a/source/node/index.md
+++ b/source/node/index.md
@@ -83,6 +83,13 @@ This is the oVirt Node 4 image including the latest oVirt 4 packages.
 * [Installation ISO](http://jenkins.ovirt.org/job/ovirt-node-ng_ovirt-4.0_build-artifacts-el7-x86_64/lastSuccessfulBuild/artifact/exported-artifacts/latest-installation-iso.html)
 * Jenkins job: <http://jenkins.ovirt.org/job/ovirt-node-ng_ovirt-4.0_build-artifacts-el7-x86_64/>
 
+## oVirt Node 4.1
+
+This is the oVirt Node 4.1 image including the latest oVirt 4.1 packages.
+
+* [Installation ISO](http://jenkins.ovirt.org/job/ovirt-node-ng_ovirt-4.1_build-artifacts-el7-x86_64/lastSuccessfulBuild/artifact/exported-artifacts/latest-installation-iso.html)
+* Jenkins job: <http://jenkins.ovirt.org/job/ovirt-node-ng_ovirt-4.1_build-artifacts-el7-x86_64/>
+
 ## oVirt Node Master
 
 This is the oVirt Node image build based on oVirt packages from the master branches.


### PR DESCRIPTION
Changes proposed in this pull request:

- Added links to latest installation iso and the jenkins job for ovirt-node-ng for ovirt-4.1

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): (please @mention yourself to sign)
@yuvalturg

This pull request needs review by: (please @mention the reviewer if relevant)
@sandrobonazzola 
