### PR TITLE
fix links to Gluster-Hyperconverged documentation

### DIFF
--- a/source/documentation/gluster-hyperconverged/Gluster_Hyperconverged_Guide.html.md
+++ b/source/documentation/gluster-hyperconverged/Gluster_Hyperconverged_Guide.html.md
@@ -4,14 +4,14 @@ title: oVirt-Gluster Hyperconvergence  Guide
 
 # oVirt-Gluster Hyperconvergence Guide
 
-## Chapter 1: [Introduction](../gluster-hyperconverged/chap-Introduction)
+## Chapter 1: [Introduction](../chap-Introduction)
 
-## Chapter 2: [Deploying oVirt and Gluster hyperconverged](../gluster-hyperconverged/chap-Deploying_Hyperconverged)
+## Chapter 2: [Deploying oVirt and Gluster hyperconverged](../chap-Deploying_Hyperconverged)
 
-## Chapter 3: [Additional Steps on the hyperconverged deployment](../gluster-hyperconverged/chap-Additional_Steps)
+## Chapter 3: [Additional Steps on the hyperconverged deployment](../chap-Additional_Steps)
 
-## Chapter 4: [Troubleshooting](../gluster-hyperconverged/chap-Troubleshooting)
+## Chapter 4: [Troubleshooting](../chap-Troubleshooting)
 
-## Chapter 5: [Maintenance and Upgrading Resources](../gluster-hyperconverged/chap-Maintenance_and_Upgrading_Resources)
+## Chapter 5: [Maintenance and Upgrading Resources](../chap-Maintenance_and_Upgrading_Resources)
 
 

--- a/source/documentation/gluster-hyperconverged/chap-Additional_Steps.html.md
+++ b/source/documentation/gluster-hyperconverged/chap-Additional_Steps.html.md
@@ -15,6 +15,6 @@ To outline, next steps would be:
 * Create ISO domain - you can use a new gluster volume to set this up.
 * [Optional] Configure disaster recovery
 
-**Prev:** [Chapter: Deploying oVirt and Gluster hyperconverged](../gluster-hyperconverged/chap-Deploying_Hyperconverged) <br/>
-**Next:** [Chapter: Troubleshooting](../gluster-hyperconverged/chap-Troubleshooting)
+**Prev:** [Chapter: Deploying oVirt and Gluster hyperconverged](../chap-Deploying_Hyperconverged) <br/>
+**Next:** [Chapter: Troubleshooting](../chap-Troubleshooting)
 

--- a/source/documentation/gluster-hyperconverged/chap-Deploying_Hyperconverged.html.md
+++ b/source/documentation/gluster-hyperconverged/chap-Deploying_Hyperconverged.html.md
@@ -42,7 +42,7 @@ Refer [oVirt Nodes](../install-guide/chap-oVirt_Nodes) for instructions on insta
 
 Steps for installing are detailed in this [blog post](/blog/2017/04/up-and-running-with-ovirt-4.1-and-gluster-storage/).
 
-**Prev:** [Chapter: Introduction](../gluster-hyperconverged/chap-Introduction) <br>
-**Next:** [Chapter: Additional Steps](../gluster-hyperconverged/chap-Additional_Steps)
+**Prev:** [Chapter: Introduction](../chap-Introduction) <br>
+**Next:** [Chapter: Additional Steps](../chap-Additional_Steps)
 
 

--- a/source/documentation/gluster-hyperconverged/chap-Introduction.html.md
+++ b/source/documentation/gluster-hyperconverged/chap-Introduction.html.md
@@ -19,4 +19,4 @@ A replica 3 stores/replicates copy of the data on 3 bricks, where each of the 3 
 
 For hardware requirements, see "Hypervisor Requirements" in the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
-**Next:** [Chapter: Deploying oVirt and Gluster Hyperconverged](../gluster-hyperconverged/chap-Deploying_Hyperconverged)
+**Next:** [Chapter: Deploying oVirt and Gluster Hyperconverged](../chap-Deploying_Hyperconverged)

--- a/source/documentation/gluster-hyperconverged/chap-Maintenance_and_Upgrading_Resources.html.md
+++ b/source/documentation/gluster-hyperconverged/chap-Maintenance_and_Upgrading_Resources.html.md
@@ -30,4 +30,4 @@ NOTE: If geo-replication is setup on the gluster volumes, the geo-replication ne
     * Once all bricks are replaces, the host can be moved to maintenance and removed.
 
 
-**Prev:** [Chapter: Troubleshooting](../gluster-hyperconverged/chap-Troubleshooting) <br>
+**Prev:** [Chapter: Troubleshooting](../chap-Troubleshooting) <br>

--- a/source/documentation/gluster-hyperconverged/chap-Troubleshooting.html.md
+++ b/source/documentation/gluster-hyperconverged/chap-Troubleshooting.html.md
@@ -74,5 +74,5 @@ If the state is other than `Peer in Cluster (Connected)` then there is an issue.
 
 Refer [Troubleshooting Self-Hosted Engine](../self-hosted/chap-Deploying_Self-Hosted_Engine)
 
-**Prev:** [Chapter: Additional Steps ](../gluster-hyperconverged/chap-Additional_Steps) <br/>
-**Next:** [Chapter: Maintenance and Upgrading Resources ](../gluster-hyperconverged/chap-Maintenance_and_Upgrading_Resources)
+**Prev:** [Chapter: Additional Steps ](../chap-Additional_Steps) <br/>
+**Next:** [Chapter: Maintenance and Upgrading Resources ](../chap-Maintenance_and_Upgrading_Resources)


### PR DESCRIPTION
Currently, links on the Gluster-hyperconverged page are broken:
https://www.ovirt.org/documentation/gluster-hyperconverged/Gluster_Hyperconverged_Guide/

This patch fixes links to make navigation between pages possible again.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @jekader

This pull request needs review by: @JohnMarksRH
