### PR TITLE
Developer Documentation removed from Documentation Page, Page Reordered

### DIFF
--- a/source/documentation/index.html.haml
+++ b/source/documentation/index.html.haml
@@ -58,51 +58,22 @@ wiki_last_updated: 2014-04-26
 
   .col-md-4
     :markdown
-      ### Developer Documentation
+      ### Additional Documentation
 
-      - [Install nightly snapshot](/develop/dev-process/install-nightly-snapshot)
-      - [Building oVirt engine](/develop/developer-guide/engine/engine-development-environment)
-      - [Building oVirt Node](/develop/projects/node/building)
-      - [Building VDSM](/develop/developer-guide/vdsm/developers)
-      - [Contributing to the Node project](/develop/projects/node/contributing-to-the-node-project)
-      - [Submitting a patch with Gerrit](/develop/dev-process/working-with-gerrit)
-      - [The development process](/develop/dev-process/devprocess)
-      - [Release management](/develop/release-management/releases)
-      - [Getting in contact with the oVirt community](/community/about/contact)
-      - [Becoming a maintainer](/develop/dev-process/becoming-a-maintainer)
-      - [oVirt architecture](/documentation/architecture/architecture)
-      - [Building a custom user portal](/develop/developer-guide/sample-user-portals)
-      - [Building oVirt engine DWH](how-to/reports/dwh-development-environment)
-      - [Building oVirt engine Reports](how-to/reports/reports)
+      - [Introduction](./introduction)
+      - [Administration](./admin-guide)
+      - [Architecture](./architecture)
+      - [How To](./how-to)
+      - [Internal](./internal)
+      - [Security](./security)
+      - [SLA](./sla)
+      - [Storage](./storage)
+      - [Drafts](./draft)
+      - [ּresources](./resources)
+
 
 
   .col-md-4
-    :markdown
-      ### Getting Involved
-
-      Do you want to help us improve the documentation for oVirt?
-
-      -   Sign up for a [GitHub](https://github.com) account, and log in
-      -   Help fix some of the [issues](https://github.com/oVirt/ovirt-site/issues) we've identified
-      -   Help out with some [website gardening](https://github.com/oVirt/ovirt-site)
-
-      Your time and effort is appreciated!
-
-    :markdown
-      ### Community Documentation
-
-      oVirt community processes and resources
-
-      - [Guidelines for community activity](/community/about/community-guidelines/)
-      - [Communicating via Mailing lists and IRC](/community/about/contact/)
-      - [Reporting a bug](/community/get-involved/report-a-bug/)
-      - [Community activity](/community/about/community-activity/)
-      - [Outreach](/community/get-involved/promote/)
-      - [oVirt Global Workshops](/community/events/archives/workshop/global-workshops/)
-
-.row
-  .col-md-4
-
     :markdown
       ### Release Notes
 
@@ -119,19 +90,31 @@ wiki_last_updated: 2014-04-26
       - [oVirt 3.1](/develop/release-management/releases/3.1)
       - [oVirt 3.0](/develop/release-management/releases/3.0)
 
+.row
+  .col-md-4
+
+    :markdown
+      ### Community Documentation
+
+      oVirt community processes and resource
+
+      - [Guidelines for community activity](/community/about/community-guidelines)
+      - [Communicating via mailing lists and IRC](/community/about/contact/)
+      - [Reporting a bug](/community/get-involved/report-a-bug)
+      - [Community activiy](/community/about/community-activity/)
+      - [Outreach](/community/get-involved/promote)
+      - [oVirt Global Workshops](/community/events/archives/workshop/global-workshops/)
+
 
   .col-md-4
 
     :markdown
-      ### Additional Categories
+      ### Getting Involved
 
-      -   [Introduction](./introduction)
-      -   [Administration](./admin-guide)
-      -   [Architecture](./architecture)
-      -   [How To](./how-to)
-      -   [Internal](./internal)
-      -   [Security](./security)
-      -   [SLA](./sla)
-      -   [Storage](./storage)
-      -   [Drafts](./draft)
-      -   [Resources](./resources)
+      Do you want to help us improve the documentation for oVirt?
+
+      - Sign up for a [GitHub](https://github.com) account, and log in
+      - Help fix some of the [issues](http://github.com/ovirt/ovirt-site/issues) we've identified
+      - Help out with some [website gradening](https://github.com/oVirt/ovirt-site)
+
+      Your time and effort is appreciated!

--- a/source/documentation/index.html.haml
+++ b/source/documentation/index.html.haml
@@ -63,13 +63,13 @@ wiki_last_updated: 2014-04-26
       - [Introduction](./introduction)
       - [Administration](./admin-guide)
       - [Architecture](./architecture)
-      - [How To](./how-to)
+      - [How to guides](./how-to)
       - [Internal](./internal)
       - [Security](./security)
       - [SLA](./sla)
       - [Storage](./storage)
       - [Drafts](./draft)
-      - [ּresources](./resources)
+      - [Resources](./resources)
 
 
 
@@ -96,7 +96,7 @@ wiki_last_updated: 2014-04-26
     :markdown
       ### Community Documentation
 
-      oVirt community processes and resource
+      oVirt community processes and resources
 
       - [Guidelines for community activity](/community/about/community-guidelines)
       - [Communicating via mailing lists and IRC](/community/about/contact/)
@@ -115,6 +115,6 @@ wiki_last_updated: 2014-04-26
 
       - Sign up for a [GitHub](https://github.com) account, and log in
       - Help fix some of the [issues](http://github.com/ovirt/ovirt-site/issues) we've identified
-      - Help out with some [website gradening](https://github.com/oVirt/ovirt-site)
+      - Help out with some [website gardening](https://github.com/oVirt/ovirt-site)
 
       Your time and effort is appreciated!


### PR DESCRIPTION

Changes proposed in this pull request:

- Developer Documentation Deleted from main Documentation Page

- Other sections on page reordered to accommodate the change

- All links have been tested

- Middleman screenshot attached 
(https://cloud.githubusercontent.com/assets/25613123/25813250/805fd9c6-3421-11e7-9ab6-c687759e3294.png)


I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md) @jmarks

This pull request needs review by: (please @duck-rh @doron-fediuck @dankenigsberg @mykaul 
