### PR TITLE
Headless VM - adding a limitation for setting grub to boot in console mode

### DIFF
--- a/source/develop/release-management/features/virt/headless-vm.html.md
+++ b/source/develop/release-management/features/virt/headless-vm.html.md
@@ -2,8 +2,6 @@
 title: Headless VM 
 category: feature
 authors: SharonG
-wiki_category: Feature
-wiki_title: Features/Headless VM
 feature_name: Headless VM
 feature_modules: engine
 feature_status: Merged


### PR DESCRIPTION
Fixes issue from BZ1425076 by adding a limitation for setting grub to boot in console mode since otherwise it may hang.

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): @sgratch

This pull request needs review by: @jelkosz 