### PR TITLE
4.1.2 release notes broken links

### DIFF
--- a/source/release/4.1.2/index.html.md
+++ b/source/release/4.1.2/index.html.md
@@ -18,9 +18,9 @@ CentOS Linux 7.3 (or similar).
 For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
 and visit the [About oVirt](/documentation/introduction/about-ovirt/) page.
 
-For detailed installation instructions, read the [Installation Guide.](documentation/install-guide/Installation_Guide/)
+For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
-To learn about features introduced before 4.1.2, see the [release notes for previous versions.](documentation/#previous-release-notes)
+To learn about features introduced before 4.1.2, see the [release notes for previous versions](/documentation/#previous-release-notes).
 
 
 ## Install / Upgrade from previous versions
@@ -312,4 +312,3 @@ include collectd. Either use `includepkgs` and add those you need, or use
 ### oVirt Host Deploy
 
  - [BZ 1443064](https://bugzilla.redhat.com/1443064) <b>vdsm.conf isn't being written due to vintage condition</b><br>
-


### PR DESCRIPTION
Changes proposed in this pull request:

Corrected 2 broken links 
-[Installation Guide](/documentation/install-guide/Installation_Guide/).
-[release notes for previous versions](/documentation/#previous-release-notes).
in both instances the full stop was placed in the square brackets [Installation Guide.]

- The following two broken links have not be resolved (and are being reused in the template)

## oVirt Hosted Engine
If you're going to install oVirt as Hosted Engine on a clean system please follow *Hosted_Engine_Howto#Fresh_Install guide* or the corresponding section in *Self Hosted Engine Guide*

If you're upgrading an existing Hosted Engine setup, please follow *Hosted_Engine_Howto#Upgrade_Hosted_Engine* guide or the corresponding section within the *Upgrade Guide*

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): @jmarks

This pull request needs review by: @sandrobonazzola @mykaul 
