### PR TITLE
enable cockpit service by enabling cockpit.socket

### DIFF
--- a/source/documentation/how-to/hosted-engine.html.md
+++ b/source/documentation/how-to/hosted-engine.html.md
@@ -68,8 +68,8 @@ To deploy the self-hosted engine using the Cockpit user interface, follow these 
        
 2. Start and enable cockpit:
 
-        # systemctl enable cockpit
-        # systemctl start cockpit
+        # systemctl enable cockpit.socket
+        # systemctl start cockpit.socket
         
 3. Allow access to Cockpit in the firewall:
 


### PR DESCRIPTION
cockpit daemon is static so cannot be enabled, therefore enabling cockpit.socket instead

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @mention yourself to sign)

This pull request needs review by: (please @mention the reviewer if relevant)
@tiraboschi @sandrobonazzola 