### PR TITLE
Remove 3.6 nightly builds references

### DIFF
--- a/source/develop/release-management/releases/3.6.z/release-management.html.md
+++ b/source/develop/release-management/releases/3.6.z/release-management.html.md
@@ -2,8 +2,8 @@
 title: oVirt 3.6.z Release Management
 authors: sandrobonazzola
 wiki_title: OVirt 3.6.z Release Management
-wiki_revision_count: 3
-wiki_last_updated: 2015-11-23
+wiki_revision_count: 4
+wiki_last_updated: 2017-04-21
 ---
 
 # oVirt 3.6.z Release Management
@@ -19,17 +19,6 @@ wiki_last_updated: 2015-11-23
 | **2016-06-09** | Third Release candidate  |
 | **2016-06-15** | Fourth Release candidate |
 | **2016-06-29** | General availability     |
-
-
-## Nightly Builds
-
-Nightly builds are available enabling the oVirt 3.6 snapshots repositories
-
-[`http://resources.ovirt.org/pub/ovirt-3.6-snapshot/`](http://resources.ovirt.org/pub/ovirt-3.6-snapshot/)
-
-[`http://resources.ovirt.org/pub/ovirt-3.6-snapshot-static/`](http://resources.ovirt.org/pub/ovirt-3.6-snapshot-static/)
-
-Please refer to [Install nightly snapshot](/develop/dev-process/install-nightly-snapshot/) guide for enabling those repositories
 
 ## Release criteria
 * See [oVirt 3.6 release-management](/develop/release-management/releases/3.6/release-management/) Release Criteria


### PR DESCRIPTION
Changes proposed in this pull request:

- 3.6 gone EOL a long time ago and nightly builds are not available anymore. Removed the section

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): @sandrobonazzola
