### PR TITLE
Fixed outdated link to downstream RH content.

### DIFF
--- a/data/authors.yml
+++ b/data/authors.yml
@@ -2708,3 +2708,8 @@ maiqueb:
   name: Miguel Duarte Barroso
   email: mdbarroso@redhat.com
 
+crutonjohn:
+  name: Curtis Ray John
+  email: cujo0224@gmail.com
+  gravatar: fb9d43da7d8c95ccdcd36b82eb2d81ae
+  

--- a/source/documentation/upgrade-guide/chap-Updates_between_Minor_Releases.html.md
+++ b/source/documentation/upgrade-guide/chap-Updates_between_Minor_Releases.html.md
@@ -130,4 +130,4 @@ The oVirt Project recommends updating the hosts from the Engine; however, you ca
 **Prev:** [Chapter 8: Post-Upgrade Tasks](../chap-Post-Upgrade_Tasks/)<br>
 **Next:** [Appendix A: Updating an Offline oVirt Engine](../appe-Updating_an_Offline_oVirt_Engine/)
 
-[Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/upgrade_guide/chap-updates_between_minor_releases)
+[Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/upgrade_guide/updates_between_minor_releases)


### PR DESCRIPTION
Changes proposed in this pull request:

- Fixed broken link to downstream Red Hat link: https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/upgrade_guide/updates_between_minor_releases

- Added myself as author

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @crutonjohn

This pull request needs review by:
