### PR TITLE
remove URL magic in markdown_to_html()

### DIFF
--- a/lib/site_helpers.rb
+++ b/lib/site_helpers.rb
@@ -38,10 +38,6 @@ class SiteHelpers < Middleman::Extension
     def markdown_to_html(content)
       return unless content
 
-      if content.match(/https?:\/\//)
-        content.gsub!(/([^<])(https?:\/\/[^\s\)$]*)([^>])/, '\\1<\\2>\\3')
-      end
-
       Tilt['markdown'].new(config[:markdown]) { content.strip }.render
     end
 


### PR DESCRIPTION
The regex would probably never be perfect enough. This causes link
breakage, and hide problems or lack of proper formatting.

fixes #1503
