### PR TITLE
fix link magic in markdown_to_html

### DIFF
--- a/lib/site_helpers.rb
+++ b/lib/site_helpers.rb
@@ -39,7 +39,7 @@ class SiteHelpers < Middleman::Extension
       return unless content
 
       if content.match(/http/)
-        content.gsub!(/([^<])(http[^\s$]*)([^>])/, '\\1<\\2>\\3')
+        content.gsub!(/([^<])(http[^\s\)$]*)([^>])/, '\\1<\\2>\\3')
       end
 
       Tilt['markdown'].new(config[:markdown]) { content.strip }.render

--- a/source/develop/release-management/releases/3.5.2/index.html.md
+++ b/source/develop/release-management/releases/3.5.2/index.html.md
@@ -147,7 +147,7 @@ Following exception prevents host monitoring but affected host stays in status '
  - Can not restore backup file to rhevm with non-default lc_messages
  - Document All-Content header in RSDL and add it to SDKs
  - [AAA] Sorting by 'authorization provider' in 'users' tab don't sort
- - Unable to authenticate if user is using (http://indeed-id.com/index.html) solution for authentication.
+ - Unable to authenticate if user is using [INDEED ID](http://indeed-id.com/) solution for authentication.
  - [host-deploy] missing -t parameter to mktemp
  - Engine-setup should support cleaning of zombie commands before upgrade
 


### PR DESCRIPTION
Links may not have a title, so the regex was wrong.

Fixes issue #953
