### PR TITLE
Remove the header in certain pages that says: "X pages under...".

### DIFF
--- a/source/layouts/index.haml
+++ b/source/layouts/index.haml
@@ -7,14 +7,14 @@
   pages = sitemap.resources.select do |p|
     dirs.include?(p.source_file)
   end
-    
+
 ~ wrap_layout :layout do
   = yield
 
   - fallback_title = current_page.url.split('/').last.parameterize.titleize
 
-  %h1= "#{pages.count} pages under #{current_page.data.title || fallback_title}"
-  
+  %h1= "#{current_page.data.title || fallback_title}"
+
   %ul
     - pages.sort_by { |p| ( p.data[:title] || p.url.split('/').last.parameterize.titleize).downcase }.each do |p|
       - next if p.url == current_page.url


### PR DESCRIPTION
Remove the header in certain pages that says: "X pages under...". Those are not result pages, they contain ony list of other child pages - no need of search/result semantic
I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @eldan yourself to sign)

This pull request needs review by: (please @rollandf  the reviewer if relevant)