### PR TITLE
SSL for install instructions (was #1626)

### DIFF
--- a/source/download/index.html.haml
+++ b/source/download/index.html.haml
@@ -88,7 +88,7 @@ authors: bproffitt, dneary, knesenko, mburns, sandrobonazzola, theron
   you have the correct repositories enabled by running the following commands before upgrading with the usual procedure.
   <br/>
   ```
-  # yum install http://resources.ovirt.org/pub/yum-repo/ovirt-release42.rpm
+  # yum install https://resources.ovirt.org/pub/yum-repo/ovirt-release42.rpm
   ```
   <br/><br/>
   You should also read the [Release Notes for oVirt 4.2.4.](/release/4.2.4/)
@@ -115,7 +115,7 @@ authors: bproffitt, dneary, knesenko, mburns, sandrobonazzola, theron
 
   2.  Add the official oVirt repository.
 
-          sudo yum install http://resources.ovirt.org/pub/yum-repo/ovirt-release42.rpm
+          sudo yum install https://resources.ovirt.org/pub/yum-repo/ovirt-release42.rpm
 
       -   This will add repositories from ovirt.org to your host allowing you to get the latest oVirt rpms.
       -   It will also enable any other needed repository
@@ -177,30 +177,30 @@ authors: bproffitt, dneary, knesenko, mburns, sandrobonazzola, theron
 :markdown
   ## Version Releases of oVirt
 
-  -   [ovirt-4.2](http://resources.ovirt.org/pub/ovirt-4.2/) **Recommended**
+  -   [ovirt-4.2](https://resources.ovirt.org/pub/ovirt-4.2/) **Recommended**
   
   ### Older unsupported version releases of oVirt
   
-  -   [ovirt-4.1](http://resources.ovirt.org/pub/ovirt-4.1/)
-  -   [ovirt-4.0](http://resources.ovirt.org/pub/ovirt-4.0/)
-  -   [ovirt-3.6](http://resources.ovirt.org/pub/ovirt-3.6/)
-  -   [ovirt-3.5](http://resources.ovirt.org/pub/ovirt-3.5/)
-  -   [ovirt-3.4](http://resources.ovirt.org/pub/ovirt-3.4/)
-  -   [ovirt-3.3](http://resources.ovirt.org/pub/ovirt-3.3/)
+  -   [ovirt-4.1](https://resources.ovirt.org/pub/ovirt-4.1/)
+  -   [ovirt-4.0](https://resources.ovirt.org/pub/ovirt-4.0/)
+  -   [ovirt-3.6](https://resources.ovirt.org/pub/ovirt-3.6/)
+  -   [ovirt-3.5](https://resources.ovirt.org/pub/ovirt-3.5/)
+  -   [ovirt-3.4](https://resources.ovirt.org/pub/ovirt-3.4/)
+  -   [ovirt-3.3](https://resources.ovirt.org/pub/ovirt-3.3/)
   
   ### Nightly builds of oVirt
   
-  -   [ovirt-4.3 Nightly](http://resources.ovirt.org/pub/ovirt-master-snapshot)
-  -   [ovirt-4.2 Nightly](http://resources.ovirt.org/pub/ovirt-4.2-snapshot)
+  -   [ovirt-4.3 Nightly](https://resources.ovirt.org/pub/ovirt-master-snapshot)
+  -   [ovirt-4.2 Nightly](https://resources.ovirt.org/pub/ovirt-4.2-snapshot)
 
   ## Mirrors for oVirt Downloads
 
   ### Europe
 
-  - [NLUUG](http://ftp.nluug.nl/os/Linux/virtual/ovirt/) (
-  [oVirt 4.2](http://ftp.nluug.nl/os/Linux/virtual/ovirt/ovirt-4.2/)
-  [oVirt 4.1](http://ftp.nluug.nl/os/Linux/virtual/ovirt/ovirt-4.1/)
-  [oVirt 4.0](http://ftp.nluug.nl/os/Linux/virtual/ovirt/ovirt-4.0/)
+  - [NLUUG](https://ftp.nluug.nl/os/Linux/virtual/ovirt/) (
+  [oVirt 4.2](https://ftp.nluug.nl/os/Linux/virtual/ovirt/ovirt-4.2/)
+  [oVirt 4.1](https://ftp.nluug.nl/os/Linux/virtual/ovirt/ovirt-4.1/)
+  [oVirt 4.0](https://ftp.nluug.nl/os/Linux/virtual/ovirt/ovirt-4.0/)
   [oVirt 4.2 Development Nightly](http://ftp.nluug.nl/os/Linux/virtual/ovirt/ovirt-master-snapshot/))
   - [Plus.line AG](http://www.plusline.net/en/) (
   [oVirt 4.2](http://ftp.plusline.net/ovirt/ovirt-4.2/)
@@ -265,7 +265,7 @@ authors: bproffitt, dneary, knesenko, mburns, sandrobonazzola, theron
 
   Importing keys Automatically
 
-      yum install http://resources.ovirt.org/pub/yum-repo/ovirt-release42.rpm
+      yum install https://resources.ovirt.org/pub/yum-repo/ovirt-release42.rpm
 
   **Important:** yum will prompt sysadmin to acknowledge import of key, make sure key id is FE590CB7.
 


### PR DESCRIPTION
SSL everywhere is a good idea overall, but is a MUST condition for installation instructions to use sudo to install packages.

While we're at it, might as well update all the links to good ol' resources.ovirt.org .

I recommend updating the other links for the mirrors, but did not find a viable HTTPS endpoint (I didn't look further than to attempt to load the page as https://). The mirrors that did have a valid HTTPS endpoint were updated in this PR. Perhaps you can request your mirror providers to use an SSL certificate now that e.g. Let's Encrypt is ubiquitous, useful, automatable, etc.

Changes proposed in this pull request:

Modify project URLs to use HTTPS

Modify mirror URLs to use HTTPS where available

I confirm that this pull request was submitted according to the contribution guidelines: @quaid