### PR TITLE
Update home page pointing to 4.2.0 release

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -34,8 +34,8 @@ hide_metadata: true
     :ruby
       # Rely on either a releases.yml or scan the release directory
       # (Hard-coding release version & date is temporary)
-      release_version = '4.1.8'
-      release_date = '2017-12-11'.to_date
+      release_version = '4.2.0'
+      release_date = '2017-12-20'.to_date
 
     :markdown
       {:.pull-left}


### PR DESCRIPTION
Changes proposed in this pull request:

- Update home page pointing to 4.2.0 release

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola
