### PR TITLE
multiple empty bullets fixed & user story image resized

### DIFF
--- a/source/community/user-stories/alter-way-case-study.html.md
+++ b/source/community/user-stories/alter-way-case-study.html.md
@@ -11,15 +11,16 @@ wiki_last_updated: 2013-09-09
 # Alter Way case study
 
 <div class="row">
-<div class="col-md-7 col-md-offset-1 pad-sides">
+<div class="col-md-7 col-md-offset-1 pad-sides ">
 ## oVirt in Alter Way
 
 [Alter Way](//alterway.fr), a French hosting and services company founded in 2006, has been using oVirt in its public cloud offering, [H2O](//h2o.alterway.fr/), since last year. The service launched in October 2012, and there are already over 300 VMs being managed on the service for clients. We recently caught up with Stéphane Vincent, Director of Strategic Services and Innovation, to talk about why Alter Way chose oVirt, how they are using it, and what excites them about the 3.3 release.
 
 "We decided early on to standardise on KVM for our hypervisor layer, and evaluated a number of management solutions for it. We looked at OpenNebula, CloudStack, Proxmox, Red Hat Enterprise Virtualization, oVirt and OpenStack. In the end, we settled on oVirt for hosting our public cloud offering, and OpenStack for our private cloud offering," says Stéphane. The main features of oVirt which influenced the decision were "it allowed us to scale up as well as scale out our client workloads. oVirt allows us to do everything that our clients expect, including the ability to dedicate several hypervisors within a datacenter to a client. The main technical feature we depend on is memory ballooning - the ability to scale up the memory available to a VM based on demand."
 
-<div class="thumbnail pull-left">
-![](/images/wiki/Stephane_Vincent.png)
+<div class="thumbnail pull-left col-md-5">
+
+![](/images/wiki/Stephane_Vincent.png) 
 
 </div>
 Three other factors were key in the decision: "a very active community, an ambitious technical roadmap with regular releases, and the involvement of companies including Red Hat, Intel, NetApp, Cisco and IBM reassured us that the project would be around for the duration." The oVirt community has been very helpful, and Stéphane and his colleagues appreciate the visibility into what is coming in future versions. "We are also participants in the oVirt community", says Stéphane, "we have been happy to sponsor some hardware and network bandwidth for some of the project's infrastructure - it's appropriate that oVirt is running part of its infrastructure on oVirt managed VMs, hosted by a company running oVirt in production. In addition, we have produced several videos promoting oVirt and explaining our technical choices and how we use oVirt alongside OpenStack."

--- a/source/develop/developer-guide/vdsm/hook/hugepages.html.md
+++ b/source/develop/developer-guide/vdsm/hook/hugepages.html.md
@@ -12,11 +12,11 @@ The hugepages vdsm hook will receive hugepages=512 and will preserve 512 huge pa
 
 This is useful for VMs running large memory loads, so that memory page fragmentation is lowered and the VM can access larger memory chunks at a time. The downside is more potential for wasted RAM.
 
-How this works: The hook will add pages: sysctl vm.nr_hugepages=512 and will add add the following xml in domain\\devices:
+How this works: The hook will add pages: sysctl vm.nr_hugepages=512 and will add the following xml in domain\\devices:
 
-`   `<memoryBacking>
-`       `<hugepages/>
-`   `</memoryBacking>
+`   <memoryBacking>  `
+`     <hugepages/>   `
+`       </memoryBacking> `
 
 IMPORTANT: hugepages must be mounted prior to libvirt start up, ie:
 

--- a/source/documentation/admin-guide/administration-guide.html.md
+++ b/source/documentation/admin-guide/administration-guide.html.md
@@ -1,3 +1,7 @@
+---
+title: oVirt Administration Guide 
+---
+
 # oVirt Administration Guide
 
 The oVirt environment requires an administrator to keep it running. As an administrator, your tasks include:

--- a/source/documentation/admin-guide/appe-Branding.html.md
+++ b/source/documentation/admin-guide/appe-Branding.html.md
@@ -1,3 +1,7 @@
+---
+title: Branding
+---
+
 # Appendix F: Branding
 
 ## Re-Branding the Engine

--- a/source/documentation/admin-guide/appe-Custom_Network_Properties.html.md
+++ b/source/documentation/admin-guide/appe-Custom_Network_Properties.html.md
@@ -1,3 +1,7 @@
+---
+title: Custom Network Properties
+---
+
 # Appendix B: Custom Network Properties
 
 ## Explanation of bridge_opts Parameters

--- a/source/documentation/admin-guide/appe-System_Accounts.html.md
+++ b/source/documentation/admin-guide/appe-System_Accounts.html.md
@@ -1,3 +1,7 @@
+---
+title: System Accounts
+---
+
 # Appendix G: System Accounts
 
 ## oVirt Engine User Accounts

--- a/source/documentation/admin-guide/appe-Using_Search_Bookmarks_and_Tags.html.md
+++ b/source/documentation/admin-guide/appe-Using_Search_Bookmarks_and_Tags.html.md
@@ -1,3 +1,7 @@
+---
+title: Using Search, Bookmarks, and Tags
+---
+
 # Appendix E: Using Search, Bookmarks, and Tags
 
 ## Searches

--- a/source/documentation/admin-guide/appe-VDSM_and_Hooks.html.md
+++ b/source/documentation/admin-guide/appe-VDSM_and_Hooks.html.md
@@ -1,3 +1,7 @@
+---
+title: VSDM and Hooks
+---
+
 # Appendix A: VDSM and Hooks
 
 ## VDSM

--- a/source/documentation/admin-guide/appe-oVirt_User_Interface_Plugins.html.md
+++ b/source/documentation/admin-guide/appe-oVirt_User_Interface_Plugins.html.md
@@ -1,3 +1,7 @@
+---
+title: oVirt User Interface Plugins
+---
+
 # Appendix C: oVirt User Interface Plugins
 
 oVirt supports plug-ins that expose non-standard features. This makes it easier to use the oVirt Administration Portal to integrate with other systems. Each interface plug-in represents a set of user interface extensions that can be packaged and distributed for use with oVirt.

--- a/source/documentation/admin-guide/appe-oVirt_and_SSL.html.md
+++ b/source/documentation/admin-guide/appe-oVirt_and_SSL.html.md
@@ -1,3 +1,7 @@
+---
+title: oVirt and SSL
+---
+
 # Appendix D: oVirt and SSL
 
 ## Replacing the oVirt Engine SSL Certificate

--- a/source/documentation/admin-guide/chap-Backups_and_Migration.html.md
+++ b/source/documentation/admin-guide/chap-Backups_and_Migration.html.md
@@ -1,3 +1,7 @@
+---
+title:  Backups and Migration
+---
+
 # Chapter 13: Backups and Migration
 
 ## Backing Up and Restoring the oVirt Engine

--- a/source/documentation/admin-guide/chap-Clusters.html.md
+++ b/source/documentation/admin-guide/chap-Clusters.html.md
@@ -1,3 +1,7 @@
+---
+title: Clusters
+---
+
 # Chapter 5: Clusters
 
 ## Introduction to Clusters

--- a/source/documentation/admin-guide/chap-Data_Centers.html.md
+++ b/source/documentation/admin-guide/chap-Data_Centers.html.md
@@ -1,3 +1,7 @@
+---
+title: Data Centers
+---
+
 # Chapter 4: Data Centers
 
 ## Introduction to Data Centers

--- a/source/documentation/admin-guide/chap-Errata_Management_with_Foreman.html.md
+++ b/source/documentation/admin-guide/chap-Errata_Management_with_Foreman.html.md
@@ -1,3 +1,7 @@
+---
+title: Errata Management with Foreman
+---
+
 # Chapter 14: Errata Management with Foreman
 
 oVirt can be configured to view errata from Foreman in the oVirt Engine. This enables the administrator to receive updates about available errata, and their importance, for hosts, virtual machines, and the Engine once they have been associated with a Foreman provider. Administrators can then choose to apply the updates by running an update on the required host, virtual machine, or on the Engine.

--- a/source/documentation/admin-guide/chap-Event_Notifications.html.md
+++ b/source/documentation/admin-guide/chap-Event_Notifications.html.md
@@ -1,3 +1,7 @@
+---
+title: Event Notifications
+---
+
 # Chapter 17: Event Notifications
 
 ## Configuring Event Notifications in the Administration Portal

--- a/source/documentation/admin-guide/chap-External_Providers.html.md
+++ b/source/documentation/admin-guide/chap-External_Providers.html.md
@@ -1,3 +1,7 @@
+---
+title: External Providers
+---
+
 # Chapter 12: External Providers
 
 ## Introduction to External Providers in oVirt

--- a/source/documentation/admin-guide/chap-Global_Configuration.html.md
+++ b/source/documentation/admin-guide/chap-Global_Configuration.html.md
@@ -1,3 +1,7 @@
+---
+title: Global Configuration
+---
+
 # Chapter 1: Global Configuration
 
 Accessed from the header bar in the Administration Portal, the **Configure** window allows you to configure a number of global resources for your oVirt environment, such as users, roles, system permissions, scheduling policies, instance types, and MAC address pools. This window allows you to customize the way in which users interact with resources in the environment, and provides a central location for configuring options that can be applied to multiple clusters.

--- a/source/documentation/admin-guide/chap-Hosts.html.md
+++ b/source/documentation/admin-guide/chap-Hosts.html.md
@@ -1,3 +1,7 @@
+---
+title: Hosts
+---
+
 # Chapter 7: Hosts
 
 ## Introduction to Hosts

--- a/source/documentation/admin-guide/chap-Log_Files.html.md
+++ b/source/documentation/admin-guide/chap-Log_Files.html.md
@@ -1,3 +1,7 @@
+---
+title: Log Files
+---
+
 # Chapter 19: Log Files
 
 ## oVirt Engine Installation Log Files

--- a/source/documentation/admin-guide/chap-Logical_Networks.html.md
+++ b/source/documentation/admin-guide/chap-Logical_Networks.html.md
@@ -1,3 +1,7 @@
+---
+title: Logical Networks
+---
+
 # Chapter 6: Logical Networks
 
 ## Logical Network Tasks

--- a/source/documentation/admin-guide/chap-Pools.html.md
+++ b/source/documentation/admin-guide/chap-Pools.html.md
@@ -1,3 +1,7 @@
+---
+title: Pools
+---
+
 # Chapter 10: Pools
 
 ## Introduction to Virtual Machine Pools

--- a/source/documentation/admin-guide/chap-Proxies.html.md
+++ b/source/documentation/admin-guide/chap-Proxies.html.md
@@ -1,3 +1,7 @@
+---
+title: Proxies
+---
+
 # Chapter 20: Proxies
 
 ## SPICE Proxy Overview

--- a/source/documentation/admin-guide/chap-Quality_of_Service.html.md
+++ b/source/documentation/admin-guide/chap-Quality_of_Service.html.md
@@ -1,3 +1,7 @@
+---
+title: Quality of Services
+---
+
 # Chapter 3: Quality of Service
 
 oVirt allows you to define quality of service entries that provide fine-grained control over the level of input and output, processing, and networking capabilities that resources in your environment can access. Quality of service entries are defined at the data center level and are assigned to profiles created under clusters and storage domains. These profiles are then assigned to individual resources in the clusters and storage domains where the profiles were created.

--- a/source/documentation/admin-guide/chap-Quotas_and_Service_Level_Agreement_Policy.html.md
+++ b/source/documentation/admin-guide/chap-Quotas_and_Service_Level_Agreement_Policy.html.md
@@ -1,3 +1,7 @@
+---
+title: Quotes and Services Level Agreement Policy
+---
+
 # Chapter 16: Quotas and Service Level Agreement Policy
 
 ## Introduction to Quota

--- a/source/documentation/admin-guide/chap-Storage.html.md
+++ b/source/documentation/admin-guide/chap-Storage.html.md
@@ -1,3 +1,7 @@
+---
+title: Storage
+---
+
 # Chapter 8: Storage
 
 oVirt uses a centralized storage system for virtual machine disk images, ISO files and snapshots. Storage networking can be implemented using:

--- a/source/documentation/admin-guide/chap-System_Dashboard.html.md
+++ b/source/documentation/admin-guide/chap-System_Dashboard.html.md
@@ -1,3 +1,7 @@
+---
+title: System Dashboard
+---
+
 # Chapter 2: System Dashboard
 
 The Dashboard provides an overview of the oVirt system status by displaying a summary of oVirt's resources and utilization. This summary can alert the user to a problem and allows them to analyse the problem area.

--- a/source/documentation/admin-guide/chap-Users_and_Roles.html.md
+++ b/source/documentation/admin-guide/chap-Users_and_Roles.html.md
@@ -1,3 +1,7 @@
+---
+title: Users and Roles
+---
+
 # Chapter 15: Users and Roles
 
 ## Introduction to Users

--- a/source/documentation/admin-guide/chap-Utilities.html.md
+++ b/source/documentation/admin-guide/chap-Utilities.html.md
@@ -1,3 +1,7 @@
+---
+title: Utilities
+---
+
 # Chapter 18: Utilities
 
 ## The oVirt Engine Rename Tool

--- a/source/documentation/admin-guide/chap-Virtual_Machine_Disks.html.md
+++ b/source/documentation/admin-guide/chap-Virtual_Machine_Disks.html.md
@@ -1,3 +1,7 @@
+---
+title: Virtual machine Disks
+---
+
 # Chapter 11: Virtual Machine Disks
 
 ## Understanding Virtual Machine Storage

--- a/source/documentation/admin-guide/chap-Working_with_Gluster_Storage.html.md
+++ b/source/documentation/admin-guide/chap-Working_with_Gluster_Storage.html.md
@@ -1,3 +1,7 @@
+---
+title: Working with Gluster Storage 
+---
+
 # Chapter 9: Working with Gluster Storage
 
 ## Gluster Storage Nodes

--- a/source/documentation/how-to/virtual-machines/enable-usb2-linux-vm.html.md
+++ b/source/documentation/how-to/virtual-machines/enable-usb2-linux-vm.html.md
@@ -1,3 +1,7 @@
+---
+title: Enabling an EHCI (USB 2.0) Controller for Linux VMs on x86 Systems
+---
+
 # Enabling an EHCI (USB 2.0) Controller for Linux VMs on x86 Systems
 
 ## Overview

--- a/source/documentation/install-guide/Installation_Guide.html.md
+++ b/source/documentation/install-guide/Installation_Guide.html.md
@@ -1,3 +1,7 @@
+---
+title: Installation Guide
+---
+
 # oVirt Installation Guide
 
 ## Part I: Introduction to oVirt

--- a/source/documentation/install-guide/appe-Attaching_the_Local_ISO_Domain_to_a_Data_Center.html.md
+++ b/source/documentation/install-guide/appe-Attaching_the_Local_ISO_Domain_to_a_Data_Center.html.md
@@ -1,3 +1,7 @@
+---
+title: Attaching the Local ISO Domain to a Data Center
+---
+
 # Appendix B: Attaching the Local ISO Domain to a Data Center
 
 The local ISO domain, created during the Engine installation, appears in the Administration Portal as **Unattached**. To use it, attach it to a data center. The ISO domain must be of the same **Storage Type** as the data center. Each host in the data center must have read and write access to the ISO domain. In particular, ensure that the Storage Pool Engine has access.

--- a/source/documentation/install-guide/appe-Changing_the_Permissions_for_the_Local_ISO_Domain.html.md
+++ b/source/documentation/install-guide/appe-Changing_the_Permissions_for_the_Local_ISO_Domain.html.md
@@ -1,3 +1,7 @@
+---
+title: Changing the Permissions for the Local ISO Domain
+---
+
 # Appendix A: Changing the Permissions for the Local ISO Domain
 
 If the Engine was configured during setup to provide a local ISO domain, that domain can be attached to one or more data centers, and used to provide virtual machine image files. By default, the access control list (ACL) for the local ISO domain provides read and write access for only the Engine machine. Virtualization hosts require read and write access to the ISO domain in order to attach the domain to a data center. Use this procedure if network or host details were not available at the time of setup, or if you need to update the ACL at any time.

--- a/source/documentation/install-guide/appe-Configuring_a_Hypervisor_Host_for_PCI_Passthrough.html.md
+++ b/source/documentation/install-guide/appe-Configuring_a_Hypervisor_Host_for_PCI_Passthrough.html.md
@@ -1,3 +1,7 @@
+---
+title: Configuring a Host for PCI Passthrough
+---
+
 # Appendix G: Configuring a Host for PCI Passthrough
 
 Enabling PCI passthrough allows a virtual machine to use a host device as if the device were directly attached to the virtual machine. To enable the PCI passthrough function, you need to enable virtualization extensions and the IOMMU function. The following procedure requires you to reboot the host. If the host is attached to the Manager already, ensure you place the host into maintenance mode before running the following procedure.

--- a/source/documentation/install-guide/appe-Enabling_Gluster_Processes_on_Gluster_Storage_Nodes.html.md
+++ b/source/documentation/install-guide/appe-Enabling_Gluster_Processes_on_Gluster_Storage_Nodes.html.md
@@ -1,3 +1,7 @@
+---
+title: Enabling Gluster Processes on Gluster Storage Nodes 
+---
+
 # Appendix C: Enabling Gluster Processes on Gluster Storage Nodes
 
 1. In the Navigation Pane, select the **Clusters** tab.

--- a/source/documentation/install-guide/appe-Installing_the_Websocket_Proxy_on_a_different_host.html.md
+++ b/source/documentation/install-guide/appe-Installing_the_Websocket_Proxy_on_a_different_host.html.md
@@ -1,3 +1,7 @@
+---
+title: Installing a Websocket Proxy on a Separate Machine
+---
+
 # Appendix F: Installing a Websocket Proxy on a Separate Machine
 
 The websocket proxy allows users to connect to virtual machines via noVNC and SPICE HTML5 consoles. The noVNC client uses websockets to pass VNC data. However, the VNC server in QEMU does not provide websocket support, therefore a websocket proxy must be placed between the client and the VNC server. The proxy can run on any machine that has access to the network, including the the Engine machine.

--- a/source/documentation/install-guide/appe-Preparing_a_Local_Manually-Configured_PostgreSQL_Database_for_Use_with_the_oVirt_Engine.html.md
+++ b/source/documentation/install-guide/appe-Preparing_a_Local_Manually-Configured_PostgreSQL_Database_for_Use_with_the_oVirt_Engine.html.md
@@ -1,3 +1,7 @@
+---
+title: Preparing a Local Manually-Configured PostgreSQL Database for Use with the oVirt Engine
+---
+
 # Appendix E: Preparing a Local Manually-Configured PostgreSQL Database for Use with the oVirt Engine
 
 Optionally configure a local PostgreSQL database on the Engine machine to use as the Engine database. By default, the oVirt Engine's configuration script, `engine-setup`, creates and configures the Engine database locally on the Engine machine. To configure the Engine database on a machine that is separate from the machine where the Engine is installed, see [Preparing a Remote PostgreSQL Database for Use with the oVirt Engine](../appe-Preparing_a_Remote_PostgreSQL_Database_for_Use_with_the_oVirt_Engine).

--- a/source/documentation/install-guide/appe-Preparing_a_Remote_PostgreSQL_Database_for_Use_with_the_oVirt_Engine.html.md
+++ b/source/documentation/install-guide/appe-Preparing_a_Remote_PostgreSQL_Database_for_Use_with_the_oVirt_Engine.html.md
@@ -1,3 +1,7 @@
+---
+title: Preparing a Remote PostgreSQL Database for Use with the oVirt Engine
+---
+
 # Appendix D: Preparing a Remote PostgreSQL Database for Use with the oVirt Engine
 
 Optionally configure a PostgreSQL database on a remote Enterprise Linux 7 machine to use as the Engine database. By default, the oVirt Engine's configuration script, `engine-setup`, creates and configures the Engine database locally on the Engine machine. To set up the Engine database with custom values on the Engine machine, see [Appendix E: Preparing a Local Manually-Configured PostgreSQL Database for Use with the oVirt Engine](../appe-Preparing_a_Local_Manually-Configured_PostgreSQL_Database_for_Use_with_the_oVirt_Engine).

--- a/source/documentation/install-guide/chap-Adding_a_Hypervisor.html.md
+++ b/source/documentation/install-guide/chap-Adding_a_Hypervisor.html.md
@@ -1,3 +1,7 @@
+---
+title: Adding a Hypervisor
+---
+
 # Chapter 8: Adding a Hypervisor
 
 Adding a host to your oVirt environment can take some time, as the following steps are completed by the platform: virtualization checks, installation of packages, creation of bridge, and a reboot of the host. Use the details pane to monitor the process as the host and the Engine establish a connection.

--- a/source/documentation/install-guide/chap-Configuring_Storage.html.md
+++ b/source/documentation/install-guide/chap-Configuring_Storage.html.md
@@ -1,3 +1,7 @@
+---
+title: Configuring Storage
+---
+
 # Chapter 9: Configuring Storage
 
 ## Introduction to Storage

--- a/source/documentation/install-guide/chap-Enterprise_Linux_Hosts.html.md
+++ b/source/documentation/install-guide/chap-Enterprise_Linux_Hosts.html.md
@@ -1,3 +1,7 @@
+---
+title: Enterprise Linux Hosts
+---
+
 # Chapter 7: Enterprise Linux Hosts
 
 ## Installing Enterprise Linux Hosts

--- a/source/documentation/install-guide/chap-Installing_oVirt.html.md
+++ b/source/documentation/install-guide/chap-Installing_oVirt.html.md
@@ -1,3 +1,7 @@
+---
+title: Installing oVirt
+---
+
 # Chapter 3: Installing oVirt
 
 ## Installing the oVirt Engine Packages

--- a/source/documentation/install-guide/chap-Introduction_to_Hypervisor_Hosts.html.md
+++ b/source/documentation/install-guide/chap-Introduction_to_Hypervisor_Hosts.html.md
@@ -1,3 +1,7 @@
+---
+title: Introduction to Hypervisor Hosts
+---
+
 # Chapter 5: Introduction to Hypervisor Hosts
 
 oVirt supports two types of hosts: oVirt Node and Enterprise Linux host. Depending on your environment requirement, you may want to use one type only or both in your oVirt environment. It is recommended that you install and attach at least two hosts to the oVirt environment. Where you attach only one host you will be unable to access features such as migration and high availability.

--- a/source/documentation/install-guide/chap-Introduction_to_oVirt.html.md
+++ b/source/documentation/install-guide/chap-Introduction_to_oVirt.html.md
@@ -1,3 +1,7 @@
+---
+title: Introduction to oVirt
+---
+
 # Chapter 1: Introduction to oVirt
 
 oVirt is an open source server and desktop virtualization platform built on operating systems like CentOS and Red Hat Enterprise Linux. This guide covers:

--- a/source/documentation/install-guide/chap-System_Requirements.html.md
+++ b/source/documentation/install-guide/chap-System_Requirements.html.md
@@ -1,3 +1,7 @@
+---
+title: System Requirements
+---
+
 # Chapter 2: System Requirements
 
 ## oVirt Engine Requirements

--- a/source/documentation/install-guide/chap-oVirt_Engine_Related_Tasks.html.md
+++ b/source/documentation/install-guide/chap-oVirt_Engine_Related_Tasks.html.md
@@ -1,3 +1,7 @@
+---
+title: oVirt Engine Related Tasks
+---
+
 # Chapter 4: oVirt Engine Related Tasks
 
 ## Removing the oVirt Engine

--- a/source/documentation/install-guide/chap-oVirt_Nodes.html.md
+++ b/source/documentation/install-guide/chap-oVirt_Nodes.html.md
@@ -1,3 +1,7 @@
+---
+title: oVirt Nodes
+---
+
 # Chapter 6: oVirt Nodes
 
 oVirt 4.0 introduces an upgraded version of the oVirt Node. While the previous oVirt Node was a closed system with a basic text user interface for installation and configuration, oVirt Node can now be updated via `yum` and uses an Anaconda installation interface based on the one used by Enterprise Linux hosts.

--- a/source/documentation/intro-admin/Introduction_to_the_Administration_Portal.html.md
+++ b/source/documentation/intro-admin/Introduction_to_the_Administration_Portal.html.md
@@ -1,3 +1,7 @@
+---
+title: oVirt Introduction to the Administration Portal
+---
+
 # oVirt Introduction to the Administration Portal
 
 ## Using the Administration Portal

--- a/source/documentation/intro-user/Introduction_to_the_User_Portal.html.md
+++ b/source/documentation/intro-user/Introduction_to_the_User_Portal.html.md
@@ -1,3 +1,7 @@
+---
+title: Introduction to the User Portal
+---
+
 # Introduction to the User Portal
 
 ## Chapter 1: [Accessing the User Portal](../chap-Accessing_the_User_Portal)

--- a/source/documentation/intro-user/chap-Accessing_the_User_Portal.html.md
+++ b/source/documentation/intro-user/chap-Accessing_the_User_Portal.html.md
@@ -1,3 +1,7 @@
+---
+title: Accessing the User Portal
+---
+
 # Chapter 1: Accessing the User Portal
 
 ## oVirt Engine Client Requirements

--- a/source/documentation/intro-user/chap-The_Basic_Tab.html.md
+++ b/source/documentation/intro-user/chap-The_Basic_Tab.html.md
@@ -1,3 +1,7 @@
+---
+title: The Basic Tab
+---
+
 # Chapter 2: The Basic Tab
 
 ## Basic Tab Graphical Interface

--- a/source/documentation/intro-user/chap-The_Extended_Tab.html.md
+++ b/source/documentation/intro-user/chap-The_Extended_Tab.html.md
@@ -1,3 +1,7 @@
+---
+title: The Extended Tab
+---
+
 # Chapter 3: The Extended Tab
 
 # Extended Tab Graphical Interface

--- a/source/documentation/self-hosted/Self-Hosted_Engine_Guide.html.md
+++ b/source/documentation/self-hosted/Self-Hosted_Engine_Guide.html.md
@@ -1,3 +1,7 @@
+---
+title: oVirt Self-Hosted Engine Guide
+---
+
 # oVirt Self-Hosted Engine Guide
 
 ## Chapter 1: [Introduction](../chap-Introduction)

--- a/source/documentation/self-hosted/chap-Backing_up_and_Restoring_an_EL-Based_Self-Hosted_Environment.html.md
+++ b/source/documentation/self-hosted/chap-Backing_up_and_Restoring_an_EL-Based_Self-Hosted_Environment.html.md
@@ -1,3 +1,7 @@
+---
+title: Backing up and Restoring an EL-Based Self-Hosted Environment
+---
+
 # Chapter 6: Backing up and Restoring an EL-Based Self-Hosted Environment
 
 The nature of the self-hosted engine, and the relationship between the hosts and the hosted-engine virtual machine, means that backing up and restoring a self-hosted engine environment requires additional considerations to that of a standard oVirt environment. In particular, the hosted-engine hosts remain in the environment at the time of backup, which can result in a failure to synchronize the new host and hosted-engine virtual machine after the environment has been restored.

--- a/source/documentation/self-hosted/chap-Data_Warehouse_and_Reports.html.md
+++ b/source/documentation/self-hosted/chap-Data_Warehouse_and_Reports.html.md
@@ -1,3 +1,7 @@
+---
+title: Data Warehouse and Reports
+---
+
 # Chapter 9: Data Warehouse and Reports
 
 ## Overview of Configuring Data Warehouse

--- a/source/documentation/self-hosted/chap-Deploying_Self-Hosted_Engine.html.md
+++ b/source/documentation/self-hosted/chap-Deploying_Self-Hosted_Engine.html.md
@@ -1,3 +1,7 @@
+---
+title: Deploying Self-Hosted Engine
+---
+
 # Chapter 2: Deploying Self-Hosted Engine
 
 ## Deploying Self-Hosted Engine on Enterprise Linux Hosts

--- a/source/documentation/self-hosted/chap-Installing_Additional_Hosts_to_a_Self-Hosted_Environment.html.md
+++ b/source/documentation/self-hosted/chap-Installing_Additional_Hosts_to_a_Self-Hosted_Environment.html.md
@@ -1,3 +1,7 @@
+---
+title: Installing Additional Hosts to a Self-Hosted Environment
+---
+
 # Chapter 7: Installing Additional Hosts to a Self-Hosted Environment
 
 Additional self-hosted engine hosts are added in the same way as a regular host, with an additional step to deploy the host as a self-hosted engine host. The shared storage domain is automatically detected and the host can be used as a failover host to host the Manager virtual machine when required. You can also attach regular hosts to a self-hosted engine environment, but they cannot be used to host the Manager virtual machine. It is highly recommended to have at least two self-hosted engine hosts to ensure the Manager virtual machine is highly available. Additional hosts can also be added using the REST API.

--- a/source/documentation/self-hosted/chap-Introduction.html.md
+++ b/source/documentation/self-hosted/chap-Introduction.html.md
@@ -1,3 +1,7 @@
+---
+title: Introduction
+---
+
 # Chapter 1: Introduction
 
 A self-hosted engine is a virtualized environment in which the oVirt Engine runs on a virtual machine on the hosts managed by that engine. The virtual machine is created as part of the host configuration, and the Engine is installed and configured in parallel to the host configuration process. The primary benefit of the self-hosted Engine is that it requires less hardware to deploy an instance of oVirt as the Engine runs as a virtual machine, not on physical hardware. Additionally, the Engine is configured to be highly available. If the host running the Engine virtual machine goes into maintenance mode, or fails unexpectedly, the virtual machine will be migrated automatically to another host in the environment. A minimum of two self-hosted Engine hosts are required to support the high availability feature.

--- a/source/documentation/self-hosted/chap-Maintenance_and_Upgrading_Resources.html.md
+++ b/source/documentation/self-hosted/chap-Maintenance_and_Upgrading_Resources.html.md
@@ -1,3 +1,7 @@
+---
+title: Maintenance and Upgrading Resources
+---
+
 # Chapter 5: Maintenance and Upgrading Resources
 
 ## Maintaining the Self-Hosted Engine

--- a/source/documentation/self-hosted/chap-Migrating_Databases.html.md
+++ b/source/documentation/self-hosted/chap-Migrating_Databases.html.md
@@ -1,3 +1,7 @@
+---
+title: Migrating Databases
+---
+
 # Chapter 8: Migrating Databases
 
 ## Migrating the Self-Hosted Engine Database to a Remote Server Database

--- a/source/documentation/self-hosted/chap-Migrating_from_Bare_Metal_to_an_EL-Based_Self-Hosted_Environment.html.md
+++ b/source/documentation/self-hosted/chap-Migrating_from_Bare_Metal_to_an_EL-Based_Self-Hosted_Environment.html.md
@@ -1,3 +1,7 @@
+---
+title: Migrating from Bare Metal to an EL-Based Self-Hosted Environment
+---
+
 # Chapter 4: Migrating from Bare Metal to an EL-Based Self-Hosted Environment
 
 ## Migrating to a Self-Hosted Environment

--- a/source/documentation/self-hosted/chap-Troubleshooting.html.md
+++ b/source/documentation/self-hosted/chap-Troubleshooting.html.md
@@ -1,3 +1,7 @@
+---
+title: Troubleshooting
+---
+
 # Chapter 3: Troubleshooting
 
 ## Troubleshooting the Self-Hosted Engine

--- a/source/documentation/upgrade-guide/appe-Updating_an_Offline_oVirt_Engine.html.md
+++ b/source/documentation/upgrade-guide/appe-Updating_an_Offline_oVirt_Engine.html.md
@@ -1,3 +1,7 @@
+---
+title: Updating an Offline oVirt Engine
+---
+
 # Appendix A: Updating an Offline oVirt Engine
 
 ## Updating the Local Repository for an Offline oVirt Engine Installation

--- a/source/documentation/upgrade-guide/chap-Post-Upgrade_Tasks.html.md
+++ b/source/documentation/upgrade-guide/chap-Post-Upgrade_Tasks.html.md
@@ -1,3 +1,7 @@
+---
+title: Post-Upgrade Tasks
+---
+
 # Chapter 4: Post-Upgrade Tasks
 
 ## Changing the Cluster Compatibility Version

--- a/source/documentation/upgrade-guide/chap-Updates_between_Minor_Releases.html.md
+++ b/source/documentation/upgrade-guide/chap-Updates_between_Minor_Releases.html.md
@@ -1,3 +1,7 @@
+---
+title: Updates Between Minor Releases
+---
+
 # Chapter 2: Updates Between Minor Releases
 
 ## Updating the oVirt Engine

--- a/source/documentation/upgrade-guide/chap-Updating_the_oVirt_Environment.html.md
+++ b/source/documentation/upgrade-guide/chap-Updating_the_oVirt_Environment.html.md
@@ -1,3 +1,7 @@
+---
+title: Updating the oVirt Environment
+---
+
 # Chapter 1: Updating the oVirt Environment
 
 This guide covers updating your oVirt environment between minor releases, and upgrading to the next major version. Always update to the latest minor version of your current oVirt Engine version before you upgrade to the next major version.

--- a/source/documentation/upgrade-guide/chap-Upgrading_to_oVirt_4.0.html.md
+++ b/source/documentation/upgrade-guide/chap-Upgrading_to_oVirt_4.0.html.md
@@ -1,3 +1,7 @@
+---
+title: Upgrading to oVirt 4.0
+---
+
 # Chapter 3: Upgrading to oVirt 4.0
 
 ## oVirt 4.0 Upgrade Considerations

--- a/source/documentation/upgrade-guide/upgrade-guide.md
+++ b/source/documentation/upgrade-guide/upgrade-guide.md
@@ -1,3 +1,7 @@
+---
+title: oVirt Upgrade Guide
+---
+
 # oVirt Upgrade Guide
 
 This guide covers updating your oVirt environment between minor releases, and upgrading to the next major version. Always update to the latest minor version of your current oVirt Engine version before you upgrade to the next major version.

--- a/source/documentation/vmm-guide/Virtual_Machine_Management_Guide.html.md
+++ b/source/documentation/vmm-guide/Virtual_Machine_Management_Guide.html.md
@@ -1,3 +1,7 @@
+---
+title: oVirt Virtual Machine Management Guide
+---
+
 # oVirt Virtual Machine Management Guide
 
 ## Chapter 1: [Introduction](../chap-Introduction)

--- a/source/documentation/vmm-guide/appe-Reference_Settings_in_Administration_Portal_and_User_Portal_Windows.html.md
+++ b/source/documentation/vmm-guide/appe-Reference_Settings_in_Administration_Portal_and_User_Portal_Windows.html.md
@@ -1,3 +1,8 @@
+---
+title: Reference Settings in Administration Portal and User Portal Windows
+
+---
+
 # Appendix A: Reference Settings in Administration Portal and User Portal Windows
 
 ## Explanation of Settings in the New Virtual Machine and Edit Virtual Machine Windows

--- a/source/documentation/vmm-guide/chap-Additional_Configuration.html.md
+++ b/source/documentation/vmm-guide/chap-Additional_Configuration.html.md
@@ -1,3 +1,7 @@
+---
+title: Additional Configuration
+---
+
 # Chapter 4: Additional Configuration
 
 ## Configuring Single Sign-On for Virtual Machines

--- a/source/documentation/vmm-guide/chap-Administrative_Tasks.html.md
+++ b/source/documentation/vmm-guide/chap-Administrative_Tasks.html.md
@@ -1,3 +1,8 @@
+---
+title: Administrative Tasks
+
+---
+
 # Chapter 6: Administrative Tasks
 
 ## Shutting Down a Virtual Machine

--- a/source/documentation/vmm-guide/chap-Editing_Virtual_Machines.html.md
+++ b/source/documentation/vmm-guide/chap-Editing_Virtual_Machines.html.md
@@ -1,3 +1,7 @@
+---
+title: Editing Virtual Machines
+---
+
 # Editing Virtual Machines
 
 ## Editing Virtual Machine Properties

--- a/source/documentation/vmm-guide/chap-Installing_Linux_Virtual_Machines.html.md
+++ b/source/documentation/vmm-guide/chap-Installing_Linux_Virtual_Machines.html.md
@@ -1,3 +1,7 @@
+---
+title: Installing Linux Virtual Machines
+---
+
 # Chapter 2: Installing Linux Virtual Machines
 
 This chapter describes the steps required to install a Linux virtual machine:

--- a/source/documentation/vmm-guide/chap-Installing_Windows_Virtual_Machines.html.md
+++ b/source/documentation/vmm-guide/chap-Installing_Windows_Virtual_Machines.html.md
@@ -1,3 +1,7 @@
+---
+title: Installing Windows Virtual Machines
+---
+
 # Chapter 3: Installing Windows Virtual Machines
 
 This chapter describes the steps required to install a Windows virtual machine:

--- a/source/documentation/vmm-guide/chap-Introduction.html.md
+++ b/source/documentation/vmm-guide/chap-Introduction.html.md
@@ -1,3 +1,7 @@
+---
+title: Introduction
+---
+
 # Chapter 1: Introduction
 
 A virtual machine is a software implementation of a computer. The oVirt environment enables you to create virtual desktops and virtual servers.

--- a/source/documentation/vmm-guide/chap-Templates.html.md
+++ b/source/documentation/vmm-guide/chap-Templates.html.md
@@ -1,3 +1,7 @@
+---
+title: Templates
+---
+
 # Chapter 7: Templates
 
 A template is a copy of a virtual machine that you can use to simplify the subsequent, repeated creation of similar virtual machines. Templates capture the configuration of software, configuration of hardware, and the software installed on the virtual machine on which the template is based. The virtual machine on which a template is based is known as the source virtual machine.


### PR DESCRIPTION
Fixes issue #825 and #837 

Changes proposed in this pull request:

- i added a front matter section with the title of the page on each of the pages in admin-guide directory which corrected the multiple empty bullets

- i did same for install-guide, intro-admin, intro-user, how-to, self-hosted and vmm-guide directories

- resized the image in Alter way case study

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): (please @bessii on yourself to sign)

This pull request needs review by: (please @jasonbrooks  the reviewer if relevant)
