### PR TITLE
Fixed Typo in package name

### DIFF
--- a/source/develop/developer-guide/vdsm/on-ubuntu.html.md
+++ b/source/develop/developer-guide/vdsm/on-ubuntu.html.md
@@ -34,7 +34,7 @@ selinux-utils
 
 *   Other dependencies
 
-fence-agents ntp iproute nfs-server nfs-client lvm2 e2fsprogs open-iscsi psmisc bridge-utils dosfstools glusterfs-client glusterfs-common multipath-tools libsanlock-dev sanlock qemu-kvm-spice qemu-kvm qemu-utils guntls-bin python-rtslib
+fence-agents ntp iproute nfs-server nfs-client lvm2 e2fsprogs open-iscsi psmisc bridge-utils dosfstools glusterfs-client glusterfs-common multipath-tools libsanlock-dev sanlock qemu-kvm-spice qemu-kvm qemu-utils gnutls-bin python-rtslib
 
 **Workaround**: install them manually through apt-get
 


### PR DESCRIPTION
Fixed typo: guntils-bin to gnutils-bin

Fixes issue # (delete if not relevant)

Changes proposed in this pull request:

- Fixing a typo in package name "guntils-bin" (changed to gnutils-bin)

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): (please @mention yourself to sign)
@dgramop

This pull request needs review by: (please @mention the reviewer if relevant)
