### PR TITLE
Remove status colors from feature list

### DIFF
--- a/source/layouts/feature.html.haml
+++ b/source/layouts/feature.html.haml
@@ -1,8 +1,6 @@
 :ruby
   @feature_base = '/develop/release-management/features/'
 
-  statuses = []
-
   # Session object cach for feature info
   $feature_info_store ||= {}
 
@@ -26,26 +24,6 @@
       feature_page = sitemap.find_resource_by_destination_path(constructed_url)
 
       $feature_info_store[frag] = feature_page.data if feature_page
-    end
-  end
-
-  # Normalize the status (for classes, etc.)
-  def normalize_status status
-    case status
-    when /wip/i, /progress/i
-      'WIP'
-    when /QA/i
-      'QA'
-    when /development/i
-      'Development'
-    when /review/i
-      'Review'
-    when /release/i
-      'Released'
-    when '', nil
-      'Unknown'
-    else
-      status.strip.gsub(/ /, '-')
     end
   end
 
@@ -125,11 +103,6 @@
       %form#feature-search.hide
         .form-group
           %input.form-control#feature-search-input{autocomplete: 'off', placeholder: 'Filter features'}
-          .checkbox
-            %label
-              -# %input{type: 'checkbox'} Hello
-              - statuses.each do |stat|
-                %input{type: 'checkbox'} = stat
 
       - features_dir.each do |cat, feature_group|
         - pretty_cat = cat.empty? ? 'Unclassified' : cat.gsub('/', ' / ').titleize
@@ -141,22 +114,16 @@
 
             - if info
               - feature_title = info['feature_name'] || info['title']
-              - status_title = info['feature_status']
-              - status = normalize_status status_title
             - else
               - feature_title = clean_title feature
-              - status_title = 'Unclassified'
-              - status = normalize_status ''
 
             - next if feature_title.to_s.empty?
 
-            - statuses.push(status_title)
-
             - selected = "/#{@feature_base}/#{cat}/#{feature}/".squeeze('/') == "/#{current_page.url}/".squeeze('/')
-            - classes = "#{selected ? 'selected' : ''} status-#{status.downcase}"
+            - classes = "#{selected ? 'selected' : ''}"
 
             %li{class: classes}
-              %a{href: "#{@feature_base}/#{cat}/#{feature}".squeeze('/'), title: "Status: #{status}"}= clean_title feature_title
+              %a{href: "#{@feature_base}/#{cat}/#{feature}".squeeze('/')}= clean_title feature_title
               = info ? "" : "NO DATA"
 
     %section.feature-info.col-md-8
@@ -285,9 +252,6 @@
 
   $ ->
     $input.focus()
-
-    statuses = #{statuses.compact.map {|s| s.downcase}.uniq}
-    console.log statuses
 
     $form
       .removeClass 'hide'

--- a/source/stylesheets/lib/site.sass
+++ b/source/stylesheets/lib/site.sass
@@ -249,22 +249,6 @@ $social-list: twitter facebook google-plus youtube
 li.selected
   font-weight: bold
 
-ul.feature-list
-  li[class*="status-"] a
-    color: red
-    opacity: 0.75
-
-  li.status-wip a
-    color: orange
-
-  li.status-unknown a
-    color: #aaa
-
-  li.status-released a,
-  li.status-completed a
-    color: green
-    opacity: 1
-
 .alert
   position: relative
   overflow: visible


### PR DESCRIPTION
## Fixes issue
Status colors on [feature page ](https://www.ovirt.org/develop/release-management/features/) make the page hard on the eyes and the color codes don't really add value as the viewer wouldn't necessarily know what they represent

## Changes proposed in this pull request:

- Remove status color coding so that all links will be in green - like elsewhere on site

- Bold green for selected feature remains unchanged 

I confirm that this pull request was submitted according to the [contribution guidelines](/CONTRIBUTING.md): @jmarks

This pull request needs review by: @mykaul @duck-rh 
