### PR TITLE
SELinux labeling fix for container setup

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -4,4 +4,4 @@ DOCKERID=`cat .dockerid`
 
 echo "Running docker image $DOCKERID"
 
-docker run -u $UID -v $PWD:/opt/website -p 4567:4567 -it $DOCKERID $@
+docker run -u $UID -v $PWD:/opt/website:z -p 4567:4567 -it $DOCKERID $@


### PR DESCRIPTION
If selinux was enabled, volume defined in script docker-run.sh was
mounted but inaccessible. 'z' volume flag instructs docker to fix the
labeling.

Reference doc: https://docs.docker.com/engine/admin/volumes/bind-mounts/#configure-the-selinux-label
Details: https://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/

@garrett please review