### PR TITLE
Add instruction to install ovirt repo

### DIFF
--- a/source/documentation/self-hosted/chap-Deploying_Self-Hosted_Engine.html.md
+++ b/source/documentation/self-hosted/chap-Deploying_Self-Hosted_Engine.html.md
@@ -10,11 +10,15 @@ title: Deploying Self-Hosted Engine
 
 **Installing the Self-Hosted Engine**
 
-1. Install the self-hosted engine packages:
+1. Add the official oVirt repository
+
+        # sudo yum install http://resources.ovirt.org/pub/yum-repo/ovirt-release42.rpm
+
+2. Install the self-hosted engine packages:
 
         # yum install ovirt-hosted-engine-setup
 
-2. Install the oVirt Engine Virtual Appliance package for the Engine virtual machine installation:
+3. Install the oVirt Engine Virtual Appliance package for the Engine virtual machine installation:
 
         # yum install ovirt-engine-appliance
 


### PR DESCRIPTION
Add a missing instruction to install ovirt repo prior to install ovirt-hosted-engine-setup

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @mention yourself to sign)

This pull request needs review by: (please @mention the reviewer if relevant)
@sandrobonazzola  @tiraboschi 