### PR TITLE
Remove 'BUNDLED WITH' in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,6 +243,3 @@ DEPENDENCIES
   therubyracer
   wdm (~> 0.1.0)
   wikicloth
-
-BUNDLED WITH
-   1.13.7


### PR DESCRIPTION
Older bundler removes this information while doing a bundle install,
while this operation has no reason to tamper with this file. This in
turn causes problems when updating the repository on the web builder.
