### PR TITLE
clean up hosted-engine upgrade how-to

### DIFF
--- a/source/documentation/how-to/hosted-engine.html.md
+++ b/source/documentation/how-to/hosted-engine.html.md
@@ -140,19 +140,7 @@ To resume HA functionality, use:
 
 ## **Upgrade Hosted Engine**
 
-Assuming you have already deployed Hosted Engine on your hosts and running the Hosted Engine VM, having the same oVirt version both on hosts and Hosted Engine VM.
-
-1.  Set hosted engine maintenance mode to global (now ha agent stop monitoring engine-vm, you can see above how to activate it)
-2.  Access to engine-vm and upgrade oVirt to latest version using the same procedure used for non hosted engine setups.
-3.  Select one of the hosted-engine nodes (hypervisors) and put it into maintenance mode from the engine. Note that the host must be in maintenance to allow upgrade to run.
-4.  Upgrade that host with new packages (changes repository to latest version and run yum update -y) on this stage may appear vdsm-tool exception <https://bugzilla.redhat.com/show_bug.cgi?id=1088805>
-5.  Restart vdsmd (# service vdsmd restart)
-6.  Restart ha-agent and broker services (# systemctl restart ovirt-ha-broker && systemctl restart ovirt-ha-agent)
-7.  Exit the global maintenance mode: in a few minutes the engine VM should migrate to the fresh upgraded host cause it will get an higher score
-8.  When the migration has been completed re-enter into global maintenance mode
-9.  Repeat step 3-6 for all the other hosted-engine hosts
-10. Enter for example via UI to engine and change 'Default' cluster (where all your hosted hosts seats) compatibility version to current version (for example 3.6 and activate your hosts (to get features of the new version)
-11. Change hosted-engine maintenance to none, starting from 3.4 you can do it via UI(right click on engine vm, and 'Disable Global HA Maintenance Mode')
+Please refer to [oVirt Upgrade Guide](/upgrade-guide/upgrade-guide/)
 
 ## **Hosted Engine Backup and Restore**
 

--- a/source/documentation/self-hosted/chap-Installing_Additional_Hosts_to_a_Self-Hosted_Environment.html.md
+++ b/source/documentation/self-hosted/chap-Installing_Additional_Hosts_to_a_Self-Hosted_Environment.html.md
@@ -38,5 +38,7 @@ Additional self-hosted engine hosts are added in the same way as a regular host,
 
 8. Click **OK**.
 
+_Note: To add the ability to deploy the Self-Hosted Engine on an existing host, you must select **Installation** and choose **Reinstall** on the host and repeat the above steps._
+
 **Prev:** [Chapter 6: Backing up and Restoring an EL-Based Self-Hosted Environment](../chap-Backing_up_and_Restoring_an_EL-Based_Self-Hosted_Environment) <br>
 **Next:** [Chapter 8: Migrating Databases](../chap-Migrating_Databases)

--- a/source/documentation/upgrade-guide/chap-Updates_between_Minor_Releases.html.md
+++ b/source/documentation/upgrade-guide/chap-Updates_between_Minor_Releases.html.md
@@ -8,9 +8,10 @@ title: Updates Between Minor Releases
 
 Updates to the oVirt Engine are released via the oVirt Project.
 
-Note: If you are using a [Self-Hosted Engine](/self-hosted/Self-Hosted_Engine_Guide/) this does not apply.
 
 **Updating oVirt Engine**
+
+Note: If you are using a [Self-Hosted Engine](/self-hosted/Self-Hosted_Engine_Guide/) this does not apply.
 
 1. On the oVirt Engine machine, check if updated packages are available:
 
@@ -66,45 +67,43 @@ The process for upgrading a [Self-Hosted Engine](/self-hosted/Self-Hosted_Engine
 
 The following assumes that you have already deployed the Hosted Engine on your hosts and the Hosted Engine VM is running the same oVirt version as the host(s).
 
-1.  Virtualization Host: Enable global maintenance mode from one of the hosts
-```
-host ~ # hosted-engine --set-maintenance --mode=global
-```
+1.  Virtualization Host: Update packages (you may need to changes repository to latest version or install the latest versions metapackage e.g. ovirt-release42-4.2.1 after ensuring the the host is in maintenance mode.)
 
-2.  Virtualization Host: Update packages (you may need to changes repository to latest version or install the latest versions metapackage e.g. ovirt-release42-4.2.1)
+    **Note:** If you are updating packages on a host, it's important to ensure the host is in maintenance mode first, which can be done from the command line or from the web UI.
+
 ```
 host ~ # yum update
 ```
 
-3.  Virtualization Host: Restart vdsmd
+2.  Virtualization Host: Restart vdsmd
 ```
 host ~ # systemctl restart vdsmd
 ```
 
-4.  Virtualization Host: Restart ha-agent and broker services
+3.  Virtualization Host: Restart ha-agent and broker services
 ```
 host ~ # systemctl restart ovirt-ha-broker && systemctl restart ovirt-ha-agent
 ```
 
-5.  Hosted-Engine-VM: Update packages
+4.  Hosted-Engine-VM: Update packages
 ```
-hosted-engine ~ # yum update
+hosted-engine ~ # yum update ovirt\*setup\*
 ```
 
-6.  Hosted-Engine-VM: Run engine-setup and follow the prompts
+5.  Hosted-Engine-VM: Run engine-setup and follow the prompts
 ```
 hosted-engine ~ # engine-setup
 ```
 
-7.  Host: Exit the global maintenance mode, after a few minutes the engine VM should migrate to the fresh upgraded host cause it will get an higher score.
+6.  Host: Exit the global maintenance mode, after a few minutes the engine VM should migrate to the fresh upgraded host cause it will get an higher score.
 ```
 host ~ #  hosted-engine --set-maintenance --mode=none
 ```
 
-8. Host: When the engine VM migration has been completed re-enter global maintenance mode
-9. Repeat step 3-6 for all the other hosted-engine hosts
-10. Via the web UI update the cluster compatibility version to current version (for example from 4.1 to 4.2) and activate your hosts
-11. Exit global maintenance mode
+7. Host: When the engine VM migration has been completed re-enter global maintenance mode
+8. Repeat step 3-6 for all the other hosted-engine hosts
+9. Via the web UI update the cluster compatibility version to current version (for example from 4.1 to 4.2) and activate your hosts
+10. Exit global maintenance mode
 
 Note: You can enter and exit maintenance mode it via the web UI (right click on engine vm, and 'Enable/Disable Global HA Maintenance Mode')
 

--- a/source/documentation/upgrade-guide/chap-Updates_between_Minor_Releases.html.md
+++ b/source/documentation/upgrade-guide/chap-Updates_between_Minor_Releases.html.md
@@ -8,6 +8,8 @@ title: Updates Between Minor Releases
 
 Updates to the oVirt Engine are released via the oVirt Project.
 
+Note: If you are using a [Self-Hosted Engine](/self-hosted/Self-Hosted_Engine_Guide/) this does not apply.
+
 **Updating oVirt Engine**
 
 1. On the oVirt Engine machine, check if updated packages are available:
@@ -57,6 +59,54 @@ Updates to the oVirt Engine are released via the oVirt Project.
         # engine-setup
 
 **Important:** The update process may take some time; allow time for the update process to complete and do not stop the process once initiated.
+
+## Updating the oVirt Self-Hosted Engine and Underlying Virtualization Host(s)
+
+The process for upgrading a [Self-Hosted Engine](/self-hosted/Self-Hosted_Engine_Guide/) is slightly different as the engine is running as a VM.
+
+The following assumes that you have already deployed the Hosted Engine on your hosts and the Hosted Engine VM is running the same oVirt version as the host(s).
+
+1.  Virtualization Host: Enable global maintenance mode from one of the hosts
+```
+host ~ # hosted-engine --set-maintenance --mode=global
+```
+
+2.  Virtualization Host: Update packages (you may need to changes repository to latest version or install the latest versions metapackage e.g. ovirt-release42-4.2.1)
+```
+host ~ # yum update
+```
+
+3.  Virtualization Host: Restart vdsmd
+```
+host ~ # systemctl restart vdsmd
+```
+
+4.  Virtualization Host: Restart ha-agent and broker services
+```
+host ~ # systemctl restart ovirt-ha-broker && systemctl restart ovirt-ha-agent
+```
+
+5.  Hosted-Engine-VM: Update packages
+```
+hosted-engine ~ # yum update
+```
+
+6.  Hosted-Engine-VM: Run engine-setup and follow the prompts
+```
+hosted-engine ~ # engine-setup
+```
+
+7.  Host: Exit the global maintenance mode, after a few minutes the engine VM should migrate to the fresh upgraded host cause it will get an higher score.
+```
+host ~ #  hosted-engine --set-maintenance --mode=none
+```
+
+8. Host: When the engine VM migration has been completed re-enter global maintenance mode
+9. Repeat step 3-6 for all the other hosted-engine hosts
+10. Via the web UI update the cluster compatibility version to current version (for example from 4.1 to 4.2) and activate your hosts
+11. Exit global maintenance mode
+
+Note: You can enter and exit maintenance mode it via the web UI (right click on engine vm, and 'Enable/Disable Global HA Maintenance Mode')
 
 ## Updating Virtualization Hosts
 


### PR DESCRIPTION
Changes proposed in this pull request:

 Clean up and clarify hosted-engine upgrade process

- Favour the main upgrade guide over an individual howto for the hosted-engine
- Add hosted-engine section to the upgrade guide
- Add link to upgrade guide from (legacy) how to
- Add missing step of running `engine-setup` within the hosted engine VM
- Clarify what commands are run on the host vs the hosted-engine VM
- Code quote commands
- Remove link referencing old bugs
- Cleanup formatting

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sammcj
