### PR TITLE
Fedora 26 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     icalendar (1.5.4)
-    json (1.8.3)
+    json (1.8.6)
     kramdown (1.6.0)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -135,7 +135,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
     nokogiri (1.6.6.2)
-    oj (2.12.2)
+    oj (3.3.5)
     open-uri-cached (0.0.5)
     padrino-helpers (0.12.8.1)
       i18n (~> 0.6, >= 0.6.7)
@@ -245,4 +245,4 @@ DEPENDENCIES
   wikicloth
 
 BUNDLED WITH
-   1.13.6
+   1.13.7


### PR DESCRIPTION
Minimum changes I could find to have gems install properly on F26.

