### PR TITLE
changes to users and providers page

### DIFF
--- a/source/community/user-stories/users-and-providers.html.md
+++ b/source/community/user-stories/users-and-providers.html.md
@@ -11,136 +11,110 @@ page_classes: partner-logos
 
 <!-- TODO: Content review -->
 
-# Users and Providers
+# oVirt Users and Providers
 
 Our community keeps growing as more individual users and organizations choose oVirt: Some are implementing it in their datacenters, while others are using oVirt as the basis for their own customer solutions. Red Hat, which opened the oVirt codebase, uses it as the upstream version of its commercial virtualization product, RHV. oVirt is also the upstream version for Wind River's open virtualization product.
 
-Below you will find the list of oVirt users, solution providers, supporters and downstream commercial products.
+## Service Providers
+The following companies are deploying oVirt based solutions. For more examples, read the [**Nimbus Concept**](/community/user-stories/nimbus-concept-case-study/) and [**UDS Enterprise**](/community/user-stories/universidad-de-sevilla-case-study/) case studies.
 
-## oVirt-Based Service Providers
-
-<div class="parner-block">
-[![Nimbus Concept](/images/logos/Nimbus.png)](http://www.nimbusconcept.com/index-en.html)
-[Nimbus Concept](//www.nimbusconcept.com/index-en.html) has developed OriginStack, an appliance that integrates hardware, virtualization (oVirt/KVM), private cloud (OpenStack), and support in one integrated package. Read the **[case study.](/community/user-stories/nimbus-concept-case-study/ "Nimbus Concept Case Study")**
-</div>
-
-<div class="parner-block">
+<div class="case-studies">
+<div class="case-study">
 [![Red Hat, Inc.](/images/logos/Red_Hat.svg)](http://www.redhat.com/en)
-[Red Hat](//www.redhat.com/en) is the corporate member of the oVirt community responsible for opening oVirt's codebase. Besides providing support for oVirt's community, Red Hat uses oVirt as the codebase for its [Red Hat Virtualization](//www.redhat.com/en/technologies/virtualization/enterprise-virtualization) product.
+[Red Hat](//www.redhat.com/en) is the corporate member of the oVirt community, responsible for opening oVirt's codebase. Besides providing support for oVirt's community, Red Hat uses oVirt as the codebase for its [Red Hat Virtualization](//www.redhat.com/en/technologies/virtualization/enterprise-virtualization) product.
 </div>
 
-<div class="parner-block">
-[![UDS Enterprise](/images/logos/UDS.png)](https://www.udsenterprise.com)
-[UDS Enterprise](//www.udsenterprise.com) is a multiplatform connection broker that administers and manages virtual and remote desktops, apps, and other Windows & Linux services. It is compatible with Red Hat and oVirt KVM. Read the **[case study.](/community/user-stories/universidad-de-sevilla-case-study/)**
-</div>  
-
-<div class="parner-block">
+<div class="case-study">
 [![Wind River](/images/logos/Wind_River.svg)](http://www.windriver.com/)
 [Wind River](//www.windriver.com/) offers a comprehensive device development portfolio, including its [Open Virtualization](//www.windriver.com/products/open-virtualization-profile/) product, a real-time virtualization solution using KVM and oVirt technology.
 </div>
 
-## oVirt Partners in Education
+## Partners in Education
 
-Educational institutions around the world are choosing oVirt to manage their virtual workloads, finding it a scalable, feature-rich and cost-effective solution.
+These institutions have chosen oVirt to manage their virtual workloads. See also the [**Keele University**](https://www.ovirt.org/community/user-stories/keele-university-case-study/), [**Florida State University**](https://www.ovirt.org/community/user-stories/RCC-case-study/), and [**University of Seville**](https://www.ovirt.org/community/user-stories/universidad-de-sevilla-case-study/) case studies.
 
-<div class="parner-block">
-[![RCC](/images/logos/FSUSig_Horizontal_Color.png)](https://rcc.fsu.edu/) [Florida State University’s Research Computing Center](https://rcc.fsu.edu/) provides the FSU research community with high-performance computational resources to enable scientific research. Read the [**case study.**](https://www.ovirt.org/community/user-stories/RCC-case-study/)
-</div>
-
-<div class="parner-block">
-[![](/images/logos/Sevilla.png)](http://www.us.es/) The [University of Seville](http://www.us.es/eng) is one of the top-ranked universities in Spain. It has a student body of over 65,000 and hosts an extensive international student program. Read the [**case study.**](https://www.ovirt.org/community/user-stories/universidad-de-sevilla-case-study/)
-</div>
-
-<div class="parner-block">
-[![Keele](/images/logos/Keele.svg)](https://www.keele.ac.uk)
-[Keele University](/community/user-stories/keele-university-case-study/) in Staffordshire UK, is a public research university. It has a small, dedicated IT staff handling the IT demands of 10,000 students and 2,000 staff. Read the [**case study**.](https://www.ovirt.org/community/user-stories/keele-university-case-study/)
-</div>
-
-<div class="parner-block">
+<div class="case-studies">
+<div class="case-study">
 [![NUST](/images/logos/Nust.svg)](http://www.nust.edu.pk/Pages/Home.aspx)
 The [National University of Sciences & Technology (NUST)](//www.nust.edu.pk/Pages/Home.aspx) is a public research university in Islamabad, Pakistan. The university primarily focuses on Science, technology, engineering and mathematics.
 </div>
 
-<div class="parner-block">
+<div class="case-study">
 [![Silesian University](/images/logos/Silesian.svg)](http://www.slu.cz/slu/en)
-[Silesian University](//www.slu.cz/slu/en) in Opava, Czech Republic, has an enrollment of more than 9000 students in approximately 50 study programs. It is a member of the European University Association.
+[Silesian University](//www.slu.cz/slu/en) in Opava, Czech Republic is one of the top five universities created in the country after 1989. It has an enrollment of more than 9000 students in approximately 50 study programs. Silesian University is a member of the European University Association.
 </div>
 
-## oVirt Professional Services & Integrators
+## Professional Services & Integrators
 
-Companies and public institutions all over the world have found oVirt a great solution to manage internal and customer-facing servers. These organizations are using oVirt in production, as well as actively participating in the oVirt community.
+These organizations use oVirt for internal and customer-facing servers, and are active in the oVirt community. See also the [**Brussels Airport**](/community/user-stories/brussels-airport-case-study/), [**it-novum**](/community/user-stories/it-novum-case-study/), [**Judici**](https://www.ovirt.org/community/user-stories/judici-case-study/), and [**Nieuwland**](https://www.ovirt.org/community/user-stories/nieuwland-case-study/) case studies.
 
-<div class="parner-block">
+<div class="case-studies">
+<div class="case-study">
 [![ALBA Software](/images/logos/Alba.png)](http://www.albasoft.com/web/#/home)
 [ALBA Software](//www.albasoft.com/web/#/home) has been providing consulting, integration, and Internet development services since 1999.
 </div>
 
-<div class="parner-block">
+<div class="case-study">
 [![Cornerstone Technical Solutions](/images/logos/Cornerstone.png)](https://cornerstonets.net/)
-[Cornerstone Technical Solutions](//cornerstonets.net/managed-services) offers virtualization to consolidate datacenters, enabling clients the flexibility to combine CTS service offerings, which use oVirt, for their needs.
+[Cornerstone Technical Solutions](//cornerstonets.net/managed-services) delivers IT management services, including oVirt-based virtualization services for consolidating datacenters.
 </div>
 
-<div class="parner-block">
-[![Internet Complete!, Inc.](/images/logos/Tl.png)](http://icnet.net/)  
-[Internet Complete](//icnet.net/) is dedicated to providing customers in Oklahoma with leading technologies - such as oVirt-managed hosting - for fast and reliable Internet solutions.
+<div class="case-study">
+[![Internet Complete!, Inc.](/images/logos/Tl.png)](http://icnet.net/)
+ [Internet Complete](//icnet.net/) is dedicated to providing customers in Oklahoma with leading technologies - such as oVirt-managed hosting - for fast and reliable Internet solutions.
 </div>
 
-<div class="parner-block">
+<div class="case-study">
 [![Netbulae](/images/logos/Netbulae.png)](http://www.netbulae.eu/)
 The founders of [Netbulae](//www.netbulae.eu/) have experience in ICT, automation, graphics and multimedia sectors, and use those skills and the oVirt platform to deliver virtual datacenter management services to their customer base.
 </div>
 
-<div class="parner-block">
+<div class="case-study">
 [![R01](/images/logos/R01.png)](http://r01.ru/)
-[Registrar R01](//r01.ru/), a registrar of domain names, belongs to a group of companies Hosting Community. The company became the first accredited registrar in the national domain RU and today offers a wide range of professional services, being one of the leaders in the number of registered domains .RU, .SU and .RF.
+[Registrar R01](//r01.ru/) was the first accredited registrar for the RU domain. Today, the company is a leading registrar of the .RU .SU and .RF domains and is a provider of a wide range of professional services.
 </div>
 
-<div class="parner-block">
-![](/images/logos/It-novum.png)
-[it-novum](/community/user-stories/it-novum-case-study/) is a leading consultancy for business open source in the German-speaking market. it-novum focuses on the intergation of open source with closed source and the development of combined open source solutions and platforms.
-Read the [**case study.**](/community/user-stories/it-novum-case-study/)
-</div>
-
-<div class="parner-block">
+<div class="case-study">
 [![Yi Yunjie](/images/logos/Eayun.svg)](http://www.eayun.cn)
-[Yi Yunjie Technology (Beijing) Ltd.](//www.eayun.cn) is a technology research company and provider of cloud computing products and operational service for medium to large enterprise customers, with independent development of the professional-oriented cloud computing solutions.
+[Yi Yunjie Technology (Beijing) Ltd.](//www.eayun.cn) is an independent developer and provider of cloud computing solutions and operational services for medium to large enterprise customers.
 </div>
 
-## oVirt Cloud Providers
+## Cloud Providers
 
-<div class="parner-block">
+<div class="case-studies">
+<div class="case-study">
 [![Cloud Times](/images/logos/Ct.png)](http://www.cloud-times.com/)
 [Cloud Times](//www.cloud-times.com/) is a solution provider of Cloud Client Equipment, Virtual Desktop Infrastructure, and the “Cloud plus Client” Management Platform, helping Chinese enterprises in the transition to “Cloud plus Client” architecture.
 </div>
 
-<div class="parner-block">
+<div class="case-study">
 ![](/images/logos/AlterWay.png)
-[Alter Way](https://www.alterway.fr/) is a French hosting company that provides solutions for their customers' digital strategies, in a DevOps approach and using open source solutions, including oVirt. Read the Alter Way [**case study.**](/community/user-stories/alter-way-case-study/)
+[Alter Way](https://www.alterway.fr/) is a French hosting company that provides solutions for their customers' digital strategies, using a DevOps approach and open source solutions, including oVirt. Read the [**case study.**](/community/user-stories/alter-way-case-study/)
 </div>
 
-
-## oVirt Supporters
+## Supporters
 
 The following organizations are very helpful to the oVirt community by providing tools and services that are helpful to the development of oVirt.
 
-<div class="parner-block">
-[![jetbrains](/images/logos/logo_JetBrains_4.png)](http://www.jetbrains.com/idea/features/index.html)
-[IntelliJ IDEA](http://www.jetbrains.com/idea/features/index.html) and [PyCharm](http://www.jetbrains.com/pycharm/) are two developer products with donated licenses from [JetBrains](http://www.jetbrains.com/).
-</div>
-
-<div class="parner-block">
-[![Jprofiler](/images/logos/Jprofiler.png)](http://www.ej-technologies.com/products/jprofiler/overview.html)
-[jprofiler](http://www.ej-technologies.com/products/jprofiler/overview.html) from [ej-technologies GmBH](http://www.ej-technologies.com/) assists oVirt developers in finding performance bottlenecks, pin down memory leaks and understand threading issues.
-</div>
-
-<div class="parner-block">
+<div class="case-studies">
+<div class="case-study">
 [![WhiteSource](/images/logos/WhiteSource.png)](http://www.whitesourcesoftware.com/features/)
 oVirt developers use [whitesource](http://www.whitesourcesoftware.com/features/) to continuously monitor oVirt components for security and license issues and to obtain alerts on problematic components.
 </div>
 
-## oVirt Board Members
+<div class="case-study">
+[![Jprofiler](/images/logos/Jprofiler.png)](http://www.ej-technologies.com/products/jprofiler/overview.html)
+[jprofiler](http://www.ej-technologies.com/products/jprofiler/overview.html) from [ej-technologies GmBH](http://www.ej-technologies.com/) assists oVirt developers in finding performance bottlenecks, pin down memory leaks and understand threading issues.
+</div>
 
-The following companies are represented on [the oVirt Board](/OVirt_Board "OVirt Board").
+<div class="case-study">
+[![jetbrains](/images/logos/logo_JetBrains_4.png)](http://www.jetbrains.com/idea/features/index.html)
+[IntelliJ IDEA](http://www.jetbrains.com/idea/features/index.html) and [PyCharm](http://www.jetbrains.com/pycharm/) are two developer products with donated licenses from [JetBrains](http://www.jetbrains.com/).
+</div>
+
+## Board Members
+
+The following companies are represented on [the oVirt Board](https://www.ovirt.org/community/about/board/).
 
 {:.ovirt-board-logos}
 [![Canonical](/images/logos/Canonical.svg)](http://canonical.com/)

--- a/source/community/user-stories/users-and-providers.html.md
+++ b/source/community/user-stories/users-and-providers.html.md
@@ -39,39 +39,9 @@ This page highlights the users, solution providers, supporters, and downstream c
 [Wind River](//www.windriver.com/) offers a comprehensive device development portfolio, including its [Open Virtualization](//www.windriver.com/products/open-virtualization-profile/) product, a real-time virtualization solution using KVM and oVirt technology.
 </div>
 
-## oVirt Customer Stories
-
-The oVirt Project is made great by the users who advocate and help in the development of [oVirt](/Download "Download"), by using oVirt in a variety of production environments every day. When we find them, we are pleased to list them here.
-
-<div class="parner-block">
-[![AlterWay](/images/logos/AlterWay.png)](http://www.alterway.fr)
-[AlterWay](//alterway.fr) offers hosting services to the oVirt project for free, including oVirt-managed Virtual Machines and a dedicated server for Jenkins, for use in the oVirt project infrastructure. They launched an oVirt-based public cloud offering called [H2O](http://h2o.alterway.fr) in October 2012. **[Case Study](/community/user-stories/alter-way-case-study/ "Alter Way case study")**
-</div>
-
-<div class="parner-block">
-[![BrusselsAirportCompany](/images/logos/BrusselsAirport.svg)](http://www.brusselsairport.be)
-Faced with an opportunity to take the approximately 150 virtual machines housed on 30 Solaris machines and manage them with another virtual datacenter management tool, the [Brussels Airport Company](//www.brusselsairport.be) IT team went with oVirt running atop CentOS. **[Case Study](/community/user-stories/brussels-airport-case-study/ "Brussels Airport Case Study")**
-</div>
-
-<div class="parner-block">
-[![Judici](/images/logos/Judici.png)](http://www.judici.com)
-[Judici](//www.judici.com) offers the public litigant information, criminal and civil court information, case minutes, and calendar data for hearings, and is rolling out the capability to e-file cases online for 68 of Illinois' 102 county courts. And it's making this happen with completely open source software, including oVirt. **[Case Study](/community/user-stories/judici-case-study/ "Judici Case Study")**
-</div>
-
-<div class="parner-block">
-[![Nieuwland](/images/logos/Nwld.png)](http://nieuwland.nl/)
-Dutch software development company [Nieuwland Geo-Informatie](//nieuwland.nl/) creates mobile applications that need to tap into a lot of geographic information in a reliable and fast manner. To do this, they needed a virtualization solution that would have high availability at a reasonable cost. **[Case Study](/community/user-stories/nieuwland-case-study/ "Nieuwland case study")**
-</div>
-
-## oVirt Educational Stories
+## oVirt Partners in Education
 
 oVirt is popular with a lot of users, but one set of organizations that finds oVirt very useful for production is academic institutions. We have found users from universities and colleges from around the world who have implemented oVirt to manage their virtual workloads.
-
-<div class="parner-block">
-[![Keele University](/images/logos/Keele.svg)](http://www.keele.ac.uk/)
-[Keele University](//www.keele.ac.uk/), Stafforshire UK  
-Keele University has a small and dedicated IT staff handling all of the IT demands of the 10,000 students and 2,000 staff. To handle their virtualization needs, they have been using oVirt 3.2 since mid 2013. **[Case Study](/community/user-stories/keele-university-case-study/ "Keele University case study")**
-</div>
 
 <div class="parner-block">
 [![NUST](/images/logos/Nust.svg)](http://www.nust.edu.pk/Pages/Home.aspx)
@@ -84,6 +54,8 @@ The National University of Sciences and Technology aims to emerge as a comprehen
 [Silesian University in Opava](//www.slu.cz/slu/en), Opava, Czech Republic  
 The Silesian University in Opava, a member of European University Association, belongs among the top five universities created after 1989. Immediately after its inception, the university began to provide students comprehensive education in the fields of humanities and economics.
 </div>
+
+To learn more on oVirt partners in education, visit the [case studies](https://www.ovirt.org/community/user-stories/user-stories/) page.
 
 ## oVirt Professional Services / Integrators
 
@@ -105,11 +77,6 @@ Companies and public institutions all over the world have found oVirt a great so
 </div>
 
 <div class="parner-block">
-[![it-novum Logo](/images/logos/It-novum.png)](http://www.it-novum.com/)
-[it-novum](//www.it-novum.com/) is a company that's very focused on delivering open source, so when they decided to build a product and solution set for their customers' datacenter needs, it made sense that oVirt was included. **[Case Study](/community/user-stories/it-novum-case-study/ "IT Novum case study")**
-</div>
-
-<div class="parner-block">
 [![Netbulae](/images/logos/Netbulae.png)](http://www.netbulae.eu/)
 The founders of [Netbulae](//www.netbulae.eu/) have experience in ICT, automation, graphics and multimedia sectors, and use those skills and the oVirt platform to deliver virtual datacenter management services to their customer base.
 </div>
@@ -117,6 +84,9 @@ The founders of [Netbulae](//www.netbulae.eu/) have experience in ICT, automatio
 <div class="parner-block">
 [![R01](/images/logos/R01.png)](http://r01.ru/)
 [Registrar R01](//r01.ru/) - registrar of domain names, belongs to a group of companies Hosting Community. The company became the first accredited registrar in the national domain RU and today offers a wide range of professional services, being one of the leaders in the number of registered domains .RU, .SU and .RF.
+
+For more on oVirt professional services and integrators, read the [IT Novum case study](https://www.ovirt.org/community/user-stories/it-novum-case-study/).
+
 </div>
 
 <div class="parner-block">
@@ -127,13 +97,10 @@ The founders of [Netbulae](//www.netbulae.eu/) have experience in ICT, automatio
 ## oVirt Cloud Providers
 
 <div class="parner-block">
-[![AlterWay](/images/logos/AlterWay.png)](http://www.alterway.fr)
-[AlterWay](//alterway.fr) offers hosting services to the oVirt project for free, including oVirt-managed Virtual Machines and a dedicated server for Jenkins, for use in the oVirt project infrastructure. They launched an oVirt-based public cloud offering called [H2O](http://h2o.alterway.fr) in October 2012. **[Case Study](/community/user-stories/alter-way-case-study/ "Alter Way case study")**
-</div>
-
-<div class="parner-block">
 [![Cloud Times](/images/logos/Ct.png)](http://www.cloud-times.com/)
 [Cloud Times](//www.cloud-times.com/) is a startup invested by CBC and funded by Dr Edward Tian, known as the Father of Chinese Broadband. Cloud Times is devoted to being the leading solution provider of Cloud Client Equipment, Virtual Desktop Infrastructure, and “Cloud plus Client” Management Platform, and to help Chinese enterprises in the transition to “Cloud plus Client” architecture.
+
+For more on cloud providers that are using oVirt, read our [case study](https://www.ovirt.org/community/user-stories/alter-way-case-study/).
 </div>
 
 ## oVirt Supporters

--- a/source/community/user-stories/users-and-providers.html.md
+++ b/source/community/user-stories/users-and-providers.html.md
@@ -13,15 +13,15 @@ page_classes: partner-logos
 
 # Users and Providers
 
-Our community is growing every day, as individual users and organizations alike discover oVirt and start integrating it into their IT strategies. How they use oVirt varies: implementing it in their datacenters and even using oVirt as the basis of their own solutions for their customers. For Red Hat, which opened the oVirt codebase, oVirt is used as the upstream for the commercial Red Hat Virtualization product. oVirt is also the upstream for Wind River's Open Virtualization product.
+Our community keeps growing as more individual users and organizations choose oVirt: Some are implementing it in their datacenters, while others are using oVirt as the basis for their own customer solutions. Red Hat, which opened the oVirt codebase, uses it as the upstream version of its commercial virtualization product, RHV. oVirt is also the upstream version for Wind River's open virtualization product.
 
-This page highlights the users, solution providers, supporters, and downstream commercial products of oVirt.
+Below you will find the list of oVirt users, solution providers, supporters and downstream commercial products.
 
-## oVirt-Based Products
+## oVirt-Based Service Providers
 
 <div class="parner-block">
 [![Nimbus Concept](/images/logos/Nimbus.png)](http://www.nimbusconcept.com/index-en.html)
-[Nimbus Concept](//www.nimbusconcept.com/index-en.html) has taken oVirt and other open source tools to deliver solutions to their customers, and now is offering something unique: OriginStack, an appliance that integrates hardware, virtualization (oVirt/KVM), private cloud (OpenStack), and support in one integrated package. **[Case Study](/community/user-stories/nimbus-concept-case-study/ "Nimbus Concept Case Study")**
+[Nimbus Concept](//www.nimbusconcept.com/index-en.html) has developed OriginStack, an appliance that integrates hardware, virtualization (oVirt/KVM), private cloud (OpenStack), and support in one integrated package. Read the **[case study.](/community/user-stories/nimbus-concept-case-study/ "Nimbus Concept Case Study")**
 </div>
 
 <div class="parner-block">
@@ -31,8 +31,8 @@ This page highlights the users, solution providers, supporters, and downstream c
 
 <div class="parner-block">
 [![UDS Enterprise](/images/logos/UDS.png)](https://www.udsenterprise.com)
-[UDS Enterprise](//www.udsenterprise.com) is a multiplatform connection broker supported and developed by [VirtualCable](//www.virtualcable.es). This software administers and manages virtual and remote desktops, applications and other Windows & Linux services. It is compatible, among others, with Citrix XenServer, Microsoft Hyper-V, Nutanix Acropolis, Red Hat KVM, oVirt KVM, VMware vSphere.... **[Case Study](/community/user-stories/universidad-de-sevilla-case-study/)**
-</div>
+[UDS Enterprise](//www.udsenterprise.com) is a multiplatform connection broker that administers and manages virtual and remote desktops, apps, and other Windows & Linux services. It is compatible with Red Hat and oVirt KVM. Read the **[case study.](/community/user-stories/universidad-de-sevilla-case-study/)**
+</div>  
 
 <div class="parner-block">
 [![Wind River](/images/logos/Wind_River.svg)](http://www.windriver.com/)
@@ -41,39 +41,48 @@ This page highlights the users, solution providers, supporters, and downstream c
 
 ## oVirt Partners in Education
 
-oVirt is popular with a lot of users, but one set of organizations that finds oVirt very useful for production is academic institutions. We have found users from universities and colleges from around the world who have implemented oVirt to manage their virtual workloads.
+Educational institutions around the world are choosing oVirt to manage their virtual workloads, finding it a scalable, feature-rich and cost-effective solution.
+
+<div class="parner-block">
+[![RCC](/images/logos/FSUSig_Horizontal_Color.png)](https://rcc.fsu.edu/) [Florida State University’s Research Computing Center](https://rcc.fsu.edu/) provides the FSU research community with high-performance computational resources to enable scientific research. Read the [**case study.**](https://www.ovirt.org/community/user-stories/RCC-case-study/)
+</div>
+
+<div class="parner-block">
+[![](/images/logos/Sevilla.png)](http://www.us.es/) The [University of Seville](http://www.us.es/eng) is one of the top-ranked universities in Spain. It has a student body of over 65,000 and hosts an extensive international student program. Read the [**case study.**](https://www.ovirt.org/community/user-stories/universidad-de-sevilla-case-study/)
+</div>
+
+<div class="parner-block">
+[![Keele](/images/logos/Keele.svg)](https://www.keele.ac.uk)
+[Keele University](/community/user-stories/keele-university-case-study/) in Staffordshire UK, is a public research university. It has a small, dedicated IT staff handling the IT demands of 10,000 students and 2,000 staff. Read the [**case study**.](https://www.ovirt.org/community/user-stories/keele-university-case-study/)
+</div>
 
 <div class="parner-block">
 [![NUST](/images/logos/Nust.svg)](http://www.nust.edu.pk/Pages/Home.aspx)
-[National University of Sciences & Technology](//www.nust.edu.pk/Pages/Home.aspx), Islamabad, Pakistan  
-The National University of Sciences and Technology aims to emerge as a comprehensive residential institution responsive to technological change, dedicated to excellence and committed to international educational and research needs of Pakistan.
+The [National University of Sciences & Technology (NUST)](//www.nust.edu.pk/Pages/Home.aspx) is a public research university in Islamabad, Pakistan. The university primarily focuses on Science, technology, engineering and mathematics.
 </div>
 
 <div class="parner-block">
-[![Silesian University in Opava](/images/logos/Silesian.svg)](http://www.slu.cz/slu/en)
-[Silesian University in Opava](//www.slu.cz/slu/en), Opava, Czech Republic  
-The Silesian University in Opava, a member of European University Association, belongs among the top five universities created after 1989. Immediately after its inception, the university began to provide students comprehensive education in the fields of humanities and economics.
+[![Silesian University](/images/logos/Silesian.svg)](http://www.slu.cz/slu/en)
+[Silesian University](//www.slu.cz/slu/en) in Opava, Czech Republic, has an enrollment of more than 9000 students in approximately 50 study programs. It is a member of the European University Association.
 </div>
 
-To learn more on oVirt partners in education, visit the [case studies](https://www.ovirt.org/community/user-stories/user-stories/) page.
-
-## oVirt Professional Services / Integrators
+## oVirt Professional Services & Integrators
 
 Companies and public institutions all over the world have found oVirt a great solution to manage internal and customer-facing servers. These organizations are using oVirt in production, as well as actively participating in the oVirt community.
 
 <div class="parner-block">
 [![ALBA Software](/images/logos/Alba.png)](http://www.albasoft.com/web/#/home)
-[ALBA Software](//www.albasoft.com/web/#/home) has provided consulting, integration, and Internet development services since 1999.
+[ALBA Software](//www.albasoft.com/web/#/home) has been providing consulting, integration, and Internet development services since 1999.
 </div>
 
 <div class="parner-block">
-[![Cornerstone Technical Solutions](/images/logos/Cornerstone.png)](http://cornerstonets.net/home/managed-services.html)
-[Cornerstone Technical Solutions](//cornerstonets.net/home/index.html) offers virtualization to consolidate datacenters, enabling clients the flexibility to combine CTS service offerings, which use oVirt, for their needs.
+[![Cornerstone Technical Solutions](/images/logos/Cornerstone.png)](https://cornerstonets.net/)
+[Cornerstone Technical Solutions](//cornerstonets.net/managed-services) offers virtualization to consolidate datacenters, enabling clients the flexibility to combine CTS service offerings, which use oVirt, for their needs.
 </div>
 
 <div class="parner-block">
-[![Internet Complete!, Inc.](/images/logos/Tl.png)](http://icnet.net/)
-[Internet Complete](//icnet.net/) is dedicated to providing Oklahoma customers with the leading technologies (including oVirt-managed hosting) they need for fast, reliable Internet solutions.
+[![Internet Complete!, Inc.](/images/logos/Tl.png)](http://icnet.net/)  
+[Internet Complete](//icnet.net/) is dedicated to providing customers in Oklahoma with leading technologies - such as oVirt-managed hosting - for fast and reliable Internet solutions.
 </div>
 
 <div class="parner-block">
@@ -83,10 +92,13 @@ The founders of [Netbulae](//www.netbulae.eu/) have experience in ICT, automatio
 
 <div class="parner-block">
 [![R01](/images/logos/R01.png)](http://r01.ru/)
-[Registrar R01](//r01.ru/) - registrar of domain names, belongs to a group of companies Hosting Community. The company became the first accredited registrar in the national domain RU and today offers a wide range of professional services, being one of the leaders in the number of registered domains .RU, .SU and .RF.
+[Registrar R01](//r01.ru/), a registrar of domain names, belongs to a group of companies Hosting Community. The company became the first accredited registrar in the national domain RU and today offers a wide range of professional services, being one of the leaders in the number of registered domains .RU, .SU and .RF.
+</div>
 
-For more on oVirt professional services and integrators, read the [IT Novum case study](https://www.ovirt.org/community/user-stories/it-novum-case-study/).
-
+<div class="parner-block">
+![](/images/logos/It-novum.png)
+[it-novum](/community/user-stories/it-novum-case-study/) is a leading consultancy for business open source in the German-speaking market. it-novum focuses on the intergation of open source with closed source and the development of combined open source solutions and platforms.
+Read the [**case study.**](/community/user-stories/it-novum-case-study/)
 </div>
 
 <div class="parner-block">
@@ -98,10 +110,14 @@ For more on oVirt professional services and integrators, read the [IT Novum case
 
 <div class="parner-block">
 [![Cloud Times](/images/logos/Ct.png)](http://www.cloud-times.com/)
-[Cloud Times](//www.cloud-times.com/) is a startup invested by CBC and funded by Dr Edward Tian, known as the Father of Chinese Broadband. Cloud Times is devoted to being the leading solution provider of Cloud Client Equipment, Virtual Desktop Infrastructure, and “Cloud plus Client” Management Platform, and to help Chinese enterprises in the transition to “Cloud plus Client” architecture.
-
-For more on cloud providers that are using oVirt, read our [case study](https://www.ovirt.org/community/user-stories/alter-way-case-study/).
+[Cloud Times](//www.cloud-times.com/) is a solution provider of Cloud Client Equipment, Virtual Desktop Infrastructure, and the “Cloud plus Client” Management Platform, helping Chinese enterprises in the transition to “Cloud plus Client” architecture.
 </div>
+
+<div class="parner-block">
+![](/images/logos/AlterWay.png)
+[Alter Way](https://www.alterway.fr/) is a French hosting company that provides solutions for their customers' digital strategies, in a DevOps approach and using open source solutions, including oVirt. Read the Alter Way [**case study.**](/community/user-stories/alter-way-case-study/)
+</div>
+
 
 ## oVirt Supporters
 


### PR DESCRIPTION
Fixes issue **page too long**

Changes proposed in this pull request:

The page has been reformatted:
- Currently, the individual companies / orgs are separated by the tag: **div class="parner-block"**
The layout is cumbersome and takes up too much space. Therefore, I have replaced **div class="parner-block"** with **div class="case-study"** as used on the case studies page.

Companies and orgs removed:
- To make the page shorter and avoid overalp, I have removed descriptions of organizations that already have a case study. For example: Brussels Airport and Keele University. Instead, I have added a short text and a link to the case study.

Edits
- I have edited the page to make all the description shorter and tighter

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): @jmarks

This pull request needs review by: @mykaul @duck-rh @doron-fediuck 
