### PR TITLE
changed h tag above previous release notes

### DIFF
--- a/source/documentation/index.html.haml
+++ b/source/documentation/index.html.haml
@@ -110,11 +110,11 @@ wiki_last_updated: 2014-04-26
 
     :markdown
       ### Release Notes
-     
+
       #### Latest Release Notes
       - [oVirt 4.1.1](/release/4.1.1/)
-      
-      ### Previous Release Notes
+
+      #### Previous Release Notes
       - [oVirt 4.0.6](/release/4.0.6/)
       - [oVirt 3.6](/develop/release-management/releases/3.6)
       - [oVirt 3.5](/develop/release-management/releases/3.5)


### PR DESCRIPTION
Fixes issue # (delete if not relevant)



- Changed h tag above "previous release notes" from H3 to H4.
http://www.ovirt.org/documentation/

-

-

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): (please @jmarks

This pull request needs review by: @mykaul 
