### PR TITLE
Move Plugin features to UX Category

### DIFF
--- a/source/develop/release-management/features/ux/plugins.html.md
+++ b/source/develop/release-management/features/ux/plugins.html.md
@@ -1,0 +1,70 @@
+---
+title: Plugins
+category: feature
+authors: jboggs
+---
+
+# Plugin Support
+
+## Summary
+
+This feature adds the ability to add additional functionality to the node
+
+## Owner
+
+*   Name: Joey Boggs (jboggs)
+*   Email: <jboggs@redhat.com>
+*   IRC: jboggs at #ovirt (irc.oftc.net)
+
+## Current status
+
+*   Completed:
+*   Completed: Moved SNMP functionality into a plugin (ovirt-node-plugin-snmp)
+*   In progress: Move CIM page to plugin
+*   Last updated: Oct. 23. 2012
+
+## Detailed Description
+
+Plugins extend functionality by adding in packages and methods to easily configure them.
+
+For example ovirt-node-plugin-snmp provides:
+
+      - auto-install
+      - setup pages after installation
+      - minimization
+
+*   /etc/ovirt-config-boot.d/snmp_autoinstall.py
+*   /etc/ovirt-plugins.d/snmp.minimize
+*   /usr/lib/python2.7/site-packages/ovirt_config_setup/snmp.py
+
+Auto installation scripts go into /etc/ovirt-config-boot.d and are run after the install completes
+
+Minimization configs are named /etc/ovirt-plugins.d/\*.minimize and run after the plugin is installed to the image
+
+Setup UI pages are placed into /usr/lib/python2.7/site-packages/ovirt_config_setup/
+
+To install a plugin:
+
+         edit-node --install-plugin=PLUGIN_PACKAGE_NAME --repo=plugins.repo ovirt-node-image.iso
+
+To view what plugins are installed by viewing available manifests:
+
+         edit-node --print-manifest ovirt-image.iso
+
+## Benefit to oVirt
+
+Ability to minimize to a core image and reduce space used
+
+Can add additional custom functionality to installer/setup
+
+Can customize the iso to add packages, set default passwords, public keys
+
+## Dependencies / Related Features
+
+livecd-tools
+
+## Documentation / External references
+
+TBD
+
+

--- a/source/develop/release-management/features/ux/uipluginsoriginaldesignnotes.html.md
+++ b/source/develop/release-management/features/ux/uipluginsoriginaldesignnotes.html.md
@@ -1,0 +1,37 @@
+---
+title: UIPluginsOriginalDesignNotes
+authors: vszocs
+---
+
+# UI Plugins Original Design Notes
+
+## WebAdmin UI plugin infrastructure
+
+*My notes on implementing 3rd party UI plugin infrastructure for WebAdmin GWT application.*
+
+### Create PluginManager class as GIN-managed eager singleton
+
+*   PluginManager will create and expose global "plugins" JavaScript object through JSNI.
+*   Initially, "plugins" object will be empty. 3rd party plugins will register themselves into this object when they're invoked by plugin infrastructure. This is very similar to how jQuery plugins work.
+
+Example plugin code (each plugin is represented by a piece of JavaScript):
+
+    plugins.myPlugin = {
+        // plugin life-cycle functions will go here
+    };
+
+*   PluginManager will invoke (evaluate) all 3rd party plugins. The global "plugins" object will now contain all registered plugins.
+*   For exposing WebAdmin classes (plugin API) to plugins (JavaScript code), gwt-exporter project will be used. See <http://code.google.com/p/gwt-exporter/wiki/GettingStarted>.
+
+### Define plugin life-cycle controlled by PluginManager
+
+*   PluginManager will invoke plugin life-cycle functions on registered plugins.
+*   Some ideas on life-cycle functions:
+    -   init - called right after invoking the plugin, allows the plugin to initialize itself before it's put to use (init function must return something to indicate that the plugin is ready)
+    -   handle - handles a specific application event, for example: VM in VM main tab has been selected, we're about to present context-sensitive menu, plugin might want to add its own context-sensitive menu item(s)
+    -   events - defines which application events (extension points) is the plugin interested in
+
+### Define automatic plugin discovery and loader architecture
+
+*   WebAdmin host page servlet can detect 3rd party plugins placed in some directory and include them into the final page. Alternatively, plugins can be detected and requested async after WebAdmin startup.
+*   Allow plugins to define their dependencies (other JavaScript libraries). For this purpose, plugin configuration (JSON or XML) file can be defined.


### PR DESCRIPTION
Changes proposed in this pull request:

- In line with plan to reorganize feature categories, the two plugin features have been moved under "UX"

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @jmarks

This pull request needs review by: (please @mykaul 
