### PR TITLE
Memory hot unplug documentation updated

### DIFF
--- a/source/develop/release-management/features/hot-unplug-memory.html.md
+++ b/source/develop/release-management/features/hot-unplug-memory.html.md
@@ -4,8 +4,8 @@ category: feature
 authors: mzamazal
 wiki_category: Feature
 wiki_title: Features/Hot Unplug Memory
-wiki_revision_count: 1
-wiki_last_updated: 2017-02-15
+wiki_revision_count: 2
+wiki_last_updated: 2017-03-21
 ---
 
 # Hot unplug memory
@@ -31,8 +31,8 @@ some limitations:
 - You can't remove arbitrary amount of memory.  Only previously hot plugged
   memory devices can be removed.
 
-- The guest OS must support memory hot unplug.  Most contemporary Linux systems
-  should support it.
+- The guest OS must support memory hot unplug.  Up-to-date RHEL/CentOS 7
+  systems support it.
 
 - All blocks of the previously hot plugged memory must be onlined as movable.
 
@@ -43,53 +43,11 @@ fail or cause problems.
 
 ## Making hot plugged memory movable
 
-To make hot plugged memory movable, it is necessary to execute proper actions
-when onlining a hot plugged memory.  The hot plugged memory is not available to
-the guest OS until it is onlined.  Your guest OS may ensure that a hot plugged
-memory is onlined automatically.  For instance, on RHEL 7.3 systems there is a
-udev file `/lib/udev/rules.d/40-redhat.rules` containing a line that looks like
-this:
-
-    # Memory hotadd request
-    SUBSYSTEM=="memory", ACTION=="add", PROGRAM="/bin/uname -p", RESULT!="s390*", ATTR{state}=="offline", ATTR{state}="online"
-
-However the state of the newly added memory is set to `online`, rather than
-`online_movable`, in the rule.  This makes the hot plugged memory non-movable.
-Simply changing `online` to `online_movable` would not work on current systems
-(as of RHEL 7.3) since movable blocks of memory must be onlined in the right
-order and the system doesn't guarantee that.  In the result, only a part of the
-newly added memory might be available if `online` was changed to
-`online_movable`.  (But if `online_movable` has already been present in the
-udev rule then the system should support it correctly and you probably do not
-have to change anything.)
-
-To handle the problem you must disable the rule.  Copy
-`/lib/udev/rules.d/40-redhat.rules` to `/etc/udev/rules.d/40-redhat.rules` and
-comment out the line above in `/etc/udev/rules.d/40-redhat.rules` file by
-putting `#` character in front of it:
-
-    # Memory hotadd request
-    # SUBSYSTEM=="memory", ACTION=="add", PROGRAM="/bin/uname -p", RESULT!="s390*", ATTR{state}=="offline", ATTR{state}="online"
-
-Then run
-
-    sudo systemctl restart systemd-udevd
-
-After that udev won't online the newly added memory automatically anymore.  You
-must do that manually each time after you hot plug some memory, using the
-following shell script:
-
-    #!/bin/bash
-    for i in `ls -d1 /sys/devices/system/memory/memory* | sort -nr -t y -k 5`; do 
-      if [ "`cat $i/state`" == "offline" ]; then
-        echo online_movable > $i/state
-      fi
-    done
-    
-Note: After upgrading the system to a new version, you should check whether
-there are any changes in `/lib/udev/rules.d/40-redhat.rules`.  If they are then
-you should propagate them to `/etc/udev/rules.d/40-redhat.rules`, e.g. by
-copying and editing the changed file again as described above.
+To fulfill the requirement of making hot plugged memory movable on an
+up-to-date RHEL/CentOS 7 guest system, ovirt-guest-agent of version
+1.0.13-2.el7 or higher must be installed in the guest.  Please note that proper
+ovirt-guest-agent version must be installed in the guest prior to hot plugging
+any memory in order to guarantee that hot plugged memory is movable.
 
 ## How to hot unplug memory from a VM
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Memory hot unplug works on current RHEL/CentOS guests, not on most Linux systems.

- Manual guest OS configuration is not needed, new ovirt-guest-agent handles it.

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): @mz-pdm

This pull request needs review by: @jniederm 
