### PR TITLE
added rest-api documentation, take 2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "data/events"]
 	path = data/events
 	url = https://github.com/OSAS/rh-events.git
+[submodule "source/documentation/rest-api"]
+	path = source/documentation/rest-api
+	url = https://github.com/oVirt/ovirt-engine-api-model.git
+	branch = gh-pages

--- a/config.rb
+++ b/config.rb
@@ -211,7 +211,8 @@ require 'lib/monkeypatch_blog_date.rb'
 configure :development do
   puts "\nUpdating git submodules..."
   puts `git submodule init && git submodule sync`
-  puts `git submodule foreach "git pull -qf origin master"`
+  # "--remote" replaces "foreach git pull ...", and respects branch from .gitmodules
+  puts `git submodule update --recursive --remote`
   puts "\n"
   puts '== Administration is at http://0.0.0.0:4567/admin/'
 
@@ -228,7 +229,8 @@ end
 configure :build do
   puts "\nUpdating git submodules..."
   puts `git submodule init`
-  puts `git submodule foreach "git pull -qf origin master"`
+  # "--remote" replaces "foreach git pull ...", and respects branch from .gitmodules
+  puts `git submodule update --recursive --remote`
   puts "\n"
 
   ## Ignore administration UI

--- a/source/documentation/index.html.haml
+++ b/source/documentation/index.html.haml
@@ -70,6 +70,7 @@ wiki_last_updated: 2014-04-26
       - [Getting in contact with the oVirt community](/community/about/contact)
       - [Becoming a maintainer](/develop/dev-process/becoming-a-maintainer)
       - [oVirt architecture](/documentation/architecture/architecture)
+      - [REST API](/documentation/rest-api/)
       - [Feature Roadmap oVirt 3.6](/develop/release-management/releases/3.6)
         (see also old roadmaps for
         [oVirt 3.5](/develop/release-management/releases/3.5),


### PR DESCRIPTION
Changes proposed in this pull request: second try to add rest-api documentation to the website.

Documentation is pulled as submodule from ovirt-engine-api-model repository. Needed to patch config.rb to update the submodule properly, pulling from the correct branch, instead of always `master`.

This is a follow-up to #681 

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): @rafaelmartins

This pull request needs review by: @sandrobonazzola @jhernand @phoracek @MarSik @bproffitt @garrett (anyone else is free to review too)
