### PR TITLE
Remove references to oVirt Live

### DIFF
--- a/source/download/index.html.haml
+++ b/source/download/index.html.haml
@@ -22,9 +22,6 @@ authors: bproffitt, dneary, knesenko, mburns, sandrobonazzola, theron
 
     The preferred way to install oVirt is by using your operating system's package manager.
 
-    {:.alert.alert-warning}
-    If you are new to oVirt and would like an easy way to try oVirt, download our [Live version](/download/ovirt-live/) where you can use oVirt on CentOS without installing it on your machine.
-
     [See the oVirt Quickstart Guide for quick start information](/documentation/quickstart)
 
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Removed references to oVirt Live from download page: it's deprecated and partially broken in 4.1, removed in 4.2.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola

This pull request needs review by: @mykaul 
