### PR TITLE
added setup commands for Debian

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,21 @@
 #!/bin/sh
 
-git submodule init && git submodule update
+#setup for redhat
+if [ -f /etc/redhat-release ]; then
+  git submodule init && git submodule update
 
-sudo yum install -y ruby-devel rubygems-devel gcc-c++ curl-devel rubygem-bundler patch zlib-devel redhat-rpm-config openssl
+  sudo yum install -y ruby-devel rubygems-devel gcc-c++ curl-devel rubygem-bundler patch zlib-devel redhat-rpm-config openssl
 
-bundle install
+  bundle install
+# setup for debian 
+elif [ -f /etc/debian_version ]; then
+  git submodule init && git submodule update
+
+  sudo apt install -y build-essential ruby-bundler libcurl4-openssl-dev zlib1g-dev ruby-dev
+
+  bundle install 
+
+else
+    echo "Could not verify system is redhat or debian."
+    exit 1
+fi 

--- a/setup.sh
+++ b/setup.sh
@@ -1,21 +1,19 @@
 #!/bin/sh
 
-#setup for redhat
+#setup for RedHat
 if [ -f /etc/redhat-release ]; then
   git submodule init && git submodule update
 
   sudo yum install -y ruby-devel rubygems-devel gcc-c++ curl-devel rubygem-bundler patch zlib-devel redhat-rpm-config openssl
 
-  bundle install
-# setup for debian 
+# setup for Debian 
 elif [ -f /etc/debian_version ]; then
   git submodule init && git submodule update
 
   sudo apt install -y build-essential ruby-bundler libcurl4-openssl-dev zlib1g-dev ruby-dev
 
-  bundle install 
-
 else
-    echo "Could not verify system is redhat or debian."
+    echo "Could not verify system is RedHat or Debian."
     exit 1
 fi 
+  bundle install

--- a/setup.sh
+++ b/setup.sh
@@ -1,15 +1,14 @@
 #!/bin/sh
 
+git submodule init && git submodule update
 #setup for RedHat
 if [ -f /etc/redhat-release ]; then
-  git submodule init && git submodule update
-
+  
   sudo yum install -y ruby-devel rubygems-devel gcc-c++ curl-devel rubygem-bundler patch zlib-devel redhat-rpm-config openssl
 
 # setup for Debian 
 elif [ -f /etc/debian_version ]; then
-  git submodule init && git submodule update
-
+  
   sudo apt install -y build-essential ruby-bundler libcurl4-openssl-dev zlib1g-dev ruby-dev
 
 else


### PR DESCRIPTION
Changes proposed in this pull request:

- added a test of the linux distro to the setup.sh file and added commands to setup for Debian 

I tested the script on Fedora 25 (workstation edition) and on Mint Serena 18.1 (based on Ubuntu Xenial), and it worked on both. 
After running the setup.sh file on both systems, the run-server.sh script worked in both cases, so I didn't change it. 

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): @lgh2

This pull request needs review by: @jasonbrooks 
