### PR TITLE
'development' env should not be loaded for deploy action

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -209,6 +209,9 @@ require 'lib/monkeypatch_blog_date.rb'
 ###
 #
 configure :development do
+  # workaround https://github.com/middleman-contrib/middleman-deploy/issues/51
+  next if ARGV.include? 'deploy'
+
   puts "\nUpdating git submodules..."
   puts `git submodule init && git submodule sync`
   puts `git submodule foreach "git pull -qf origin master"`


### PR DESCRIPTION
see https://github.com/middleman-contrib/middleman-deploy/issues/51

Fixes issue # (delete if not relevant)

Changes proposed in this pull request:

-

-

-

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): (please @mention yourself to sign)

This pull request needs review by: (please @mention the reviewer if relevant)
