### PR TITLE
update list of supported guest OSes

### DIFF
--- a/source/download/index.html.haml
+++ b/source/download/index.html.haml
@@ -147,7 +147,7 @@ authors: bproffitt, dneary, knesenko, mburns, sandrobonazzola, theron
   |Red Hat Enterprise Linux 4|32-bit, 64-bit||Yes|
   |Red Hat Enterprise Linux 5|32-bit, 64-bit||Yes|
   |Red Hat Enterprise Linux 6|32-bit, 64-bit||Yes|
-  |Red Hat Enterprise Linux 7|32-bit, 64-bit||Yes|
+  |Red Hat Enterprise Linux 7|64-bit||Yes|
   |SUSE Linux Enterprise Server 10 [1]|32-bit, 64-bit||No|
   |SUSE Linux Enterprise Server 11 [2]|32-bit, 64-bit||No|
   |Ubuntu 12.04 (Precise Pangolin LTS)|32-bit, 64-bit||Yes|
@@ -157,11 +157,13 @@ authors: bproffitt, dneary, knesenko, mburns, sandrobonazzola, theron
   |Windows XP Service Pack 3 and newer|32-bit||Yes|
   |Windows 7|32-bit, 64-bit||Yes|
   |Windows 8|32-bit, 64-bit||No|
+  |Windows 10|32-bit, 64-bit||No|
   |Windows Server 2003 Service Pack 2 and newer|32-bit, 64-bit||Yes|
   |Windows Server 2008|32-bit, 64-bit||Yes|
   |Windows Server 2008 R2|64-bit||Yes|
   |Windows Server 2012 R2|64-bit||No|
-
+  |Windows Server 2016|64-bit||No|
+  
   [1] select Other Linux for the guest type in the user interface<br/>
   [2] SPICE drivers (QXL) are not supplied by Red Hat. Distribution's vendor may provide SPICE drivers.
 


### PR DESCRIPTION
this patch updates the list of supported guest operating systems based on the list in the VM properties menu


Changes proposed in this pull request:

- RHEL7 - 32-bit removed as this version only comes as 64-bit

- added win10

- added win2k16

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @jekader

This pull request needs review by: @sandrobonazzola @JohnMarksRH 
