### PR TITLE
nightly-snapshot: removed 3.6 and 4.0

### DIFF
--- a/source/develop/dev-process/install-nightly-snapshot.html.md
+++ b/source/develop/dev-process/install-nightly-snapshot.html.md
@@ -2,8 +2,8 @@
 title: Install nightly snapshot
 authors: sandrobonazzola
 wiki_title: Install nightly snapshot
-wiki_revision_count: 4
-wiki_last_updated: 2015-08-05
+wiki_revision_count: 5
+wiki_last_updated: 2017-04-21
 ---
 
 # Install nightly snapshot
@@ -23,26 +23,5 @@ You need to install both stable release rpm and development release rpm:
 `yum install `[`http://resources.ovirt.org/pub/yum-repo/ovirt-release41.rpm`](http://resources.ovirt.org/pub/yum-repo/ovirt-release41.rpm)
 
 `yum install `[`http://resources.ovirt.org/pub/yum-repo/ovirt-release41-snapshot.rpm`](http://resources.ovirt.org/pub/yum-repo/ovirt-release41-snapshot.rpm)
-
-for adding all needed repositories.
-
-## From 4.0 branches
-
-You need to install both stable release rpm and development release rpm:
-
-`yum install `[`http://resources.ovirt.org/pub/yum-repo/ovirt-release40.rpm`](http://resources.ovirt.org/pub/yum-repo/ovirt-release40.rpm)
-
-`yum install `[`http://resources.ovirt.org/pub/yum-repo/ovirt-release40-snapshot.rpm`](http://resources.ovirt.org/pub/yum-repo/ovirt-release40-snapshot.rpm)
-
-for adding all needed repositories.
-
-
-## From 3.6 branches
-
-You need to install both stable release rpm and development release rpm:
-
-`yum install `[`http://resources.ovirt.org/pub/yum-repo/ovirt-release36.rpm`](http://resources.ovirt.org/pub/yum-repo/ovirt-release36.rpm)
-
-`yum install `[`http://resources.ovirt.org/pub/yum-repo/ovirt-release36-snapshot.rpm`](http://resources.ovirt.org/pub/yum-repo/ovirt-release36-snapshot.rpm)
 
 for adding all needed repositories.


### PR DESCRIPTION
Changes proposed in this pull request:

- Removed instructions for installing 3.6 and 4.0 nightly snapshot, gone EOL long ago and not available anymore

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): @sandrobonazzola

This pull request needs review by: @mykaul 
