### PR TITLE
Escape quotes

### DIFF
--- a/source/develop/developer-guide/engine/engine-development-environment.html.md
+++ b/source/develop/developer-guide/engine/engine-development-environment.html.md
@@ -133,7 +133,7 @@ Note: javassit used in some of the unit tests hits a regression introduced in ja
 
         su - postgres -c "psql -d template1 -c \"create user engine password 'engine';\""
         su - postgres -c "psql -d template1 -c \"create database engine owner engine template template0 encoding 'UTF8' lc_collate 'en_US.UTF-8' lc_ctype 'en_US.UTF-8';\""
-        su - postgres -c "psql -d template1 -c \"CREATE EXTENSION "uuid-ossp";\""
+        su - postgres -c "psql -d template1 -c \"CREATE EXTENSION \\\"uuid-ossp\\\";\""
 
 ### Source
 


### PR DESCRIPTION
Changes proposed in this pull request:
- escape quotes so that command can be copy-pasted directly into cmd line

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @mention yourself to sign)
@vjuranek
