### PR TITLE
add note on adding self-hosted engine to already installed host

### DIFF
--- a/source/documentation/self-hosted/chap-Installing_Additional_Hosts_to_a_Self-Hosted_Environment.html.md
+++ b/source/documentation/self-hosted/chap-Installing_Additional_Hosts_to_a_Self-Hosted_Environment.html.md
@@ -38,5 +38,7 @@ Additional self-hosted engine hosts are added in the same way as a regular host,
 
 8. Click **OK**.
 
+_Note: To add the ability to deploy the Self-Hosted Engine on an existing host, you must select **Installation** and choose **Reinstall** on the host and repeat the above steps._
+
 **Prev:** [Chapter 6: Backing up and Restoring an EL-Based Self-Hosted Environment](../chap-Backing_up_and_Restoring_an_EL-Based_Self-Hosted_Environment) <br>
 **Next:** [Chapter 8: Migrating Databases](../chap-Migrating_Databases)


### PR DESCRIPTION
Changes proposed in this pull request:

- Add a note on the installing additional hosts page stating that you must reinstall oVirt via the web-UI if you wish to add the ability to run the self-hosted engine (e.g. if it wasn't selected when first installed).

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sammcj
