### PR TITLE
changed News heading to Blog

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -73,7 +73,7 @@ hide_metadata: true
 
         %h2
           = data.site.name
-          News
+          Blog
 
         = partial :blog_posts, locals: {limit: 3}
 


### PR DESCRIPTION
Fixes issue # (delete if not relevant)

Changes proposed in this pull request:

- On home page, changed "News" heading to "Blog"
-Middleman didn't respond, so unable to see change in test site. The site says "oVirt News" so where is the "oVirt"

-

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): @jmarks

This pull request needs review by: @bproffitt @mykaul 
