### PR TITLE
fix link for mailing list info

### DIFF
--- a/source/community/about/contact.html.md
+++ b/source/community/about/contact.html.md
@@ -6,7 +6,7 @@ authors: dneary, quaid, rbergeron, sandrobonazzola
 
 # Communication
 
-There are a number of ways to communicate with the oVirt Community. [ Mailing lists](#Mailing_lists), [ IRC](#IRC), our [bug tracker](https://bugzilla.redhat.com/enter_bug.cgi?classification=oVirt) and [our patch review system](http://gerrit.ovirt.org).
+There are a number of ways to communicate with the oVirt Community. [ Mailing lists](/community/about/mailing-lists/), [ IRC](#IRC), our [bug tracker](https://bugzilla.redhat.com/enter_bug.cgi?classification=oVirt) and [our patch review system](http://gerrit.ovirt.org).
 
 ## IRC
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Add link to official list of mailing lists related to oVirt


I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @mention yourself to sign) @sammcj
  
Helps #1228