### PR TITLE
Update home page with 4,1.6

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -52,8 +52,8 @@ hide_metadata: true
     :ruby
       # Rely on either a releases.yml or scan the release directory
       # (Hard-coding release version & date is temporary)
-      release_version = '4.1.5'
-      release_date = '2017-08-22'.to_date
+      release_version = '4.1.6'
+      release_date = '2017-09-18'.to_date
 
     :markdown
       {:.pull-left}


### PR DESCRIPTION
Changes proposed in this pull request:

- Update home page pointing to 4.1.6 released today

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola
