### PR TITLE
Update migrate-to-hosted-engine.html.md

### DIFF
--- a/source/develop/developer-guide/engine/migrate-to-hosted-engine.html.md
+++ b/source/develop/developer-guide/engine/migrate-to-hosted-engine.html.md
@@ -5,7 +5,7 @@ authors: didi
 
 # Migrate to Hosted Engine
 
-An example showing how to migrate an existing engine installation to [Self Hosted Engine](/develop/release-management/features/engine/self-hosted-engine/), using [backup/restore](/develop/release-management/features/engine/engine-backup/).
+An example showing how to migrate an existing engine installation to [Self Hosted Engine](/develop/release-management/features/sla/self-hosted-engine/), using [backup/restore](/develop/release-management/features/integration/engine-backup/).
 
 ## Preparations
 
@@ -193,7 +193,7 @@ Then restore the backup using a database we already created on another machine. 
 
       # engine-backup --mode=restore --file=backup1 --log=backup1-restore.log --change-db-credentials --db-host=didi-lap --db-user=engine --db-password --db-name=engine
 
-This will require manual preparation work of configuring postgresql and creating a user/database if using a local database, which is the default. For more details see [backup/restore](/develop/release-management/features/engine/engine-backup/).
+This will require manual preparation work of configuring postgresql and creating a user/database if using a local database, which is the default. For more details see [backup/restore](/develop/release-management/features/integration/engine-backup/).
 
 This restores files and the database, but still does not start the service nor does other stuff which is normally done by setup.
 


### PR DESCRIPTION
@sandrobonazzola  I corrected a couple of links on this page. 
Is the link at the bottom of the page correct?
That's it. If we now point a browser at https://my-engine.home.local/ovirt-engine/ , we can login to the web admin interface, and in addition to our existing data, we'll find also a host called 'hosted_engine_1' and a VM called 'HostedEngine'.

Fixes issue # (delete if not relevant)

Changes proposed in this pull request:

-

-

-

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @mention yourself to sign)

This pull request needs review by: (please @mention the reviewer if relevant)
