### PR TITLE
Documentation for using containers with oVirt

### DIFF
--- a/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-ManageIQ-container.html.md
+++ b/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-ManageIQ-container.html.md
@@ -21,19 +21,19 @@ or
 
 2. Use the Docker image of ManageIQ available at Docker Hub: https://hub.docker.com/r/manageiq/manageiq/
 
-Pull the Docker image as follows:
+   Pull the Docker image as follows:
 
   `$ sudo docker pull manageiq/manageiq:fine-3`
   
 At present, the tag is `fine:3` but that changes with time, so to be sure go to https://manageiq/download to see what the latest tag is.
 
-2. Run the container
+3. Run the container
 
   `$ sudo docker run --name ovirt-manageiq --privileged -d -p 8443:443 manageiq/manageiq:fine-3`
 
-Trying to access the container via `https://localhost:8443` will raise a "Secure Connection Failed" error. 
+Note: Trying to access the container via `https://localhost:8443` will raise a "Secure Connection Failed" error. 
 
-Waiting a few moments and trying again, will show you the "Insecure Connection" warning. Click on the "Advanced" button and 
+Waiting a few moments and trying again will show you the "Insecure Connection" warning. Click on the "Advanced" button and 
 add an exception for the site. Confirming the exception should bring you to the ManageIQ Login page. 
 
 Default login for ManageIQ:

--- a/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-ManageIQ-container.html.md
+++ b/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-ManageIQ-container.html.md
@@ -12,26 +12,20 @@ to log into the oVirt Engine successfully.
 ### Steps
 
 1. Make sure that the Docker service is running:
-
-
-    `$ sudo service docker start`
+  `$ sudo service docker start`
 
 or
-
-    `$ sudo systemctl start docker.service`
+  `$ sudo systemctl start docker.service`
 
 2. Use the Docker image of ManageIQ available at Docker Hub: https://hub.docker.com/r/manageiq/manageiq/
 
 Pull the Docker image as follows: 
-
-    `$ sudo docker pull manageiq/manageiq:fine-3`
+  `$ sudo docker pull manageiq/manageiq:fine-3`
   
 At present, the tag is `fine:3` but that changes with time, so to be sure go to https://manageiq/download to see what the latest tag is.
 
 2. Run the container
-
-
-    `$ sudo docker run --name ovirt-manageiq --privileged -d -p 8443:443 manageiq/manageiq:fine-3`
+  `$ sudo docker run --name ovirt-manageiq --privileged -d -p 8443:443 manageiq/manageiq:fine-3`
 
 Trying to access the container via `https://localhost:8443` will raise a "Secure Connection Failed" error. 
 

--- a/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-ManageIQ-container.html.md
+++ b/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-ManageIQ-container.html.md
@@ -12,19 +12,23 @@ to log into the oVirt Engine successfully.
 ### Steps
 
 1. Make sure that the Docker service is running:
+
   `$ sudo service docker start`
 
 or
+
   `$ sudo systemctl start docker.service`
 
 2. Use the Docker image of ManageIQ available at Docker Hub: https://hub.docker.com/r/manageiq/manageiq/
 
-Pull the Docker image as follows: 
+Pull the Docker image as follows:
+
   `$ sudo docker pull manageiq/manageiq:fine-3`
   
 At present, the tag is `fine:3` but that changes with time, so to be sure go to https://manageiq/download to see what the latest tag is.
 
 2. Run the container
+
   `$ sudo docker run --name ovirt-manageiq --privileged -d -p 8443:443 manageiq/manageiq:fine-3`
 
 Trying to access the container via `https://localhost:8443` will raise a "Secure Connection Failed" error. 
@@ -32,8 +36,10 @@ Trying to access the container via `https://localhost:8443` will raise a "Secure
 Waiting a few moments and trying again, will show you the "Insecure Connection" warning. Click on the "Advanced" button and 
 add an exception for the site. Confirming the exception should bring you to the ManageIQ Login page. 
 
-Default login for ManageIQ: 
+Default login for ManageIQ:
+
 user: `admin`
+
 password: `smartvm`
 
 4. Change Options

--- a/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-ManageIQ-container.html.md
+++ b/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-ManageIQ-container.html.md
@@ -1,6 +1,6 @@
 ---
 title: Using oVirt Engine with a PostgreSQL container.
-authors: jbrooks, leni1
+authors: leni1
 ---
 The base environment is CentOS 7. 
 oVirt Engine is assumed to running as per the configuration in oVirt Engine with a PostgreSQL container. 

--- a/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-ManageIQ-container.html.md
+++ b/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-ManageIQ-container.html.md
@@ -2,8 +2,10 @@
 title: Using oVirt Engine with a PostgreSQL container.
 authors: leni1
 ---
-The base environment is CentOS 7. 
+The base environment is CentOS 7.
+
 oVirt Engine is assumed to running as per the configuration in oVirt Engine with a PostgreSQL container. 
+
 Alternatively you may have both PostgreSQL and oVirt installed locally on your machine, so long as you are able
 to log into the oVirt Engine successfully. 
 
@@ -19,9 +21,10 @@ or
     `$ sudo systemctl start docker.service`
 
 2. Use the Docker image of ManageIQ available at Docker Hub: https://hub.docker.com/r/manageiq/manageiq/
+
 Pull the Docker image as follows: 
 
-$ sudo docker pull manageiq/manageiq:fine-3
+    `$ sudo docker pull manageiq/manageiq:fine-3`
   
 At present, the tag is `fine:3` but that changes with time, so to be sure go to https://manageiq/download to see what the latest tag is.
 
@@ -31,6 +34,7 @@ At present, the tag is `fine:3` but that changes with time, so to be sure go to 
     `$ sudo docker run --name ovirt-manageiq --privileged -d -p 8443:443 manageiq/manageiq:fine-3`
 
 Trying to access the container via `https://localhost:8443` will raise a "Secure Connection Failed" error. 
+
 Waiting a few moments and trying again, will show you the "Insecure Connection" warning. Click on the "Advanced" button and 
 add an exception for the site. Confirming the exception should bring you to the ManageIQ Login page. 
 

--- a/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-ManageIQ-container.html.md
+++ b/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-ManageIQ-container.html.md
@@ -1,0 +1,60 @@
+---
+title: Using oVirt Engine with a PostgreSQL container.
+authors: jbrooks, leni1
+---
+The base environment is CentOS 7. 
+oVirt Engine is assumed to running as per the configuration in oVirt Engine with a PostgreSQL container. 
+Alternatively you may have both PostgreSQL and oVirt installed locally on your machine, so long as you are able
+to log into the oVirt Engine successfully. 
+
+### Steps
+1. Make sure that the Docker service is running:
+
+$ sudo service docker start
+
+or
+
+$ sudo systemctl start docker.service
+
+2. Use the Docker image of ManageIQ available at Docker Hub: https://hub.docker.com/r/manageiq/manageiq/
+Pull the Docker image as follows: 
+
+$ sudo docker pull manageiq/manageiq:fine-3
+  
+At present, the tag is `fine:3` but that changes with time, so to be sure go to https://manageiq/download to see what the latest tag is.
+
+2. Run the container
+
+sudo docker run --name ovirt-manageiq --privileged -d -p 8443:443 manageiq/manageiq:fine-3
+
+Trying to access the container via https://localhost:8443 will raise a "Secure Connection Failed" error. 
+Waiting a few moments and trying again, will show you the "Insecure Connection" warning. Click on the "Advanced" button and 
+add an exception for the site. Confirming the exception should bring you to the ManageIQ Login page. 
+
+Default login for ManageIQ: 
+user - admin
+password - smartvm
+
+4. Change Options
+
+Click on 'Admininstrator' and then select 'Configuration' to change how the appliance behaves:
+1. Select the appliance to configure
+
+    CFME Region: Region 0 → Zones → Zone: Default zone(current) → Server: EVM[1](current) should be selected by default.
+
+    The hostname and IP address of the appliance will be shown here, be careful as in some cases this will be the internal IP address and not the one you connected to.
+
+    You can change the Company Name to whatever you want, the change will be reflected in the interface. 
+    Change it to ManageIQ
+    Select your time zone, and, if you want, you can change the language default.
+
+2. Adding oVirt Engine as a provider to ManageIQ:
+Compute -> Infrastructure -> Providers
+Click on "Configuration". Select 'Add a new infrastructure provider'.
+- Hostname of the both the provider and the C & U database should be the IP address of the 
+  Docker container that has oVirt Engine's database.
+- API port for the provider should be that of oVirt Engine (443) and that of the C & U database should be 
+  5432 (for PostgreSQL).
+- Remember to specify the correct database name, owner and password for the C & U database 
+  (e.g. if you configured oVirt to have a database and owner called `engine`, be sure to use the same for the 
+  C & U database for ManageIQ along with the associated credentials).

--- a/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-ManageIQ-container.html.md
+++ b/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-ManageIQ-container.html.md
@@ -8,13 +8,15 @@ Alternatively you may have both PostgreSQL and oVirt installed locally on your m
 to log into the oVirt Engine successfully. 
 
 ### Steps
+
 1. Make sure that the Docker service is running:
 
-$ sudo service docker start
+
+    `$ sudo service docker start`
 
 or
 
-$ sudo systemctl start docker.service
+    `$ sudo systemctl start docker.service`
 
 2. Use the Docker image of ManageIQ available at Docker Hub: https://hub.docker.com/r/manageiq/manageiq/
 Pull the Docker image as follows: 
@@ -25,15 +27,16 @@ At present, the tag is `fine:3` but that changes with time, so to be sure go to 
 
 2. Run the container
 
-sudo docker run --name ovirt-manageiq --privileged -d -p 8443:443 manageiq/manageiq:fine-3
 
-Trying to access the container via https://localhost:8443 will raise a "Secure Connection Failed" error. 
+    `$ sudo docker run --name ovirt-manageiq --privileged -d -p 8443:443 manageiq/manageiq:fine-3`
+
+Trying to access the container via `https://localhost:8443` will raise a "Secure Connection Failed" error. 
 Waiting a few moments and trying again, will show you the "Insecure Connection" warning. Click on the "Advanced" button and 
 add an exception for the site. Confirming the exception should bring you to the ManageIQ Login page. 
 
 Default login for ManageIQ: 
-user - admin
-password - smartvm
+user: `admin`
+password: `smartvm`
 
 4. Change Options
 
@@ -50,7 +53,7 @@ Click on 'Admininstrator' and then select 'Configuration' to change how the appl
 
 2. Adding oVirt Engine as a provider to ManageIQ:
 Compute -> Infrastructure -> Providers
-Click on "Configuration". Select 'Add a new infrastructure provider'.
+Click on 'Configuration'. Select 'Add a new infrastructure provider'.
 - Hostname of the both the provider and the C & U database should be the IP address of the 
   Docker container that has oVirt Engine's database.
 - API port for the provider should be that of oVirt Engine (443) and that of the C & U database should be 

--- a/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-a-PostgreSQL-container.html.md
+++ b/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-a-PostgreSQL-container.html.md
@@ -30,11 +30,13 @@ vi /var/lib/pgsql/data/pg_hba.conf
 ```
 
 Ensure the database can be accessed remotely by enabling md5 client authentication. Edit the /var/lib/pgsql/data/pg_hba.conf file, and add the following line immediately underneath the line starting with local at the bottom of the file, replacing X.X.X.X with the IP address of the Engine:
+
 ```
  host    database_name    user_name    X.X.X.X/32   md5
 ```
 
 Edit `postgresql.conf` and add following lines:
+
 ```
 vi /var/lib/pgsql/data/postgresql.conf
 
@@ -223,7 +225,8 @@ You should be able to access oVirt's web portal at the address mentioned above.
 
 Notes: When you first start your machine, be sure to start the Docker container that has your database. 
 After this, restart the `ovirt-engine` service using the following command:
-`systemctl restart ovirt-engine`
-Do use the image pulled from registry.centos.org/centos/postgres:latest. The one provided by PostgreSQL is difficult 
-to configure since it seems intended to use as is. Your mileage on this may vary. 
+  `systemctl restart ovirt-engine`
+
+Do use the image pulled from registry.centos.org/centos/postgres:latest. 
+The one provided by PostgreSQL is difficult to configure since it seems intended to use as is. Your mileage on this may vary. 
 The 404 error that appears initially should disappear and you should get the web login page for oVirt, after a few seconds or so.

--- a/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-a-PostgreSQL-container.html.md
+++ b/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-a-PostgreSQL-container.html.md
@@ -1,0 +1,229 @@
+The base environment used here is CentOS 7.
+
+1. Install ovirt-engine:
+
+```
+yum install -y http://resources.ovirt.org/pub/yum-repo/ovirt-release41.rpm
+yum install ovirt-engine -y
+```
+
+2. Start postgres container:
+
+```
+docker run --name=postgresql -d -p 5432:5432 registry.centos.org/centos/postgres:latest 
+```
+
+3. Prepare the PostgreSQL database according to the guide below:
+https://www.ovirt.org/documentation/install-guide/appe-Preparing_a_Remote_PostgreSQL_Database_for_Use_with_the_oVirt_Engine/
+
+
+```
+docker exec -ti postgresql bash
+su - postgres
+psql
+
+postgres=# create role engine with login encrypted password 'password';
+postgres=# create database engine owner engine template template0 encoding 'UTF8' lc_collate 'en_US.UTF-8' lc_ctype 'en_US.UTF-8';
+postgres=# \q
+
+vi /var/lib/pgsql/data/pg_hba.conf
+```
+
+Ensure the database can be accessed remotely by enabling md5 client authentication. Edit the /var/lib/pgsql/data/pg_hba.conf file, and add the following line immediately underneath the line starting with local at the bottom of the file, replacing X.X.X.X with the IP address of the Engine:
+```
+ host    database_name    user_name    X.X.X.X/32   md5
+```
+
+Edit `postgresql.conf` and add following lines:
+```
+vi /var/lib/pgsql/data/postgresql.conf
+
+autovacuum_vacuum_scale_factor = 0.01
+autovacuum_analyze_scale_factor = 0.075
+autovacuum_max_workers = 6
+maintenance_work_mem = 65536
+max_connections = 150
+lc_messages = 'en_US.UTF-8'
+```
+
+4. Restart the database within the container:
+
+```
+-bash-4.2$ pg_ctl restart
+exit
+exit
+```
+
+5. Setup ovirt-engine:
+
+```
+engine-setup
+
+# engine-setup 
+[ INFO  ] Stage: Initializing
+[ INFO  ] Stage: Environment setup
+          Configuration files: ['/etc/ovirt-engine-setup.conf.d/10-packaging-jboss.conf', '/etc/ovirt-engine-setup.conf.d/10-packaging.conf']
+          Log file: /var/log/ovirt-engine/setup/ovirt-engine-setup-20170803144341-soqdsk.log
+          Version: otopi-1.6.2 (otopi-1.6.2-1.el7.centos)
+[ INFO  ] Stage: Environment packages setup
+[ INFO  ] Stage: Programs detection
+[ INFO  ] Stage: Environment setup
+[ INFO  ] Stage: Environment customization
+         
+          --== PRODUCT OPTIONS ==--
+         
+          Configure Engine on this host (Yes, No) [Yes]: 
+          Configure Image I/O Proxy on this host? (Yes, No) [Yes]: 
+          Configure WebSocket Proxy on this host (Yes, No) [Yes]: 
+          Please note: Data Warehouse is required for the engine. If you choose to not configure it on this host, you have to configure it on a remote host, and then configure the engine on this host so that it can access the database of the remote Data Warehouse host.
+          Configure Data Warehouse on this host (Yes, No) [Yes]: No
+          Configure VM Console Proxy on this host (Yes, No) [Yes]: 
+         
+          --== PACKAGES ==--
+         
+[ INFO  ] Checking for product updates...
+[ INFO  ] No product updates found
+         
+          --== NETWORK CONFIGURATION ==--
+         
+          Host fully qualified DNS name of this server [centos-1.osas.lab]: 
+          Setup can automatically configure the firewall on this system.
+          Note: automatic configuration of the firewall may overwrite current settings.
+          Do you want Setup to configure the firewall? (Yes, No) [Yes]: 
+[ INFO  ] firewalld will be configured as firewall manager.
+         
+          --== DATABASE CONFIGURATION ==--
+         
+          Where is the Engine database located? (Local, Remote) [Local]: Remote
+         
+          ATTENTION
+         
+          Manual action required.
+          Please create database for ovirt-engine use. Use the following commands as an example:
+         
+          create role engine with login encrypted password '<password>';
+          create database engine owner engine
+           template template0
+           encoding 'UTF8' lc_collate 'en_US.UTF-8'
+           lc_ctype 'en_US.UTF-8';
+         
+          Make sure that database can be accessed remotely.
+         
+          Engine database host [localhost]: centos-1.osas.lab
+          Engine database port [5432]: 
+          Engine database secured connection (Yes, No) [No]: 
+          Engine database name [engine]: 
+          Engine database user [engine]: 
+          Engine database password: 
+         
+          --== OVIRT ENGINE CONFIGURATION ==--
+         
+          Engine admin password: 
+          Confirm engine admin password: 
+          Application mode (Virt, Gluster, Both) [Both]: 
+         
+          --== STORAGE CONFIGURATION ==--
+         
+          Default SAN wipe after delete (Yes, No) [No]: 
+         
+          --== PKI CONFIGURATION ==--
+         
+          Organization name for certificate [osas.lab]: 
+         
+          --== APACHE CONFIGURATION ==--
+         
+          Setup can configure the default page of the web server to present the application home page. This may conflict with existing applications.
+          Do you wish to set the application as the default page of the web server? (Yes, No) [Yes]: 
+          Setup can configure apache to use SSL using a certificate issued from the internal CA.
+          Do you wish Setup to configure that, or prefer to perform that manually? (Automatic, Manual) [Automatic]: 
+         
+          --== SYSTEM CONFIGURATION ==--
+         
+          Configure an NFS share on this server to be used as an ISO Domain? (Yes, No) [No]: 
+         
+          --== MISC CONFIGURATION ==--
+         
+         
+          --== END OF CONFIGURATION ==--
+         
+[ INFO  ] Stage: Setup validation
+[WARNING] Less than 16384MB of memory is available
+         
+          --== CONFIGURATION PREVIEW ==--
+         
+          Application mode                        : both
+          Default SAN wipe after delete           : False
+          Firewall manager                        : firewalld
+          Update Firewall                         : True
+          Host FQDN                               : centos-1.osas.lab
+          Configure local Engine database         : False
+          Set application as default page         : True
+          Configure Apache SSL                    : True
+          Engine database secured connection      : False
+          Engine database user name               : engine
+          Engine database name                    : engine
+          Engine database host                    : centos-1.osas.lab
+          Engine database port                    : 5432
+          Engine database host name validation    : False
+          Engine installation                     : True
+          PKI organization                        : osas.lab
+          DWH installation                        : False
+          Configure local DWH database            : False
+          Configure Image I/O Proxy               : True
+          Configure VMConsole Proxy               : True
+          Configure WebSocket Proxy               : True
+         
+          Please confirm installation settings (OK, Cancel) [OK]: 
+[ INFO  ] Stage: Transaction setup
+[ INFO  ] Stopping engine service
+[ INFO  ] Stopping ovirt-fence-kdump-listener service
+[ INFO  ] Stopping Image I/O Proxy service
+[ INFO  ] Stopping vmconsole-proxy service
+[ INFO  ] Stopping websocket-proxy service
+[ INFO  ] Stage: Misc configuration
+[ INFO  ] Stage: Package installation
+[ INFO  ] Stage: Misc configuration
+[ INFO  ] Upgrading CA
+[ INFO  ] Creating CA
+[ INFO  ] Creating/refreshing Engine database schema
+[ INFO  ] Configuring Image I/O Proxy
+[ INFO  ] Setting up ovirt-vmconsole proxy helper PKI artifacts
+[ INFO  ] Setting up ovirt-vmconsole SSH PKI artifacts
+[ INFO  ] Configuring WebSocket Proxy
+[ INFO  ] Creating/refreshing Engine 'internal' domain database schema
+[ INFO  ] Generating post install configuration file '/etc/ovirt-engine-setup.conf.d/20-setup-ovirt-post.conf'
+[ INFO  ] Stage: Transaction commit
+[ INFO  ] Stage: Closing up
+[ INFO  ] Starting engine service
+[ INFO  ] Restarting ovirt-vmconsole proxy service
+         
+          --== SUMMARY ==--
+         
+[ INFO  ] Restarting httpd
+          Please use the user 'admin@internal' and password specified in order to login
+          The engine requires access to the Data Warehouse database.
+          Data Warehouse was not set up. Please set it up on some other machine and configure access to it on the engine.
+          Web access is enabled at:
+              http://myexample.domain.org:80/ovirt-engine
+              https://myexample.domain.org:443/ovirt-engine
+          Internal CA 8F:C8:A6:B6:D0:6E:34:92:D2:65:21:63:9C:35:64:4D:EE:09:59:72
+          SSH fingerprint: 0d:54:5c:7e:63:6f:fb:85:47:f7:00:8d:4f:95:cc:c1
+[WARNING] Less than 16384MB of memory is available
+         
+          --== END OF SUMMARY ==--
+         
+[ INFO  ] Stage: Clean up
+          Log file is located at /var/log/ovirt-engine/setup/ovirt-engine-setup-20170803144341-soqdsk.log
+[ INFO  ] Generating answer file '/var/lib/ovirt-engine/setup/answers/20170803144525-setup.conf'
+[ INFO  ] Stage: Pre-termination
+[ INFO  ] Stage: Termination
+[ INFO  ] Execution of setup completed successfully
+```
+You should be able to access oVirt's web portal at the address mentioned above. 
+
+Notes: When you first start your machine, be sure to start the Docker container that has your database. 
+After this, restart the `ovirt-engine` service using the following command:
+`systemctl restart ovirt-engine`
+Do use the image pulled from registry.centos.org/centos/postgres:latest. The one provided by PostgreSQL is difficult 
+to configure since it seems intended to use as is. Your mileage on this may vary. 
+The 404 error that appears initially should disappear and you should get the web login page for oVirt, after a few seconds or so.

--- a/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-a-PostgreSQL-container.html.md
+++ b/source/documentation/how-to/ovirt-and-containers/Using-oVirt-Engine-with-a-PostgreSQL-container.html.md
@@ -1,3 +1,8 @@
+---
+title: Using oVirt Engine with a PostgreSQL container.
+authors: jbrooks, leni1
+---
+
 The base environment used here is CentOS 7.
 
 1. Install ovirt-engine:

--- a/source/documentation/how-to/ovirt-and-containers/about-containerized.html.md
+++ b/source/documentation/how-to/ovirt-and-containers/about-containerized.html.md
@@ -1,3 +1,7 @@
+---
+title: About: oVirt and containers
+authors: leni1
+---
 ### oVirt and containers
 #### About
 The aim here is to provide documentation for easy testing of various components that work with oVirt. 

--- a/source/documentation/how-to/ovirt-and-containers/about-containerized.html.md
+++ b/source/documentation/how-to/ovirt-and-containers/about-containerized.html.md
@@ -1,0 +1,19 @@
+### oVirt and containers
+#### About
+The aim here is to provide documentation for easy testing of various components that work with oVirt. 
+Often components (e.g FreeIPA, ManageIQ, Ceph, Cinder etc) cannot be installed alongside oVirt due to conflicting 
+dependencies. Using these applications in containers allows users to sidestep these issues while at the same time 
+getting to deploy them for testing purposes on the same machine as oVirt. Such an approach also allows for separate 
+upgrades of components, direct management of resources, as well as emulation of situations where these components are 
+running separately such as in a production environment, even though we may be running the component containers on a single 
+server. 
+
+Some of the components that we're looking at include:
+- PostgreSQL 
+- Gluster 
+- Ceph 
+- OpenStack Glance/Cinder/Neutron 
+- ManageIQ
+- FreeIPA 
+
+Another components that oVirt uses can be added as well to the list above. 

--- a/source/documentation/how-to/ovirt-and-containers/about-containerized.html.md
+++ b/source/documentation/how-to/ovirt-and-containers/about-containerized.html.md
@@ -4,13 +4,9 @@ authors: leni1
 ---
 ### oVirt and containers
 #### About
-The aim here is to provide documentation for easy testing of various components that work with oVirt. 
-Often components (e.g FreeIPA, ManageIQ, Ceph, Cinder etc) cannot be installed alongside oVirt due to conflicting 
-dependencies. Using these applications in containers allows users to sidestep these issues while at the same time 
-getting to deploy them for testing purposes on the same machine as oVirt. Such an approach also allows for separate 
-upgrades of components, direct management of resources, as well as emulation of situations where these components are 
-running separately such as in a production environment, even though we may be running the component containers on a single 
-server. 
+This is documentation of how to use the oVirt Engine with the different software components that are commonly used with it via containers. Often components (e.g FreeIPA, ManageIQ, Ceph, Cinder etc) cannot be installed alongside the oVirt Engine on the same machine due to conflicting dependencies. In some cases, these components are designed for installation and usage on a server separate from the one hosting the oVirt Engine. 
+
+The aim here is to demonstrate how containers of these components can be used with the oVirt Engine. Using containers allows users to sidestep the issues described briefly above while simplifying what is required to spin up a testing environment. This approach allows for separate upgrades of components, direct management of resources, as well as emulation of situations where these components are running separately e.g. in a production environment, even though we may be running the component containers on a single server. 
 
 Some of the components that we're looking at include:
 - PostgreSQL 
@@ -20,4 +16,4 @@ Some of the components that we're looking at include:
 - ManageIQ
 - FreeIPA 
 
-Another components that oVirt uses can be added as well to the list above. 
+Other components that the oVirt Engine uses can be added to the list above with time. 


### PR DESCRIPTION
As part of the Outreachy project for oVirt, we are trying to document using oVirt with several other open source software components in software containers as outlined [here](http://www.ovirt.org/community/activities/outreachy/).

Changes proposed in this pull request:

- Addition of a folder to hold the documentation proposed above. 
- Document detailing the aims behind the proposed documentation
- Sample documentation for using PostgreSQL in a container with the oVirt Engine. 
- Sample documentation for using ManageIQ in a container with the oVirt Engine.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md):  @leni1

This pull request needs review by: @jasonbrooks 
