### PR TITLE
Create hosted-engine-invalid-bond-modes.md

### DIFF
--- a/source/develop/developer-guide/engine/hosted-engine-invalid-bond-modes.md
+++ b/source/develop/developer-guide/engine/hosted-engine-invalid-bond-modes.md
@@ -1,0 +1,27 @@
+---
+title: Hosted-Engine invalid bond modes
+authors: Ido Rosenzwig
+---
+
+# Hosted-Engine invalid bond modes
+
+Some bond modes (0, 5, 6) cause problems in VM networks.
+Therefore, when the user has to select network device, during the Hosted-engine deployment,
+bonds that are configured in these modes cannot be selected.
+
+## Enable invalid bond modes
+
+If one wish to configure Hosted-Engine with unsupported bond mode, it can be done by doing the following:               
+ 
+1. create a config file e.g. /etc/ovirt-hosted-engine/my-config.conf with content:
+
+```
+[environment:default]
+OVEHOSTED_NETWORK/allowInvalidBondModes=bool:True
+```
+
+2. create a env file e.g. /etc/ovirt-hosted-engine-setup.env.d/my-env.conf with content:
+
+```
+environment="APPEND:CORE/configFileAppend=str:/etc/ovirt-hosted-engine/my-config.conf"
+```

--- a/source/develop/developer-guide/engine/hosted-engine-invalid-bond-modes.md
+++ b/source/develop/developer-guide/engine/hosted-engine-invalid-bond-modes.md
@@ -7,21 +7,30 @@ authors: Ido Rosenzwig
 
 Some bond modes (0, 5, 6) cause problems in VM networks.
 Therefore, when the user has to select network device, during the Hosted-engine deployment,
+in version 4.2 or later,
 bonds that are configured in these modes cannot be selected.
+
+See also: [BZ 1233127](https://bugzilla.redhat.com/1233127).
 
 ## Enable invalid bond modes
 
-If one wish to configure Hosted-Engine with unsupported bond mode, it can be done by doing the following:               
+If one wishes to enforce Hosted-Engine setup to allow unsupported bond modes, it can be done by doing the following:
  
-1. create a config file e.g. /etc/ovirt-hosted-engine/my-config.conf with content:
+1. Create a setup conf directory, if it does not already exist:
 
+```
+# mkdir -p /etc/ovirt-hosted-engine-setup.conf.d
+```
+
+2. Create a file in it, named e.g. 99-force-invalid-bond-modes.conf, with the following content:
 ```
 [environment:default]
 OVEHOSTED_NETWORK/allowInvalidBondModes=bool:True
 ```
 
-2. create a env file e.g. /etc/ovirt-hosted-engine-setup.env.d/my-env.conf with content:
+3. Run ```hosted-engine --deploy``` as usual.
 
+Alternatively, you can pass the option directly on the command line:
 ```
-environment="APPEND:CORE/configFileAppend=str:/etc/ovirt-hosted-engine/my-config.conf"
+# hosted-engine --otopi-environment=OVEHOSTED_NETWORK/allowInvalidBondModes=bool:True --deploy
 ```


### PR DESCRIPTION
Add documentation for using unsupported bond modes on Hosted-Engine setup
following a RFE : https://bugzilla.redhat.com/show_bug.cgi?id=1233127

This is based on PR #1135 .

Fixes issue # (delete if not relevant)

Changes proposed in this pull request:

-

-

-

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @mention yourself to sign)

This pull request needs review by: (please @mention the reviewer if relevant)
