### PR TITLE
Update obsolete sanlock link

### DIFF
--- a/source/develop/developer-guide/vdsm/sanlock.html.md
+++ b/source/develop/developer-guide/vdsm/sanlock.html.md
@@ -24,8 +24,7 @@ For more information, see
 
 *   sanlock(8)
 *   wdmd(8)
-*   <https://fedorahosted.org/sanlock/>
-*   <https://fedorahosted.org/sanlock/wiki/wdmd>
+*   <https://pagure.io/sanlock/blob/master/f/README.mk>
 
 ## VDSM And SANLock
 


### PR DESCRIPTION
Changes proposed in this pull request:

- update obsolete sanlock link

- remove wdmd link as wdmd info is part of newly linked sanlock README

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @vjuranek 
