### PR TITLE
Update Doc: Deploying oVirt and Gluster Hyperconverged. Add missing dependency installation step.

### DIFF
--- a/source/documentation/gluster-hyperconverged/chap-Deploying_Hyperconverged.html.md
+++ b/source/documentation/gluster-hyperconverged/chap-Deploying_Hyperconverged.html.md
@@ -20,18 +20,22 @@ title: Deploying oVirt and Gluster Hyperconverged
 
 **Installing the packages on the first host**
 
-1. On all 3 hosts, subscribe to ovirt repos from http://resources.ovirt.org/pub/yum-repo/
+1. On all 3 hosts, subscribe to ovirt repos from https://resources.ovirt.org/pub/yum-repo/
    For instance, to subscribe to oVirt 4.1 repo.
 
-        # yum install http://resources.ovirt.org/pub/yum-repo/ovirt-release41.rpm
+        # yum install https://resources.ovirt.org/pub/yum-repo/ovirt-release41.rpm
 
-2. On all 3 hosts, install gdeploy and cockpit-ovirt that will provide a UI for the installation. gdeploy is a wrapper tool around Ansible that helps to setup gluster volumes. vdsm-gluster is a plugin to manage gluster services.
-      
-        # yum install gdeploy cockpit-ovirt-dashboard vdsm-gluster 
+2. On all 3 hosts, install the following packages:
+      - cockpit-ovirt-dashboard (provides a UI for the installation)
+      - vdsm-gluster (plugin to manage gluster services)
 
-3. On the first host, install the oVirt Engine Virtual Appliance package for the Engine virtual machine installation:
+       # yum install cockpit-ovirt-dashboard vdsm-gluster 
 
-        # yum install ovirt-engine-appliance
+3. On the first host, install the following packages:
+      - ovirt-engine-appliance (for the Engine virtual machine installation)
+      - gdeploy (a wrapper tool around Ansible that helps to setup gluster volumes)
+ 
+       # yum install ovirt-engine-appliance gdeploy
 
 
         

--- a/source/documentation/gluster-hyperconverged/chap-Deploying_Hyperconverged.html.md
+++ b/source/documentation/gluster-hyperconverged/chap-Deploying_Hyperconverged.html.md
@@ -33,6 +33,10 @@ title: Deploying oVirt and Gluster Hyperconverged
 
         # yum install ovirt-engine-appliance
 
+4. Install the Gluster Plugin for VDSM.
+
+        # yum install vdsm-gluster     
+        
 ## Deploying on oVirt Node based Hosts
 
 **oVirt Node contains all the required packages to set up the hyperconverged environment.**

--- a/source/documentation/gluster-hyperconverged/chap-Deploying_Hyperconverged.html.md
+++ b/source/documentation/gluster-hyperconverged/chap-Deploying_Hyperconverged.html.md
@@ -20,22 +20,20 @@ title: Deploying oVirt and Gluster Hyperconverged
 
 **Installing the packages on the first host**
 
-1. Subscribe to ovirt repos from http://resources.ovirt.org/pub/yum-repo/
-   For instance, to subscribe to oVirt 4.1 repo,
+1. On all 3 hosts, subscribe to ovirt repos from http://resources.ovirt.org/pub/yum-repo/
+   For instance, to subscribe to oVirt 4.1 repo.
 
         # yum install http://resources.ovirt.org/pub/yum-repo/ovirt-release41.rpm
 
-2. Install gdeploy and cockpit-ovirt that will provide a UI for the installation. gdeploy is a wrapper tool around Ansible that helps to setup gluster volumes.
+2. On all 3 hosts, install gdeploy and cockpit-ovirt that will provide a UI for the installation. gdeploy is a wrapper tool around Ansible that helps to setup gluster volumes. vdsm-gluster is a plugin to manage gluster services.
       
-        # yum install gdeploy cockpit-ovirt-dashboard
+        # yum install gdeploy cockpit-ovirt-dashboard vdsm-gluster 
 
-3. Install the oVirt Engine Virtual Appliance package for the Engine virtual machine installation:
+3. On the first host, install the oVirt Engine Virtual Appliance package for the Engine virtual machine installation:
 
         # yum install ovirt-engine-appliance
 
-4. Install the Gluster Plugin for VDSM.
 
-        # yum install vdsm-gluster     
         
 ## Deploying on oVirt Node based Hosts
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Add a step indicating that gluster-vdsm has to be installed on enterprise linux hosts.



I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @rohantmp

This pull request needs review by: @sabose 