### PR TITLE
Update Documentation index

### DIFF
--- a/source/documentation/index.html.haml
+++ b/source/documentation/index.html.haml
@@ -2,7 +2,7 @@
 title: Documentation
 category: documentation
 layout: toc
-authors: dneary, metao, quaid
+authors: dneary, metao, quaid, sandrobonazzola
 ---
 
 
@@ -32,7 +32,6 @@ authors: dneary, metao, quaid
       - [Security](./security)
       - [SLA](./sla)
       - [Storage](./storage)
-      - [Drafts](./draft)
       - [Resources](./resources)
       - ***
       - ####[Looking for developer Documentation?](./../develop)


### PR DESCRIPTION
Fixes issue #1632

Changes proposed in this pull request:

- Dropped dangling link to  "Additional Documentation" -> "Drafts" 

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola

This pull request needs review by: @shaunix 
