### PR TITLE
changes to structure and content of community page

### DIFF
--- a/source/community/index.html.md
+++ b/source/community/index.html.md
@@ -29,7 +29,7 @@ We look forward to working with you!
 
 ## Develop the Code
 
-Are you a wiz with Java, Python, or Bash? We’d love to have you join us! For in-depth information on the projects and procedures, visit the [develop section](/develop/).
+Are you a wiz with Java, Python, or Bash? We’d love to have you join us! For in-depth information on the projects and procedures, visit the [Develop pages](/develop/).
 
 ## Translate, 翻译, תרגום
 
@@ -43,9 +43,13 @@ Read our featured [case studies](https://www.ovirt.org/community/user-stories/us
 
 Love design or UX? From concept through to implementation, help us to deliver a seamless experience for oVirt users. To join us, sign up to the [devel](http://lists.ovirt.org/mailman/listinfo/devel) mailing list.
 
+## Our Mailing Lists
+
+Want to get in touch? Find the [right mailing list](/community/about/mailing-lists/#users) for your inquiry.
+
 ## Meet Our Infrastructure Team
 
-The [Infrastructure](../develop/infra/infrastructure) team are volunteers and professionals managing the servers, building tools, and creating new applications to make oVIrt development a smoother process. We're located all over the globe and communicate primarily by the [\#ovirt channel on irc.OFTC.net](irc://irc.oftc.net/ovirt) and on the [ infra@ovirt.org mailing list](/community/about/mailing-lists/#infra).
+The [Infrastructure](../develop/infra/infrastructure) team are volunteers and professionals managing the servers, building tools, and creating new applications to make oVIrt development a smoother process. We're located all over the globe and communicate primarily by the **#ovirt** channel on **irc.OFTC.net** and on the [infra@ovirt.org](http://lists.ovirt.org/mailman/listinfo/infra) mailing list.
 
 
 

--- a/source/community/index.html.md
+++ b/source/community/index.html.md
@@ -8,85 +8,80 @@ wiki_last_updated: 2015-03-02
 
 <!-- TODO: [Mikey] Fix this page after content structure is final -->
 
+# Get Involved!
+
+oVirt is a community-driven virtualization project, and people just like you are making it happen! You don’t have to be a programmer. The project will greatly benefit from inputs by documentation, bug reporting, UX and design specialists.
+
+Before getting started, we recommend that you:
+
+* Sign up to the [users@ovirt.org](/community/about/mailing-lists/#users) mailing list. Then shoot us an introductory email saying how you would like to contribute.
+
+* For fluent, real-time communication, [join us on IRC](/community/about/contact/#irc).
+
+* Finally, please read our [community etiquette guidelines](https://www.ovirt.org/community/about/community-guidelines/). (Quick summary: Be nice!)
+
+We look forward to working with you!
+
+---
+
 <section class="row">
 <section class="col-md-6 pad-left-small pad-right">
 
-# Get Involved!
+## Develop the Code
 
-Everyone can contribute something back to the project — one doesn't have to be a programmer to make a difference!
+Are you a wiz with Java, Python, or Bash? We’d love to have you join us! For in-depth information on the projects and procedures, visit the [develop section](/develop/).
 
-When starting out, we suggest [signing up for the users@ovirt.org mailing list](/community/about/mailing-lists/#users) and sending an introductory email — just to introduce yourself and let people know what you're interested in related to oVirt. [Join us on IRC](/community/about/contact/#irc) and communicate with us too, if it's possible for you to do so.
+## Translate, 翻译, תרגום
 
-We're looking forward to working with you!
+Want to help make oVirt's user interface and documentation available in multiple languages for users around the globe? Examples include Italian, Portuguese, Chinese, Japanese, Korean,  and more. To help out, sign up to the [devel](http://lists.ovirt.org/mailman/listinfo/devel) mailing list.
 
-## Find and File Bugs
+## Case Studies
 
-As someone who uses the software, your help in finding and filing bugs is thoroughly appreciated.
-
-[Report oVirt bugs on the Red Hat bugzilla](https://bugzilla.redhat.com/enter_bug.cgi?classification=oVirt).
-If you don't have a Bugzilla account yet, [find out how to get one](/community/get-involved/report-a-bug/).
-
-## Translate, 翻译, ‫לתרגם‬
-
-It's great to have the oVirt software itself in multiple languages, and even better to have its documentation available in everyone's native tongue too. Help improve oVirt by working on new translations and making each version the best it can be.
-
-## Write Documentation
-
-Have a knack for writing? oVirt needs excellent, easy-to-read documentation for installation and usage, and it needs to be kept up-to-date with every release of oVirt. Log in to our [source repository](https://github.com/oVirt/ovirt-site) and help out!
+Read our featured [case studies](https://www.ovirt.org/community/user-stories/user-stories/) and find out how a wide variety of organizations around the world are successfully deploying and benefiting from oVirt.
 
 ## Design
 
-Whether you push pixels or strive to put users first — if you're a designer, you too have a place in the project. At every step of the way, from initial ideas to iterations through out the development process, design is valuable to the oVirt project.
+Love design or UX? From concept through to implementation, help us to deliver a seamless experience for oVirt users. To join us, sign up to the [devel](http://lists.ovirt.org/mailman/listinfo/devel) mailing list.
 
-## Develop the Code
+## Meet Our Infrastructure Team
 
-Know how to program? Jump in and help us out. There's even a whole section of our website dedicated to you — start by reading the [develop section](/develop/).
+The [Infrastructure](../develop/infra/infrastructure) team are volunteers and professionals managing the servers, building tools, and creating new applications to make oVIrt development a smoother process. We're located all over the globe and communicate primarily by the [\#ovirt channel on irc.OFTC.net](irc://irc.oftc.net/ovirt) and on the [ infra@ovirt.org mailing list](/community/about/mailing-lists/#infra).
 
-## Community Governance & Structure
 
-oVirt is an [open source project](http://www.opensource.org) that is an [openly governed project](/community/about/governance/). Learn more about [how the project is structured](/community/about/governance/), [how projects can be added](/develop/projects/incubating-an-subproject/), [who is on the board](/community/about/board/), and who are some of our [users and service providers](/community/user-stories/users-and-providers/).
 
 </section>
 
-
 <section class="col-md-6 pad-left pad-right-small">
 
-# Communicate with Us
+## Write Documentation
 
-Interacting with the oVirt community is everything from giving feedback through jumping in and making oVirt even better.
+Good at technical communication? oVirt needs concise, reader-friendly, up-to-date installation and usage documentation. To help out, log in to our [source repository](https://github.com/oVirt/ovirt-site).
+
+## Find and File Bugs
+
+Help us to shake bugs out of oVirt, creating a better user experience for all. You can easily report oVirt bugs on [Red Hat bugzilla](https://bugzilla.redhat.com/enter_bug.cgi?classification=oVirt). If you don't have a Bugzilla account yet, [find out how to get one](/community/get-involved/report-a-bug/).
 
 ## Meet Our Users and Supporters
 
-oVirt is made up of a broad community of supporters, sponsors, and users. Find out more about [our valued community](/community/user-stories/users-and-providers/), and see how oVirt is being used in organizations around the world!
+oVirt is made up of a broad community of supporters, sponsors, and users. Find out more about [our valued community](/community/user-stories/users-and-providers/).
 
 ## Get Social with oVirt
 
-Keep track of the latest happenings in the oVirt community, including new release announcements, and send your thoughts and links to virtualization-related topics. Follow us on:
+Keep track of the latest happenings in the oVirt community, such as new releases, and post your thoughts and links on virtualization-related topics. Follow us on:
 
 - [Twitter](https://twitter.com/ovirt)
 - [Google +](https://plus.google.com/u/0/communities/109346090491400112913)
 - [Facebook](https://www.facebook.com/groups/ovirt.openvirtualization/)
 - [YouTube](http://www.youtube.com/user/ovirtproject)
 
-## Chat with Us on IRC
+## Community Governance & Structure
 
-People using oVirt and all those who develop the software are welcome in [the \#ovirt channel on irc.OFTC.net](irc://irc.oftc.net/ovirt).
+oVirt is an [open source project](http://www.opensource.org) that is [openly governed](/community/about/governance/). Learn [how projects can be added](/develop/projects/incubating-an-subproject/), and [who is on the board](/community/about/board/).
 
-If you don't already have a IRC client, you can install [one of the clients referenced here](http://www.irchelp.org/irchelp/new2irc.html), or join our channel in your web browser by using [mibbit](https://www.mibbit.com/).
 
-We're most active from about 07:00 UMT to 11:00 UMT (09:00 IST to 17:00 PST), but there are usually folks hanging out throughout the entire day. Also: be sure to [read our simple etiquette guidelines](/community/about/community-guidelines/). (Quick summary: be nice!)
 
-## Converse on Our Mailing Lists
 
-There are many [mailing lists](/community/about/mailing-lists/) related to all aspects of oVirt. Some are for people using the software, others are for developing oVirt, and there are even more for administration and governance purposes.
 
-Remember to be polite and [read our etiquette guide](/community/about/community-guidelines/).
-
-Join all of the following mailing lists that interest you.
-
-## Meet Our Infrastructure Team
-
-The Infrastructure Team consists of dedicated volunteers and professionals managing the servers, building the tools and utilities, and creating new applications to make oVIrt development a smoother process. We're located all over the globe and communicate primarily by the [\#ovirt channel on irc.OFTC.net](irc://irc.oftc.net/ovirt) and [signing up for the infra@ovirt.org mailing list](/community/about/mailing-lists/#infra). Check out the [Infrastructure](../develop/infra/infrastructure) home page for more details!
 
 </section>
 </section>


### PR DESCRIPTION
This PR is a reorganization of the content on the main [oVirt community](https://www.ovirt.org/community/) page. The changes are:

1. Get Involved: Because this is an introduction it has been formatted so that it takes up the full length of page. The two-column format starts below it.
2. The page contained repeated information. This has been removed.
3. All the topic paragraphs (find and file bugs, documentation, etc) have been re-written, so that they are clearer, contain the relevant information, and more engaging.
4. The wording has been adjusted so that the headings in both columns line up with each other. It's visually more appealing that way.

-I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): (please @jmarks

This pull request needs review by: @mykaul @sandrobonazzola @eedri @doron-fediuck @dankenigsberg @bproffitt 
