### PR TITLE
Updated links to release notes

### DIFF
--- a/source/documentation/index.html.haml
+++ b/source/documentation/index.html.haml
@@ -78,9 +78,12 @@ wiki_last_updated: 2014-04-26
       ### Release Notes
 
       #### Latest Release Notes
-      - [oVirt 4.1.1](/release/4.1.1/)
+      - [oVirt 4.1.3](/release/4.1.3/)
+
 
       #### Previous Release Notes
+      - [oVirt 4.1.2](/release/4.1.2/)
+      - [oVirt 4.1.1](/release/4.1.1/)
       - [oVirt 4.0.6](/release/4.0.6/)
       - [oVirt 3.6.7](/release/3.6.7)
       - [oVirt 3.5.6](/develop/release-management/releases/3.5.6)


### PR DESCRIPTION

Changes proposed in this pull request:

- Updated links to release notes on my Documentation page: 4.1.3. 4.1.2

- Is 3.0 still relevant?

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): @jmarks

This pull request needs review by: @mykaul @sandrobonazzola 
