### PR TITLE
Added graceful shutdown and startup steps for gluster hyperconvergence

### DIFF
--- a/source/documentation/gluster-hyperconverged/chap-Maintenance_and_Upgrading_Resources.html.md
+++ b/source/documentation/gluster-hyperconverged/chap-Maintenance_and_Upgrading_Resources.html.md
@@ -29,5 +29,28 @@ NOTE: If geo-replication is setup on the gluster volumes, the geo-replication ne
     * Replace bricks from the host to be removed using the `Replace Brick` option
     * Once all bricks are replaces, the host can be moved to maintenance and removed.
 
+## Graceful shutdown and startup
+Currently there is no scirpt or single command available to shutdown a whole cluster. However, the following steps can be executed to manually shutdown and start a cluster again.
+
+### Shutdown
+1. Shutdown all VMs
+1. Enable global ha maintenance
+1. Wait for all VMs to be down
+1. If the cluster is running a hosted engine:
+   1. Logon to the node running hosted-engine
+   1. Shutdown hosted-engine using `hosted-engine --vm-shutdown`
+   1. Wait for stopped hosted engine using `hosted-engine --vm-status`
+1. Shutdown all nodes
+
+### Startup
+1. Switch on all nodes
+1. Start glusterd on all nodes since it does not start by default using `systemctl start glusterd`
+1. Check volume status using `gluster peer status` and `gluster volume status all` on one of the nodes
+1. Wait for ovrt-ha-agent until `hosted-engine --vm-status` does not fail anymore printing `The hosted engine configuration has not been retrieved from shared storage. Please ensure that ovirt-ha-agent is running and the storage server is reachable.`
+1. Start hosted engine `hosted-engine --vm-start` on one of the nodes
+1. Check status using `hosted-engine --vm-status` and wait until health reports to be good
+1. Wait until a node got the SPM role
+1. Disable global ha maintenance
+1. Start VMs
 
 **Prev:** [Chapter: Troubleshooting](../chap-Troubleshooting) <br>


### PR DESCRIPTION
Helpful documentation based on https://lists.ovirt.org/pipermail/users/2018-January/086065.html

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sinuswave