### PR TITLE
import-vm-net-changes: remove "storage_domain"

### DIFF
--- a/source/develop/release-management/features/network/import-vm-net-changes.html.md
+++ b/source/develop/release-management/features/network/import-vm-net-changes.html.md
@@ -60,7 +60,6 @@ POST /storagedomains/{storagedomain:id}/vms/{vm:id}/register
 ```xml
 <action>
     <cluster id=”XXX”/>
-    <storage_domain id=”YYY”/>
     ....
     <!-- The new addition start -->
     <vnic_profile_mappings>
@@ -133,7 +132,6 @@ POST /storagedomains/{storagedomain:id}/vms/{vm:id}/register
 ```xml
 <action>
     <cluster id=”XXX”/>
-    <storage_domain id=”YYY”/>
     ....
     <!-- The new addition start -->
     <reassign_bad_macs>true</reassign_bad_macs>


### PR DESCRIPTION
The "storage_domain" parameter seems not to be present in the API.

See https://gerrit.ovirt.org/#/c/72896/1 for a recent change which touched the relevant part of code today.