### PR TITLE
remove pretty URLs for some paths

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -86,9 +86,6 @@ with_layout :post do
   page '/blog/*'
 end
 
-# Make pretty URLs
-activate :directory_indexes
-
 ###
 # Compass
 ###

--- a/source/.htaccess.haml
+++ b/source/.htaccess.haml
@@ -335,18 +335,14 @@ directory_index: false
   # comment it out and use `Options +SymLinksOfOwnerMatch`, but be aware of the
   # performance impact: http://goo.gl/Mluzd
 
-  <IfModule mod_rewrite.c>
-    Options +FollowSymlinks
-  # Options +SymLinksIfOwnerMatch
-    RewriteEngine On
-  # RewriteBase /
-  </IfModule>
+  Options +FollowSymlinks
+  RewriteEngine On
 
-
-  # add trailing slash to dirs if missing
-  # RewriteCond %{REQUEST_FILENAME} !-f
-  # RewriteCond %{REQUEST_URI} !(.*)/$
-  # RewriteRule ^(.*)$ http://ovirt.org/$1/ [R=301,L]
+  # add .html
+  RewriteCond %{REQUEST_URI} !^/$
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME}.html -f
+  RewriteRule ^(.*?)(/*)$ /$1.html [R=301,L]
 
 
   # ----------------------------------------------------------------------

--- a/source/documentation/admin-guide/administration-guide.html.md
+++ b/source/documentation/admin-guide/administration-guide.html.md
@@ -24,64 +24,64 @@ The oVirt environment requires an administrator to keep it running. As an admini
 
 ## Part I: Administering and Maintaining the oVirt Environment
 
-### Chapter 1: [Global Configuration](../chap-Global_Configuration)
+### Chapter 1: [Global Configuration](chap-Global_Configuration)
 
-### Chapter 2: [Dashboard](../chap-System_Dashboard)
+### Chapter 2: [Dashboard](chap-System_Dashboard)
 
 ## Part II: Administering the Resources
 
-### Chapter 3: [Quality of Service](../chap-Quality_of_Service)
+### Chapter 3: [Quality of Service](chap-Quality_of_Service)
 
-### Chapter 4: [Data Centers](../chap-Data_Centers)
+### Chapter 4: [Data Centers](chap-Data_Centers)
 
-### Chapter 5: [Clusters](../chap-Clusters)
+### Chapter 5: [Clusters](chap-Clusters)
 
-### Chapter 6: [Logical Networks](../chap-Logical_Networks)
+### Chapter 6: [Logical Networks](chap-Logical_Networks)
 
-### Chapter 7: [Hosts](../chap-Hosts)
+### Chapter 7: [Hosts](chap-Hosts)
 
-### Chapter 8: [Storage](../chap-Storage)
+### Chapter 8: [Storage](chap-Storage)
 
-### Chapter 9:  [Pools](../chap-Pools)
+### Chapter 9:  [Pools](chap-Pools)
 
-### Chapter 10: [Virtual Disks](../chap-Virtual_Machine_Disks)
+### Chapter 10: [Virtual Disks](chap-Virtual_Machine_Disks)
 
-### Chapter 11: [External Providers](../chap-External_Providers)
+### Chapter 11: [External Providers](chap-External_Providers)
 
 ## Part III: Administering the Environment
 
-### Chapter 12: [Backups and Migration](../chap-Backups_and_Migration)
+### Chapter 12: [Backups and Migration](chap-Backups_and_Migration)
 
-### Chapter 13: [Errata Management with Foreman](../chap-Errata_Management_with_Foreman)
+### Chapter 13: [Errata Management with Foreman](chap-Errata_Management_with_Foreman)
 
-### Chapter 14: [Automating Configuration Tasks Using Ansible](../chap-Automating_Configuration_Tasks_Using_Ansible)
+### Chapter 14: [Automating Configuration Tasks Using Ansible](chap-Automating_Configuration_Tasks_Using_Ansible)
 
-### Chapter 15: [Users and Roles](../chap-Users_and_Roles)
+### Chapter 15: [Users and Roles](chap-Users_and_Roles)
 
-### Chapter 16: [Quotas and Service Level Agreement Policy](../chap-Quotas_and_Service_Level_Agreement_Policy)
+### Chapter 16: [Quotas and Service Level Agreement Policy](chap-Quotas_and_Service_Level_Agreement_Policy)
 
-### Chapter 17: [Event Notifications](../chap-Event_Notifications)
+### Chapter 17: [Event Notifications](chap-Event_Notifications)
 
-### Chapter 18: [Utilities](../chap-Utilities)
+### Chapter 18: [Utilities](chap-Utilities)
 
 ## Part IV: Gathering Information About the Environment
 
-### Chapter 19: [Log Files](../chap-Log_Files)
+### Chapter 19: [Log Files](chap-Log_Files)
 
-### Chapter 20: [Proxies](../chap-Proxies)
+### Chapter 20: [Proxies](chap-Proxies)
 
 ## Part V: Appendixes
 
-### Appendix A: [VDSM and Hooks](../appe-VDSM_and_Hooks)
+### Appendix A: [VDSM and Hooks](appe-VDSM_and_Hooks)
 
-### Appendix B: [Custom Network Properties](../appe-Custom_Network_Properties)
+### Appendix B: [Custom Network Properties](appe-Custom_Network_Properties)
 
-### Appendix C: [oVirt User Interface Plugins](../appe-oVirt_User_Interface_Plugins)
+### Appendix C: [oVirt User Interface Plugins](appe-oVirt_User_Interface_Plugins)
 
-### Appendix D: [oVirt and SSL](../appe-oVirt_and_SSL)
+### Appendix D: [oVirt and SSL](appe-oVirt_and_SSL)
 
-### Appendix E: [Branding](../appe-Branding)
+### Appendix E: [Branding](appe-Branding)
 
-### Appendix F: [System Accounts](../appe-System_Accounts)
+### Appendix F: [System Accounts](appe-System_Accounts)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/part-administering_and_maintaining_the_red_hat_virtualization_environment)2

--- a/source/documentation/admin-guide/appe-Branding.html.md
+++ b/source/documentation/admin-guide/appe-Branding.html.md
@@ -112,7 +112,7 @@ The Page Not Found page is a page that is displayed when you open a link to a pa
 
 The classes for the Page Not Found page are located in **welcome_style.css**.
 
-**Prev:** [Appendix D: oVirt and SSL](../appe-oVirt_and_SSL)<br>
-**Next:** [Appendix F: System Accounts](../appe-System_Accounts)
+**Prev:** [Appendix D: oVirt and SSL](appe-oVirt_and_SSL)<br>
+**Next:** [Appendix F: System Accounts](appe-System_Accounts)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/appe-branding)

--- a/source/documentation/admin-guide/appe-Custom_Network_Properties.html.md
+++ b/source/documentation/admin-guide/appe-Custom_Network_Properties.html.md
@@ -76,7 +76,7 @@ You also need to install the required VDSM hook package on the hosts. Depending 
 
 The **fcoe** key is now available in the Administration Portal. See [Editing host network interfaces](Editing_host_network_interfaces) to apply FCoE properties to logical networks.
 
-**Prev:** [Appendix A: VDSM and Hooks](../appe-VDSM_and_Hooks)<br>
-**Next:** [Appendix C: oVirt User Interface Plugins](../appe-oVirt_User_Interface_Plugins)
+**Prev:** [Appendix A: VDSM and Hooks](appe-VDSM_and_Hooks)<br>
+**Next:** [Appendix C: oVirt User Interface Plugins](appe-oVirt_User_Interface_Plugins)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/appe-custom_network_properties)

--- a/source/documentation/admin-guide/appe-System_Accounts.html.md
+++ b/source/documentation/admin-guide/appe-System_Accounts.html.md
@@ -70,6 +70,6 @@ A number of system user groups are created on the virtualization host when the *
 
     If UID `36` or GID `36` is already used by another account on the system a conflict will arise during installation of the `vdsm` and `qemu-kvm-rhev` packages.
 
-**Prev:** [Appendix E: Branding](../appe-Branding)
+**Prev:** [Appendix E: Branding](appe-Branding)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/appe-system_accounts)

--- a/source/documentation/admin-guide/appe-Using_Search_Bookmarks_and_Tags.html.md
+++ b/source/documentation/admin-guide/appe-Using_Search_Bookmarks_and_Tags.html.md
@@ -768,5 +768,5 @@ The specified tag is now added or removed as a custom property of the selected o
 
 The objects tagged with the specified criteria are listed in the results list.
 
-**Prev:** [Appendix D: oVirt and SSL](../appe-oVirt_and_SSL)<br>
-**Next:** [Appendix F: Branding](../appe-Branding)
+**Prev:** [Appendix D: oVirt and SSL](appe-oVirt_and_SSL)<br>
+**Next:** [Appendix F: Branding](appe-Branding)

--- a/source/documentation/admin-guide/appe-VDSM_and_Hooks.html.md
+++ b/source/documentation/admin-guide/appe-VDSM_and_Hooks.html.md
@@ -314,7 +314,7 @@ The regular expression used allows the `numaset` custom property for a given vir
             sys.stderr.write('numa: [unexpected error]: %s\n' % traceback.format_exc())
             sys.exit(2)
 
-**Prev:** [Chapter 20: Proxies](../chap-Proxies)<br>
-**Next:** [Appendix B: Custom Network Properties](../appe-Custom_Network_Properties)
+**Prev:** [Chapter 20: Proxies](chap-Proxies)<br>
+**Next:** [Appendix B: Custom Network Properties](appe-Custom_Network_Properties)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/appe-vdsm_and_hooks)

--- a/source/documentation/admin-guide/appe-oVirt_User_Interface_Plugins.html.md
+++ b/source/documentation/admin-guide/appe-oVirt_User_Interface_Plugins.html.md
@@ -119,7 +119,7 @@ If you have successfully implemented the `Hello World!` plug-in, you will see th
 
 ![](/images/admin-guide/1475.png)
 
-**Prev:** [Appendix B: Custom Network Properties](../appe-Custom_Network_Properties)<br>
-**Next:** [Appendix D: oVirt and SSL](../appe-oVirt_and_SSL)
+**Prev:** [Appendix B: Custom Network Properties](appe-Custom_Network_Properties)<br>
+**Next:** [Appendix D: oVirt and SSL](appe-oVirt_and_SSL)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/appe-red_hat_enterprise_virtualization_user_interface_plugins)

--- a/source/documentation/admin-guide/appe-oVirt_and_SSL.html.md
+++ b/source/documentation/admin-guide/appe-oVirt_and_SSL.html.md
@@ -134,7 +134,7 @@ To set up a secure connection between the oVirt Engine and an LDAP server, obtai
 
 To continue configuring an external LDAP provider, see [Configuring an External LDAP Provider](Configuring_an_External_LDAP_Provider). To continue configuring LDAP and Kerberos for Single Sign-on, see [Configuring LDAP and Kerberos for Single Sign-on](Configuring_LDAP_and_Kerberos_for_Single_Sign-on).
 
-**Prev:** [Appendix C: oVirt User Interface Plugins](../appe-oVirt_User_Interface_Plugins)<br>
-**Next:** [Appendix E: Branding](../appe-Branding)
+**Prev:** [Appendix C: oVirt User Interface Plugins](appe-oVirt_User_Interface_Plugins)<br>
+**Next:** [Appendix E: Branding](appe-Branding)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/appe-red_hat_enterprise_virtualization_and_ssl)

--- a/source/documentation/admin-guide/chap-Automating_Configuration_Tasks_Using_Ansible.html.md
+++ b/source/documentation/admin-guide/chap-Automating_Configuration_Tasks_Using_Ansible.html.md
@@ -125,7 +125,7 @@ The following procedure guides you through creating and running a playbook that 
 
 You have successfully used the `ovirt-datacenters` Ansible role to create a data center named `mydatacenter`.
 
-**Prev:** [Chapter 13: Backups and Migration](../chap-Backups_and_Migration)<br>
-**Next:** [Chapter 15: Users and Roles](../chap-Users_and_Roles)
+**Prev:** [Chapter 13: Backups and Migration](chap-Backups_and_Migration)<br>
+**Next:** [Chapter 15: Users and Roles](chap-Users_and_Roles)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-automating_rhv_configuration_using_ansible)

--- a/source/documentation/admin-guide/chap-Backups_and_Migration.html.md
+++ b/source/documentation/admin-guide/chap-Backups_and_Migration.html.md
@@ -41,7 +41,7 @@ These two modes are further extended by a set of parameters that allow you to sp
 The following options are only available when using the `engine-backup` command in `restore` mode. The option syntax below applies to restoring the Engine database. The same options exist for restoring the Data Warehouse database. See `engine-backup --help` for the Data Warehouse option syntax.
 
 `--provision-db`
-: Creates a PostgreSQL database for the Engine database backup to be restored to. This is a required parameter when restoring a backup on a remote host or fresh installation that does not have a PostgreSQL database already configured.  
+: Creates a PostgreSQL database for the Engine database backup to be restored to. This is a required parameter when restoring a backup on a remote host or fresh installation that does not have a PostgreSQL database already configured.
 
 `--change-db-credentials`
 : Allows you to specify alternate credentials for restoring the Engine database using credentials other than those stored in the backup itself. See `engine-backup --help` for the additional parameters required by this parameter.
@@ -378,7 +378,7 @@ Restore a virtual machine that has been backed up using the backup and restore A
 
 You have restored a virtual machine using a backup that was created using the backup and restore API.
 
-**Prev:** [Chapter 11: External Providers](../chap-External_Providers)<br>
-**Next:** [Chapter 13: Errata Management with Foreman](../chap-Errata_Management_with_Foreman)
+**Prev:** [Chapter 11: External Providers](chap-External_Providers)<br>
+**Next:** [Chapter 13: Errata Management with Foreman](chap-Errata_Management_with_Foreman)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-backups_and_migration)

--- a/source/documentation/admin-guide/chap-Clusters.html.md
+++ b/source/documentation/admin-guide/chap-Clusters.html.md
@@ -687,7 +687,7 @@ You have updated the compatibility version of the cluster. Once you have updated
 
     **Important:** An error message may warn that some virtual machines and templates are incorrectly configured. To fix this error, edit each virtual machine manually. The **Edit Virtual Machine** window provides additional validations and warnings that show what to correct. Sometimes the issue is automatically corrected and the virtual machine’s configuration just needs to be saved again. After editing each virtual machine, you will be able to change the cluster compatibility version.
 
-**Prev:** [Chapter 4: Data Centers](../chap-Data_Centers)<br>
-**Next:** [Chapter 6: Logical Networks](../chap-Logical_Networks)
+**Prev:** [Chapter 4: Data Centers](chap-Data_Centers)<br>
+**Next:** [Chapter 6: Logical Networks](chap-Logical_Networks)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-clusters)

--- a/source/documentation/admin-guide/chap-Data_Centers.html.md
+++ b/source/documentation/admin-guide/chap-Data_Centers.html.md
@@ -312,7 +312,7 @@ Data, such as virtual machines and templates, remains attached to the storage do
 
 You have detached the storage domain from the data center. It can take up to several minutes for the storage domain to disappear from the details pane.
 
-**Prev:** [Chapter 3: Quality of Service](../chap-Quality_of_Service)<br>
-**Next:** [Chapter 5: Clusters](../chap-Clusters)
+**Prev:** [Chapter 3: Quality of Service](chap-Quality_of_Service)<br>
+**Next:** [Chapter 5: Clusters](chap-Clusters)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-data_centers)

--- a/source/documentation/admin-guide/chap-Errata_Management_with_Foreman.html.md
+++ b/source/documentation/admin-guide/chap-Errata_Management_with_Foreman.html.md
@@ -32,7 +32,7 @@ To associate a Engine, host, and virtual machine with a Foreman provider first t
 
 For more information on viewing available errata for hosts see [Viewing Host Errata](Viewing_Host_Errata) and for virtual machines see "Viewing Red Hat Satellite Errata for a Virtual Machine" in the [Virtual Machine Management Guide](/documentation/vmm-guide/Virtual_Machine_Management_Guide/).
 
-**Prev:** [Chapter 12: Backups and Migration](../chap-Backups_and_Migration)<br>
-**Next:** [Chapter 14: Automating Configuration Tasks Using Ansible](../chap-Automating_Configuration_Tasks_Using_Ansible)
+**Prev:** [Chapter 12: Backups and Migration](chap-Backups_and_Migration)<br>
+**Next:** [Chapter 14: Automating Configuration Tasks Using Ansible](chap-Automating_Configuration_Tasks_Using_Ansible)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-errata_management_with_satellite)

--- a/source/documentation/admin-guide/chap-Event_Notifications.html.md
+++ b/source/documentation/admin-guide/chap-Event_Notifications.html.md
@@ -24,7 +24,7 @@ The oVirt Engine can notify designated users via email when specific events occu
 
 7. Enter an email address in the **Mail Recipient** field.
 
-    **Note:** The email address can be a text message email address (for example, 1234567890@carrierdomainname.com) or an email group address that includes email addresses and text message email addresses.   
+    **Note:** The email address can be a text message email address (for example, 1234567890@carrierdomainname.com) or an email group address that includes email addresses and text message email addresses.
 
 8. Click **OK**.
 
@@ -215,7 +215,7 @@ Check your SNMP manager to ensure that traps are being received.
 
 **Note:** `SNMP_MANAGERS`, `MAIL_SERVER`, or both must be properly defined in `/usr/share/ovirt-engine/services/ovirt-engine-notifier/ovirt-engine-notifier.conf ` or in an override file in order for the notifier service to run.
 
-**Prev:** [Chapter 16: Quotas and Service Level Agreement Policy](../chap-Quotas_and_Service_Level_Agreement_Policy)<br>
-**Next:** [Chapter 18: Utilities](../chap-Utilities)
+**Prev:** [Chapter 16: Quotas and Service Level Agreement Policy](chap-Quotas_and_Service_Level_Agreement_Policy)<br>
+**Next:** [Chapter 18: Utilities](chap-Utilities)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-event_notifications)

--- a/source/documentation/admin-guide/chap-External_Providers.html.md
+++ b/source/documentation/admin-guide/chap-External_Providers.html.md
@@ -495,11 +495,11 @@ If these packages are not available from the repositories already enabled on the
 
 11. Click **OK**.
 
-12. Create a new cluster that uses OVN as its default network provider. See “Creating a New Cluster” in [Chapter 5: Clusters](../chap-Clusters) and select the OVN network provider from the **Default Network Provider** drop-down list.
+12. Create a new cluster that uses OVN as its default network provider. See “Creating a New Cluster” in [Chapter 5: Clusters](chap-Clusters) and select the OVN network provider from the **Default Network Provider** drop-down list.
 
-13. Add hosts to the cluster. Hosts added to this cluster are automatically configured to communicate with OVN. To add new hosts, see “Adding a Host to the oVirt Engine” in [Chapter 7: Hosts](../chap-Hosts).
+13. Add hosts to the cluster. Hosts added to this cluster are automatically configured to communicate with OVN. To add new hosts, see “Adding a Host to the oVirt Engine” in [Chapter 7: Hosts](chap-Hosts).
 
-14. Import or add OVN networks to the new cluster. To import networks, see Section 6.3.1, “Importing Networks From External Providers”. To create new networks using OVN, see “Creating a New Logical Network in a Data Center or Cluster” in [Chapter 6: Logical Networks](../chap-Logical_Networks)], and select the **Create on external provider** check box. `ovirt-provider-ovn` is selected by default.
+14. Import or add OVN networks to the new cluster. To import networks, see Section 6.3.1, “Importing Networks From External Providers”. To create new networks using OVN, see “Creating a New Logical Network in a Data Center or Cluster” in [Chapter 6: Logical Networks](chap-Logical_Networks)], and select the **Create on external provider** check box. `ovirt-provider-ovn` is selected by default.
 
    To configure your hosts to use an existing, non-default network, see the “Configuring Hosts for an OVN Tunnel Network” section.
 
@@ -696,7 +696,7 @@ The **General** tab in the **Add Provider** window allows you to register the co
      <li><b>Data Center</b>: Specify the data center into which KVM virtual machines will be imported, or select <b>Any Data Center</b> to instead specify the destination data center during individual import operations (using the <b>Import</b> function in the <b>Virtual Machines</b> tab).</li>
      <li><b>URI</b>: The URI of the KVM host.</li>
      <li><b>Proxy Host</b>: Select a host in the chosen data center with <tt>virt-v2v</tt> installed to serve as the host during virtual machine import operations. This host must also be able to connect to the network of the KVM external provider. If you selected <b>Any Data Center</b>, you cannot choose the host here, but instead can specify a host during individual import operations (using the <b>Import</b> function in the <b>Virtual Machines</b> tab).</li>
-    </ul>  
+    </ul>
     <p><b>External Network Provider</b></p>
     <ul>
      <li><b>Provider URL</b>: The URL or fully qualified domain name of the machine on which the external network provider is hosted. You must add the port number for the external network provider to the end of the URL or fully qualified domain name. By default, this port number is 9696.</li>
@@ -752,7 +752,7 @@ The **Agent Configuration** tab in the **Add Provider** window allows users to r
 
 3. Click **OK**.
 
-**Prev:** [Chapter 10: Virtual Disks](../chap-Virtual_Machine_Disks)<br>
-**Next:** [Chapter 12: Backups and Migration](../chap-Backups_and_Migration)
+**Prev:** [Chapter 10: Virtual Disks](chap-Virtual_Machine_Disks)<br>
+**Next:** [Chapter 12: Backups and Migration](chap-Backups_and_Migration)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-external_providers)

--- a/source/documentation/admin-guide/chap-Global_Configuration.html.md
+++ b/source/documentation/admin-guide/chap-Global_Configuration.html.md
@@ -695,6 +695,6 @@ You can remove created MAC address pools, but the default MAC address pool canno
 
 5. Click **OK**.
 
-**Next:** [Chapter 2: Dashboard](../chap-System_Dashboard)
+**Next:** [Chapter 2: Dashboard](chap-System_Dashboard)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-global_configuration)

--- a/source/documentation/admin-guide/chap-Hosts.html.md
+++ b/source/documentation/admin-guide/chap-Hosts.html.md
@@ -1019,7 +1019,7 @@ If a host unpredictably goes into a non-responsive state, for example, due to a 
 
     # engine-config --set ServerRebootTimeout=integer
 
-**Prev:** [Chapter 6: Logical Networks](../chap-Logical_Networks)<br>
-**Next:** [Chapter 8: Storage](../chap-Storage)
+**Prev:** [Chapter 6: Logical Networks](chap-Logical_Networks)<br>
+**Next:** [Chapter 8: Storage](chap-Storage)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-hosts)

--- a/source/documentation/admin-guide/chap-Log_Files.html.md
+++ b/source/documentation/admin-guide/chap-Log_Files.html.md
@@ -143,7 +143,7 @@ This procedure should be used on your centralized log server. You could use a se
 
 Your centralized log server is now configured to receive and store the `messages` and `secure` logs from your virtualization hosts.
 
-**Prev:** [Chapter 18: Utilities](../chap-Utilities)<br>
-**Next:** [Chapter 20: Proxies](../chap-Proxies)
+**Prev:** [Chapter 18: Utilities](chap-Utilities)<br>
+**Next:** [Chapter 20: Proxies](chap-Proxies)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-log_files)

--- a/source/documentation/admin-guide/chap-Logical_Networks.html.md
+++ b/source/documentation/admin-guide/chap-Logical_Networks.html.md
@@ -1146,7 +1146,7 @@ Use the following procedure to change the fully qualified domain name of hosts.
 
 5. Re-register the host with the Manager. See [Adding a Host](Adding_a_Host) for more information.
 
-**Prev:** [Chapter 5: Clusters](../chap-Clusters)<br>
-**Next:** [Chapter 7: Hosts](../chap-Hosts)
+**Prev:** [Chapter 5: Clusters](chap-Clusters)<br>
+**Next:** [Chapter 7: Hosts](chap-Hosts)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-logical_networks)

--- a/source/documentation/admin-guide/chap-Pools.html.md
+++ b/source/documentation/admin-guide/chap-Pools.html.md
@@ -130,7 +130,7 @@ If you need to configure different sysprep settings for different pools of Windo
 
                 The domain and credentials cannot be modified in the **Initial Run** tab.
 
-      * `FullName` of the local administrator:          
+      * `FullName` of the local administrator:
 
         <UserData>
         ...
@@ -604,7 +604,7 @@ Enterprise Linux hosts can be added to trusted clusters and measured against a W
 
 After the host is added to the trusted cluster, it is assessed by the OpenAttestation server. If a host is not trusted by the OpenAttestation server, it will move to a `Non Operational` state and should be removed from the trusted cluster.
 
-**Prev:** [Chapter 8: Storage](../chap-Storage)<br>
-**Next:** [Chapter 10: Virtual Disks](../chap-Virtual_Machine_Disks)
+**Prev:** [Chapter 8: Storage](chap-Storage)<br>
+**Next:** [Chapter 10: Virtual Disks](chap-Virtual_Machine_Disks)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-pools)

--- a/source/documentation/admin-guide/chap-Proxies.html.md
+++ b/source/documentation/admin-guide/chap-Proxies.html.md
@@ -219,7 +219,7 @@ The `engine-cleanup` command can be used to remove the websocket proxy from the 
 
 5. Install and configure the proxy on the separate machine. See "Installing a Websocket Proxy on a Separate Machine" in the [Installation Guide](/documentation/install-guide/Installation_Guide/) for instructions.
 
-**Prev:** [Chapter 19: Log Files](../chap-Log_Files)<br>
-**Next:** [Appendix A: VDSM and Hooks](../appe-VDSM_and_Hooks)
+**Prev:** [Chapter 19: Log Files](chap-Log_Files)<br>
+**Next:** [Appendix A: VDSM and Hooks](appe-VDSM_and_Hooks)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-proxies)

--- a/source/documentation/admin-guide/chap-Quality_of_Service.html.md
+++ b/source/documentation/admin-guide/chap-Quality_of_Service.html.md
@@ -280,7 +280,7 @@ Remove an existing CPU quality of service entry.
 
 You have removed the CPU quality of service entry, and that entry is no longer available. If any CPU profiles were based on that entry, the CPU quality of service entry for those profiles is automatically set to `[unlimited]`.
 
-**Prev:** [Chapter 2: Dashboard](../chap-System_Dashboard)<br>
-**Next:** [Chapter 4: Data Centers](../chap-Data_Centers)
+**Prev:** [Chapter 2: Dashboard](chap-System_Dashboard)<br>
+**Next:** [Chapter 4: Data Centers](chap-Data_Centers)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-quality_of_service)

--- a/source/documentation/admin-guide/chap-Quotas_and_Service_Level_Agreement_Policy.html.md
+++ b/source/documentation/admin-guide/chap-Quotas_and_Service_Level_Agreement_Policy.html.md
@@ -236,7 +236,7 @@ This procedure describes how to set service level agreement CPU features.
 
 The CPU consumption of users is now governed by the policy you have set.
 
-**Prev:** [Chapter 15: Users and Roles](../chap-Users_and_Roles)<br>
-**Next:** [Chapter 17: Event Notifications](../chap-Event_Notifications)
+**Prev:** [Chapter 15: Users and Roles](chap-Users_and_Roles)<br>
+**Next:** [Chapter 17: Event Notifications](chap-Event_Notifications)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-quotas_and_service_level_agreement_policy)

--- a/source/documentation/admin-guide/chap-Storage.html.md
+++ b/source/documentation/admin-guide/chap-Storage.html.md
@@ -88,7 +88,7 @@ Specific system user accounts and system user groups are required by oVirt so th
         # chmod 0755 /exports/export
         # chmod 0755 /exports/iso
 
-For more information on the required system users and groups see "[Appendix F, System Accounts](../appe-System_Accounts)".
+For more information on the required system users and groups see "[Appendix F, System Accounts](appe-System_Accounts)".
 
 ### Attaching NFS Storage
 
@@ -304,7 +304,7 @@ If you have configured multiple storage connection paths to the same target, fol
 
 ### Configuring iSCSI Multipathing
 
-The **iSCSI Multipathing** enables you to create and manage groups of logical networks and iSCSI storage connections. To prevent host downtime due to network path failure, configure multiple network paths between hosts and iSCSI storage. Once configured, the Engine connects each host in the data center to each bonded target via NICs/VLANs related to logical networks of the same iSCSI Bond. You can also specify which networks to use for storage traffic, instead of allowing hosts to route traffic through a default network. This option is only available in the Administration Portal after at least one iSCSI storage domain has been attached to a data center.  
+The **iSCSI Multipathing** enables you to create and manage groups of logical networks and iSCSI storage connections. To prevent host downtime due to network path failure, configure multiple network paths between hosts and iSCSI storage. Once configured, the Engine connects each host in the data center to each bonded target via NICs/VLANs related to logical networks of the same iSCSI Bond. You can also specify which networks to use for storage traffic, instead of allowing hosts to route traffic through a default network. This option is only available in the Administration Portal after at least one iSCSI storage domain has been attached to a data center.
 
 **Prerequisites**
 
@@ -636,7 +636,7 @@ Import a template from a data storage domain you have imported into your oVirt e
 
     iv. Click **OK**.
 
-8. Click **OK**.    
+8. Click **OK**.
 
 ## Storage Tasks
 
@@ -822,7 +822,7 @@ Attach a storage domain to a data center.
 
 6. Click **OK**.
 
-The storage domain is attached to the data center and is automatically activated.    
+The storage domain is attached to the data center and is automatically activated.
 
 ### Removing a Storage Domain
 
@@ -942,7 +942,7 @@ When the **Discard After Delete** check box is selected, a `blkdiscard` command 
 
 **Discard After Delete** can be enabled both when creating a block storage domain or when editing a block storage domain. See the “Adding Block Storage” and “Editing Storage Domains”. sections in this chapter.
 
-**Prev:** [Chapter 7: Hosts](../chap-Hosts)<br>
-**Next:** [Chapter 9: Pools](../chap-Pools)
+**Prev:** [Chapter 7: Hosts](chap-Hosts)<br>
+**Next:** [Chapter 9: Pools](chap-Pools)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-storage)

--- a/source/documentation/admin-guide/chap-System_Dashboard.html.md
+++ b/source/documentation/admin-guide/chap-System_Dashboard.html.md
@@ -120,7 +120,7 @@ The heatmap of the memory utilization for a specific cluster that shows the aver
 
 ## Storage Utilization
 
-The **Storage Utilization** shows the storage utilization in a heatmap.  
+The **Storage Utilization** shows the storage utilization in a heatmap.
 
 **Storage Utilization**
 
@@ -128,7 +128,7 @@ The **Storage Utilization** shows the storage utilization in a heatmap.
 
 The heatmap shows the average utilization of the storage for the last 24 hours. The formula used to calculate the storage usage by the cluster is the total utilization of the storage in the cluster. This is calculated by using the average storage utilization for each host over the last 24 hours to find the total average usage of the storage by the cluster. Hovering over the heatmap displays the storage domain name. Clicking on the heatmap navigates to **Storage** &rarr; **Domains** with the storage domains sorted by utilization.
 
-**Prev:** [Chapter 1: Global Configuration](../chap-Global_Configuration)<br>
-**Next:** [Chapter 3: Quality of Service](../chap-Quality_of_Service)
+**Prev:** [Chapter 1: Global Configuration](chap-Global_Configuration)<br>
+**Next:** [Chapter 3: Quality of Service](chap-Quality_of_Service)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-system_dashboard)

--- a/source/documentation/admin-guide/chap-Users_and_Roles.html.md
+++ b/source/documentation/admin-guide/chap-Users_and_Roles.html.md
@@ -998,7 +998,7 @@ Creating additional local domains other than the default **internal** domain is 
 
 Additionally created local domains will not get upgraded autonmatically during standard Red Hat Virtualization upgrades and need to be upgraded manually for each future release. For more information on creating additional local domains and how to upgrade the domains, see the README file at **/usr/share/doc/ovirt-engine-extension-aaa-jdbc-version/README.admin**.
 
-**Prev:** [Chapter 14: Automating Configuration Tasks Using Ansible](../chap-Automating_Configuration_Tasks_Using_Ansible)<br>
-**Next:** [Chapter 16: Quotas and Service Level Agreement Policy](../chap-Quotas_and_Service_Level_Agreement_Policy)
+**Prev:** [Chapter 14: Automating Configuration Tasks Using Ansible](chap-Automating_Configuration_Tasks_Using_Ansible)<br>
+**Next:** [Chapter 16: Quotas and Service Level Agreement Policy](chap-Quotas_and_Service_Level_Agreement_Policy)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-users_and_roles)

--- a/source/documentation/admin-guide/chap-Utilities.html.md
+++ b/source/documentation/admin-guide/chap-Utilities.html.md
@@ -619,7 +619,7 @@ There are several parameters to further refine the engine-vacuum command.
 
     # engine-vacuum -f -v -t vm_dynamic -t vds_dynamic
 
-**Prev:** [Chapter 17: Event Notifications](../chap-Event_Notifications)<br>
-**Next:** [Chapter 19: Log Files](../chap-Log_Files)
+**Prev:** [Chapter 17: Event Notifications](chap-Event_Notifications)<br>
+**Next:** [Chapter 19: Log Files](chap-Log_Files)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-utilities)

--- a/source/documentation/admin-guide/chap-Virtual_Machine_Disks.html.md
+++ b/source/documentation/admin-guide/chap-Virtual_Machine_Disks.html.md
@@ -690,7 +690,7 @@ The oVirt Project recommends performing this operation before cloning a virtual 
 
 A `Started to sparsify` event appears in the **Events** tab during the sparsify operation and the disk’s status displays as `Locked`. When the operation is complete, a `Sparsified successfully` event appears in the **Events** tab and the disk’s status displays as `OK`. The unused disk space has been returned to the host and is available for use by other virtual machines.
 
-**Prev:** [Chapter 9: Pools](../chap-Pools)<br>
-**Next:** [Chapter 11: External Providers](../chap-External_Providers)
+**Prev:** [Chapter 9: Pools](chap-Pools)<br>
+**Next:** [Chapter 11: External Providers](chap-External_Providers)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/administration_guide/chap-virtual_machine_disks)

--- a/source/documentation/admin-guide/chap-Working_with_Gluster_Storage.html.md
+++ b/source/documentation/admin-guide/chap-Working_with_Gluster_Storage.html.md
@@ -664,5 +664,5 @@ The Gluster Sync feature periodically fetches the latest cluster configuration f
 
 **Note:** The Engine continuously monitors if hosts are added to or removed from the storage cluster. If the addition or removal of a host is detected, an action item is shown in the **General** tab for the cluster, where you can either to choose to **Import** the host into or **Detach** the host from the cluster.
 
-**Prev:** [Chapter 8: Storage](../chap-Storage)<br>
-**Next:** [Chapter 10: Pools](../chap-Pools)
+**Prev:** [Chapter 8: Storage](chap-Storage)<br>
+**Next:** [Chapter 10: Pools](chap-Pools)

--- a/source/documentation/data-warehouse/Allowing_Read_Only_Access_to_the_History_Database.html.md
+++ b/source/documentation/data-warehouse/Allowing_Read_Only_Access_to_the_History_Database.html.md
@@ -59,7 +59,7 @@ To allow access to the history database without allowing edits, you must create 
 
 The read-only user’s `SELECT` statements against tables and views in the `ovirt_engine_history` database succeed, while modifications fail.
 
-**Prev:** [Tracking Tag History](../Tracking_tag_history) <br>
-**Next:** [Statistics History Views](../Statistics_history_views)
+**Prev:** [Tracking Tag History](Tracking_tag_history) <br>
+**Next:** [Statistics History Views](Statistics_history_views)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/data_warehouse_guide/allowing_read_only_access_to_the_history_database)

--- a/source/documentation/data-warehouse/Application_Settings_for_the_Data_Warehouse_service_in_ovirt-engine-dwhd.conf.html.md
+++ b/source/documentation/data-warehouse/Application_Settings_for_the_Data_Warehouse_service_in_ovirt-engine-dwhd.conf.html.md
@@ -17,7 +17,7 @@ The following is a list of options for configuring application settings for the 
 | `DWH_TABLES_KEEP_DAILY` | `43800` | The number of hours that daily data is stored. The default is five years. |
 | `DWH_ERROR_EVENT_INTERVAL` | `300000` | The minimum interval, in milliseconds, at which errors are pushed to the Engine's <b>audit.log</b>. |
 
-**Prev:** [Recording Statistical History](../Recording_statistical_history) <br>
-**Next:** [Tracking Tag History](../Tracking_tag_history)
+**Prev:** [Recording Statistical History](Recording_statistical_history) <br>
+**Next:** [Tracking Tag History](Tracking_tag_history)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/data_warehouse_guide/application_settings_for_the_data_warehouse_service_in_ovirt-engine-dwhd_file)

--- a/source/documentation/data-warehouse/Changing_the_Data_Warehouse_Sampling_Scale.html.md
+++ b/source/documentation/data-warehouse/Changing_the_Data_Warehouse_Sampling_Scale.html.md
@@ -50,7 +50,7 @@ You can change the sampling scale later by running `engine-setup` again with the
 
 You can also adjust individual data retention settings if necessary, as documented in "Application Settings for the Data Warehouse service in ovirt-engine-dwhd.conf" section.
 
-**Prev:** [Migrating Data Warehouse Service to a Separate Machine](../Migrating_Data_Warehouse_to_a_Separate_Machine)<br>
-**Next:** [Chapter 2: About the History Database](../chap-About_History_Database_Reports_and_Dashboards)
+**Prev:** [Migrating Data Warehouse Service to a Separate Machine](Migrating_Data_Warehouse_to_a_Separate_Machine)<br>
+**Next:** [Chapter 2: About the History Database](chap-About_History_Database_Reports_and_Dashboards)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/data_warehouse_guide/changing_the_data_warehouse_sampling_scale)

--- a/source/documentation/data-warehouse/Configuration_history_views.html.md
+++ b/source/documentation/data-warehouse/Configuration_history_views.html.md
@@ -988,6 +988,6 @@ The following table shows the configuration history parameters of the users in t
 | delete_date | timestamp with time zone | The date this entity was deleted from the system. |
 
 
-**Prev:** [Statistics History Views](../Statistics_history_views)
+**Prev:** [Statistics History Views](Statistics_history_views)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/data_warehouse_guide/sect-configuration_history_views)

--- a/source/documentation/data-warehouse/Data_Collection_Setup_and_Reports_Installation_Overview.html.md
+++ b/source/documentation/data-warehouse/Data_Collection_Setup_and_Reports_Installation_Overview.html.md
@@ -32,6 +32,6 @@ To calculate an estimate of the space and resources the `ovirt_engine_history` d
 
     To configure only the currently installed Data Warehouse packages, and prevent setup from applying package updates found in enabled repositories, add the `--offline` option.
 
-**Next:** [Installing and Configuring Data Warehouse on a Separate Machine](../Data_Warehouse_and_Reports_Configuration_Notes)
+**Next:** [Installing and Configuring Data Warehouse on a Separate Machine](Data_Warehouse_and_Reports_Configuration_Notes)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/data_warehouse_guide/chap-installing_and_configuring_data_warehouse#Overview_of_Configuring_Data_Warehouse)

--- a/source/documentation/data-warehouse/Data_Warehouse_Guide.html.md
+++ b/source/documentation/data-warehouse/Data_Warehouse_Guide.html.md
@@ -4,8 +4,8 @@ title: oVirt Data Warehouse Guide
 
 # oVirt Data Warehouse Guide
 
-## [Chapter 1: Installing and Configuring Data Warehouse](../chap-History_and_Reports)
+## [Chapter 1: Installing and Configuring Data Warehouse](chap-History_and_Reports)
 
-## [Chapter 2: About the History Database](../chap-About_History_Database_Reports_and_Dashboards)
+## [Chapter 2: About the History Database](chap-About_History_Database_Reports_and_Dashboards)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/data_warehouse_guide/)

--- a/source/documentation/data-warehouse/Data_Warehouse_and_Reports_Configuration_Notes.html.md
+++ b/source/documentation/data-warehouse/Data_Warehouse_and_Reports_Configuration_Notes.html.md
@@ -136,7 +136,7 @@ Install and configure Data Warehouse on a separate machine from that on which th
 
 16. Optionally, set up SSL to secure database connections using the instructions at link: http://www.postgresql.org/docs/9.5/static/ssl-tcp.html#SSL-FILE-USAGE.
 
-**Prev:** [Overview of Configuring Data Warehouse](../Data_Collection_Setup_and_Reports_Installation_Overview)<br>
-**Next:** [Migrating Data Warehouse to a Separate Machine](../Migrating_Data_Warehouse_to_a_Separate_Machine)
+**Prev:** [Overview of Configuring Data Warehouse](Data_Collection_Setup_and_Reports_Installation_Overview)<br>
+**Next:** [Migrating Data Warehouse to a Separate Machine](Migrating_Data_Warehouse_to_a_Separate_Machine)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/data_warehouse_guide/installing_and_configuring_data_warehouse_on_a_separate_machine)

--- a/source/documentation/data-warehouse/History_Database_Overview.html.md
+++ b/source/documentation/data-warehouse/History_Database_Overview.html.md
@@ -16,7 +16,7 @@ Installing the `ovirt-engine-dwh` package creates a second database called `ovir
 
 The `ovirt_engine_history` database schema changes over time. The database includes a set of database views to provide a supported, versioned API with a consistent structure. A view is a virtual table composed of the result set of a database query. The database stores the definition of a view as a `SELECT` statement. The result of the `SELECT` statement populates the virtual table that the view returns. A user references the view name in `PL/PGSQL` statements the same way a table is referenced.
 
-**Prev:** [Chapter 2: About the History Database](../chap-About_History_Database_Reports_and_Dashboards)
-**Next:** [Tracking Configuration History](../Tracking_configuration_history)
+**Prev:** [Chapter 2: About the History Database](chap-About_History_Database_Reports_and_Dashboards)
+**Next:** [Tracking Configuration History](Tracking_configuration_history)
 
  [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/data_warehouse_guide/chap-about_history_database)

--- a/source/documentation/data-warehouse/Migrating_Data_Warehouse_to_a_Separate_Machine.html.md
+++ b/source/documentation/data-warehouse/Migrating_Data_Warehouse_to_a_Separate_Machine.html.md
@@ -208,7 +208,7 @@ The questions shown in this step only appear if you are migrating the `ovirt_eng
 
 The Data Warehouse service is now hosted on a separate machine from that on which the Engine is hosted.
 
-**Prev:** [Installing and Configuring Data Warehouse on a Separate Machine](../Data_Warehouse_and_Reports_Configuration_Notes)<br>
-**Next:** [Changing the Data Warehouse Sampling Scale](../Changing_the_Data_Warehouse_Sampling_Scale)
+**Prev:** [Installing and Configuring Data Warehouse on a Separate Machine](Data_Warehouse_and_Reports_Configuration_Notes)<br>
+**Next:** [Changing the Data Warehouse Sampling Scale](Changing_the_Data_Warehouse_Sampling_Scale)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/data_warehouse_guide/sect-migrating_data_warehouse_to_a_separate_machine)

--- a/source/documentation/data-warehouse/Recording_statistical_history.html.md
+++ b/source/documentation/data-warehouse/Recording_statistical_history.html.md
@@ -10,7 +10,7 @@ Hourly data and daily data can be found in the hourly and daily tables.
 
 Each statistical datum is kept in its respective aggregation level table: samples, hourly, and daily history. All history tables also contain a history_id column to uniquely identify rows. Tables reference the configuration version of a host in order to enable reports on statistics of an entity in relation to its past configuration.
 
-**Prev:** [Tracking Configuration History](../Tracking_configuration_history) <br>
-**Next:** [Application Settings for the Data Warehouse Service in ovirt-engine-dwhd.conf](../Application_Settings_for_the_Data_Warehouse_service_in_ovirt-engine-dwhd.conf)
+**Prev:** [Tracking Configuration History](Tracking_configuration_history) <br>
+**Next:** [Application Settings for the Data Warehouse Service in ovirt-engine-dwhd.conf](Application_Settings_for_the_Data_Warehouse_service_in_ovirt-engine-dwhd.conf)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/data_warehouse_guide/recording_statistical_history)

--- a/source/documentation/data-warehouse/Statistics_history_views.html.md
+++ b/source/documentation/data-warehouse/Statistics_history_views.html.md
@@ -567,7 +567,7 @@ You can enable debug mode to record log sampling, hourly, and daily job times in
  </tbody>
 </table>
 
-**Prev:** [Allowing Read Only Access to the History Database](../Allowing_Read_Only_Access_to_the_History_Database) <br>
-**Next:** [Configuration History Views](../Configuration_history_views)
+**Prev:** [Allowing Read Only Access to the History Database](Allowing_Read_Only_Access_to_the_History_Database) <br>
+**Next:** [Configuration History Views](Configuration_history_views)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/data_warehouse_guide/sect-statistics_history_views)

--- a/source/documentation/data-warehouse/Tracking_configuration_history.html.md
+++ b/source/documentation/data-warehouse/Tracking_configuration_history.html.md
@@ -24,7 +24,7 @@ The configuration tables in the `ovirt_engine_history` database differ from the 
 
 * A `delete_date` field to indicate the date the entity was removed from the system.
 
-**Prev:** [History Database Overview](../History_Database_Overview)<br>
-**Next:** [Recording Statistical History](../Recording_statistical_history)
+**Prev:** [History Database Overview](History_Database_Overview)<br>
+**Next:** [Recording Statistical History](Recording_statistical_history)
 
  [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/data_warehouse_guide/tracking_configuration_history)

--- a/source/documentation/data-warehouse/Tracking_tag_history.html.md
+++ b/source/documentation/data-warehouse/Tracking_tag_history.html.md
@@ -16,7 +16,7 @@ The ETL Service collects tag information as displayed in the Administration Port
 
 * A tag branch is moved - the corresponding tag and relations are updated as new entries. Moved tags and relations are only flagged as updated.
 
-**Prev:** [Application Settings for the Data Warehouse Service in ovirt-engine-dwhd.conf](../Application_Settings_for_the_Data_Warehouse_service_in_ovirt-engine-dwhd.conf) <br>
-**Next:** [Allowing Read Only Access to the History Database](../Allowing_Read_Only_Access_to_the_History_Database)
+**Prev:** [Application Settings for the Data Warehouse Service in ovirt-engine-dwhd.conf](Application_Settings_for_the_Data_Warehouse_service_in_ovirt-engine-dwhd.conf) <br>
+**Next:** [Allowing Read Only Access to the History Database](Allowing_Read_Only_Access_to_the_History_Database)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/data_warehouse_guide/tracking_tag_history)

--- a/source/documentation/data-warehouse/chap-About_History_Database_Reports_and_Dashboards.html.md
+++ b/source/documentation/data-warehouse/chap-About_History_Database_Reports_and_Dashboards.html.md
@@ -4,20 +4,20 @@ title: About the History Database
 
 # Chapter 2: About the History Database
 
-## [History Database Overview](../History_Database_Overview)
+## [History Database Overview](History_Database_Overview)
 
 ## History Database
-* [Tracking Configuration History](../Tracking_configuration_history)
-* [Recording Statistical History](../Recording_statistical_history)
-* [Application Settings for the Data Warehouse Service in ovirt-engine-dwhd.conf](../Application_Settings_for_the_Data_Warehouse_service_in_ovirt-engine-dwhd.conf)
-* [Tracking Tag History](../Tracking_tag_history)
-* [Allowing Read Only Access to the History Database](../Allowing_Read_Only_Access_to_the_History_Database)
+* [Tracking Configuration History](Tracking_configuration_history)
+* [Recording Statistical History](Recording_statistical_history)
+* [Application Settings for the Data Warehouse Service in ovirt-engine-dwhd.conf](Application_Settings_for_the_Data_Warehouse_service_in_ovirt-engine-dwhd.conf)
+* [Tracking Tag History](Tracking_tag_history)
+* [Allowing Read Only Access to the History Database](Allowing_Read_Only_Access_to_the_History_Database)
 
-## [Statistics History Views](../Statistics_history_views)
+## [Statistics History Views](Statistics_history_views)
 
-## [Configuration History Views](../Configuration_history_views)
+## [Configuration History Views](Configuration_history_views)
 
- **Prev:** [Changing the Data Warehouse Sampling Scale](../Changing_the_Data_Warehouse_Sampling_Scale)<br>
- **Next:** [History Database Overview](../History_Database_Overview)
+ **Prev:** [Changing the Data Warehouse Sampling Scale](Changing_the_Data_Warehouse_Sampling_Scale)<br>
+ **Next:** [History Database Overview](History_Database_Overview)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/data_warehouse_guide/chap-about_history_database)

--- a/source/documentation/data-warehouse/chap-History_and_Reports.html.md
+++ b/source/documentation/data-warehouse/chap-History_and_Reports.html.md
@@ -4,12 +4,12 @@ title: Installing and Configuring Data Warehouse
 
 # Chapter 1: Installing and Configuring Data Warehouse
 
-## [Overview of Configuring Data Warehouse](../Data_Collection_Setup_and_Reports_Installation_Overview)
+## [Overview of Configuring Data Warehouse](Data_Collection_Setup_and_Reports_Installation_Overview)
 
-## [Installing and Configuring Data Warehouse on a Separate Machine](../Data_Warehouse_and_Reports_Configuration_Notes)
+## [Installing and Configuring Data Warehouse on a Separate Machine](Data_Warehouse_and_Reports_Configuration_Notes)
 
-## [Migrating Data Warehouse to a Separate Machine](../Migrating_Data_Warehouse_to_a_Separate_Machine)
+## [Migrating Data Warehouse to a Separate Machine](Migrating_Data_Warehouse_to_a_Separate_Machine)
 
-## [Changing the Data Warehouse Sampling Scale](../Changing_the_Data_Warehouse_Sampling_Scale)
+## [Changing the Data Warehouse Sampling Scale](Changing_the_Data_Warehouse_Sampling_Scale)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/data_warehouse_guide/chap-installing_and_configuring_data_warehouse)

--- a/source/documentation/disaster-recovery-guide/active_active_overview.html.md
+++ b/source/documentation/disaster-recovery-guide/active_active_overview.html.md
@@ -112,7 +112,7 @@ The standalone Engine is only highly available when managed externally. For exam
 
 The active-active failover can be manually performed by placing the main site's hosts into maintenance mode.
 
-**Prev:** [Chapter 1: Disaster Recovery Solutions](../disaster_recovery_solutions)<br>
-**Next:** [Chapter 3: Active-Passive Disaster Recovery](../active_passive_overview)
+**Prev:** [Chapter 1: Disaster Recovery Solutions](disaster_recovery_solutions)<br>
+**Next:** [Chapter 3: Active-Passive Disaster Recovery](active_passive_overview)
 
 [Adapted from oVirt 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/disaster_recovery_guide/active_active)

--- a/source/documentation/disaster-recovery-guide/active_passive_overview.html.md
+++ b/source/documentation/disaster-recovery-guide/active_passive_overview.html.md
@@ -42,7 +42,7 @@ You will need to manually fail back to the primary site (Site A) when it is runn
 
 You must ensure that the same general connectivity exists in the primary and secondary sites.
 
-If you have multiple networks or multiple data centers then you must use an empty network mapping in the mapping file to ensure that all entities register on the target during failover. See [Appendix A: Mapping File Attributes](../mapping_file_attributes) for more information.
+If you have multiple networks or multiple data centers then you must use an empty network mapping in the mapping file to ensure that all entities register on the target during failover. See [Appendix A: Mapping File Attributes](mapping_file_attributes) for more information.
 
 ### Storage Considerations
 
@@ -98,7 +98,7 @@ You can also create an optional playbook to clean the primary site before failin
 
 Create the playbooks and associated files in `/usr/share/ansible/roles/oVirt.disaster-recovery/` on the Ansible machine that is managing the failover and failback. If you have multiple Ansible machines that can manage it, ensure that you copy the files to all of them.
 
-You can test the configuration using one or more of the testing procedures in [Testing the Active-Passive Configuration](../testing_active_passive).
+You can test the configuration using one or more of the testing procedures in [Testing the Active-Passive Configuration](testing_active_passive).
 
 ### Using the `ovirt-dr` Script for Ansible Tasks
 
@@ -158,7 +158,7 @@ In this example the Ansible playbook is named `dr-rhv-setup.yml`, and is execute
 
         # ansible-playbook dr-rhv-setup.yml --tags "generate_mapping"
 
-3. Configure the mapping file (`disaster_recovery_vars.yml` in this case) with the backup site’s configuration. See [Appendix A: Mapping File Attributes](../mapping_file_attributes) for more information about the mapping file’s attributes.
+3. Configure the mapping file (`disaster_recovery_vars.yml` in this case) with the backup site’s configuration. See [Appendix A: Mapping File Attributes](mapping_file_attributes) for more information about the mapping file’s attributes.
 
 If you have multiple Ansible machines that can perform the failover and failback, then copy the mapping file to all relevant machines.
 
@@ -269,7 +269,7 @@ After you fail over, you must clean the environment in the primary site before f
 
 * Ensure the secondary site's storage domains are in read/write mode and the primary site's storage domains are in read only mode.
 
-* Synchronize the replication from the secondary site's storage domains to the primary site's storage domains.  
+* Synchronize the replication from the secondary site's storage domains to the primary site's storage domains.
 
 * Clean the primary site of all storage domains to be imported. This can be done manually in the Engine, or by creating and running an Ansible playbook.
 
@@ -308,7 +308,7 @@ This example uses the `dr-rhv-failback.yml` playbook created earlier.
 
 2. Enable replication from the primary storage domains to the secondary storage domains.
 
-**Prev:** [Chapter 2: Active-Active Disaster Recovery](../active_active_overview)<br>
-**Next:** [Appendix A: Mapping File Attributes](../mapping_file_attributes)
+**Prev:** [Chapter 2: Active-Active Disaster Recovery](active_active_overview)<br>
+**Next:** [Appendix A: Mapping File Attributes](mapping_file_attributes)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/disaster_recovery_guide/active_passive)

--- a/source/documentation/disaster-recovery-guide/disaster-recovery-guide.html.md
+++ b/source/documentation/disaster-recovery-guide/disaster-recovery-guide.html.md
@@ -4,14 +4,14 @@ title: Disaster Recovery Guide
 
 # Disaster Recovery Guide
 
-## Chapter 1: [Disaster Recovery Solutions](../disaster_recovery_solutions)
+## Chapter 1: [Disaster Recovery Solutions](disaster_recovery_solutions)
 
-## Chapter 2: [Active-Active Disaster Recovery](../active_active_overview)
+## Chapter 2: [Active-Active Disaster Recovery](active_active_overview)
 
-## Chapter 3: [Active-Passive Disaster Recovery](../active_passive_overview)
+## Chapter 3: [Active-Passive Disaster Recovery](active_passive_overview)
 
-## Appendix A: [Mapping File Attributes](../mapping_file_attributes)
+## Appendix A: [Mapping File Attributes](mapping_file_attributes)
 
-## Appendix B: [Testing the Active-Passive Configuration](../testing_active_passive)
+## Appendix B: [Testing the Active-Passive Configuration](testing_active_passive)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/disaster_recovery_guide/)

--- a/source/documentation/disaster-recovery-guide/disaster_recovery_solutions.html.md
+++ b/source/documentation/disaster-recovery-guide/disaster_recovery_solutions.html.md
@@ -14,6 +14,6 @@ This solution is implemented using a stretch cluster configuration. This means t
 
 Also referred to as site-to-site failover, this disaster recovery solution is implemented by configuring two separate oVirt environments: the active primary environment, and the passive secondary (backup) environment. Failover and failback between sites must be manually executed, and is managed by Ansible. See "Active-Passive Overview" in Chapter 3 for more information.
 
-**Next:** [Chapter 2: Active-Active Disaster Recovery](../active_active_overview)
+**Next:** [Chapter 2: Active-Active Disaster Recovery](active_active_overview)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/disaster_recovery_guide/disaster_recovery_solutions)

--- a/source/documentation/disaster-recovery-guide/mapping_file_attributes.html.md
+++ b/source/documentation/disaster-recovery-guide/mapping_file_attributes.html.md
@@ -162,7 +162,7 @@ dr_sites_secondary_ca_file: /etc/pki/ovirt-engine/ca.pem
 </tbody>
 </table>
 
-**Prev:** [Chapter 3: Active-Passive Disaster Recovery](../active_passive_overview)<br>
-**Next:** [Appendix B: Testing the Active-Passive Configuration](../testing_active_passive)
+**Prev:** [Chapter 3: Active-Passive Disaster Recovery](active_passive_overview)<br>
+**Next:** [Appendix B: Testing the Active-Passive Configuration](testing_active_passive)
 
 [Adapted from oVirt 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/disaster_recovery_guide/mapping_file_attributes)

--- a/source/documentation/disaster-recovery-guide/testing_active_passive.html.md
+++ b/source/documentation/disaster-recovery-guide/testing_active_passive.html.md
@@ -108,6 +108,6 @@ For more information about failing over the environment, cleaning the environmen
 
 5. Verify that all relevant storage domains, virtual machines, and templates are registered and running successfully.
 
-**Prev:** [Appendix A: Mapping File Attributes](../mapping_file_attributes)
+**Prev:** [Appendix A: Mapping File Attributes](mapping_file_attributes)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/disaster_recovery_guide/testing_active_passive)

--- a/source/documentation/gluster-hyperconverged/Gluster_Hyperconverged_Guide.html.md
+++ b/source/documentation/gluster-hyperconverged/Gluster_Hyperconverged_Guide.html.md
@@ -4,16 +4,16 @@ title: oVirt-Gluster Hyperconvergence  Guide
 
 # oVirt-Gluster Hyperconvergence Guide
 
-## Chapter 1: [Introduction](../chap-Introduction)
+## Chapter 1: [Introduction](chap-Introduction)
 
-## Chapter 2: [Deploying oVirt and Gluster hyperconverged](../chap-Deploying_Hyperconverged)
+## Chapter 2: [Deploying oVirt and Gluster hyperconverged](chap-Deploying_Hyperconverged)
 
-## Chapter 3: [Additional Steps on the hyperconverged deployment](../chap-Additional_Steps)
+## Chapter 3: [Additional Steps on the hyperconverged deployment](chap-Additional_Steps)
 
-## Chapter 4: [Troubleshooting](../chap-Troubleshooting)
+## Chapter 4: [Troubleshooting](chap-Troubleshooting)
 
-## Chapter 5: [Maintenance and Upgrading Resources](../chap-Maintenance_and_Upgrading_Resources)
+## Chapter 5: [Maintenance and Upgrading Resources](chap-Maintenance_and_Upgrading_Resources)
 
-## Chapter 6: [Single Node oVirt and Gluster hyperconverged](../chap-Single_node_hyperconverged)
+## Chapter 6: [Single Node oVirt and Gluster hyperconverged](chap-Single_node_hyperconverged)
 
 

--- a/source/documentation/gluster-hyperconverged/chap-Additional_Steps.html.md
+++ b/source/documentation/gluster-hyperconverged/chap-Additional_Steps.html.md
@@ -15,6 +15,6 @@ To outline, next steps would be:
 * Create ISO domain - you can use a new gluster volume to set this up.
 * [Optional] Configure disaster recovery
 
-**Prev:** [Chapter: Deploying oVirt and Gluster hyperconverged](../chap-Deploying_Hyperconverged) <br/>
-**Next:** [Chapter: Troubleshooting](../chap-Troubleshooting)
+**Prev:** [Chapter: Deploying oVirt and Gluster hyperconverged](chap-Deploying_Hyperconverged) <br/>
+**Next:** [Chapter: Troubleshooting](chap-Troubleshooting)
 

--- a/source/documentation/gluster-hyperconverged/chap-Deploying_Hyperconverged.html.md
+++ b/source/documentation/gluster-hyperconverged/chap-Deploying_Hyperconverged.html.md
@@ -6,7 +6,7 @@ title: Deploying oVirt and Gluster Hyperconverged
 
 ## Pre-requisites
 
-* You must have 3 Enterprise Linux 7 hosts or oVirt Node hosts. Refer [Enterprise Linux Hosts](../install-guide/chap-Enterprise_Linux_Hosts) or [oVirt Nodes](../install-guide/chap-oVirt_Nodes)
+* You must have 3 Enterprise Linux 7 hosts or oVirt Node hosts. Refer [Enterprise Linux Hosts](install-guide/chap-Enterprise_Linux_Hosts) or [oVirt Nodes](install-guide/chap-oVirt_Nodes)
 
 * You must have at least 2 interfaces on each of the hosts, so that the frontend and backend traffic can be separated out. Having only one network will cause the engine monitoring, client traffic, gluster I/O traffic to all run together and interfere each other. To segregate the backend network, the gluster cluster is formed using the backend network addresses, and the nodes are added to the engine using the frontend network address.
 
@@ -29,26 +29,26 @@ title: Deploying oVirt and Gluster Hyperconverged
       - cockpit-ovirt-dashboard (provides a UI for the installation)
       - vdsm-gluster (plugin to manage gluster services)
 
-       # yum install cockpit-ovirt-dashboard vdsm-gluster 
+       # yum install cockpit-ovirt-dashboard vdsm-gluster
 
 3. On the first host, install the following packages:
       - ovirt-engine-appliance (for the Engine virtual machine installation)
       - gdeploy (a wrapper tool around Ansible that helps to setup gluster volumes)
- 
+
        # yum install ovirt-engine-appliance gdeploy
 
 
-        
+
 ## Deploying on oVirt Node based Hosts
 
 **oVirt Node contains all the required packages to set up the hyperconverged environment.**
-Refer [oVirt Nodes](../install-guide/chap-oVirt_Nodes) for instructions on installing oVirt Node on your hosts. You can proceed to setting up the hyperconverged environment if you have 3 oVirt Node based hosts.
+Refer [oVirt Nodes](install-guide/chap-oVirt_Nodes) for instructions on installing oVirt Node on your hosts. You can proceed to setting up the hyperconverged environment if you have 3 oVirt Node based hosts.
 
 ### Setting up the hyperconverged environment
 
 Steps for installing are detailed in this [blog post](/blog/2018/02/up-and-running-with-ovirt-4-2-and-gluster-storage/).
 
-**Prev:** [Chapter: Introduction](../chap-Introduction) <br>
-**Next:** [Chapter: Additional Steps](../chap-Additional_Steps)
+**Prev:** [Chapter: Introduction](chap-Introduction) <br>
+**Next:** [Chapter: Additional Steps](chap-Additional_Steps)
 
 

--- a/source/documentation/gluster-hyperconverged/chap-Introduction.html.md
+++ b/source/documentation/gluster-hyperconverged/chap-Introduction.html.md
@@ -15,10 +15,10 @@ oVirt has been integrated with GlusterFS, an open source scale-out distributed f
 There's a minimum 3 node requirement to run a hyperconverged solution. This is to ensure high availability of the shared storage. With a 2 node deployment, gluster cannot identify quorum loss and this could lead to data inconsistencies.
 
 Either a replica 3 or a replica 3 with arbiter can be used as the gluster volume type for the deployment.
-A replica 3 stores/replicates copy of the data on 3 bricks, where each of the 3 node has a brick. With replica 3 arbiter, copy of the data is stored on 2 of the bricks and metadata is stored on the third brick ensuring consistency of data in case of split-brain. Lesser storage space is required in case of the arbiter volume, but this volume type is not as highly available as the replica 3 type.  
+A replica 3 stores/replicates copy of the data on 3 bricks, where each of the 3 node has a brick. With replica 3 arbiter, copy of the data is stored on 2 of the bricks and metadata is stored on the third brick ensuring consistency of data in case of split-brain. Lesser storage space is required in case of the arbiter volume, but this volume type is not as highly available as the replica 3 type.
 
 With oVirt 4.2, there's also an option to deploy the hyperconverged solution on a single node. This, of course, does not have any high availability guarantees but useful for users who do not need that. You can read more at [Single node hyperconverged](/documentation/gluster-hyperconverged/chap-Single_node_hyperconverged)
 
 For hardware requirements, see "Hypervisor Requirements" in the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
-**Next:** [Chapter: Deploying oVirt and Gluster Hyperconverged](../chap-Deploying_Hyperconverged)
+**Next:** [Chapter: Deploying oVirt and Gluster Hyperconverged](chap-Deploying_Hyperconverged)

--- a/source/documentation/gluster-hyperconverged/chap-Maintenance_and_Upgrading_Resources.html.md
+++ b/source/documentation/gluster-hyperconverged/chap-Maintenance_and_Upgrading_Resources.html.md
@@ -6,7 +6,7 @@ title: Maintenance and Upgrading Resources
 
 ## Maintaining the Self-Hosted Engine
 
-Refer [Maintaing the Self-hosted Engine](../self-hosted/chap-Maintenance_and_Upgrading_Resources)
+Refer [Maintaing the Self-hosted Engine](self-hosted/chap-Maintenance_and_Upgrading_Resources)
 
 ## Maintaining Gluster storage
 
@@ -15,7 +15,7 @@ Refer [Maintaing the Self-hosted Engine](../self-hosted/chap-Maintenance_and_Upg
 * If upgrading gluster version on the hosts, rolling upgrades are supported. Refer to [gluster documentation](https://gluster.readthedocs.io/en/latest/Upgrade-Guide/README/) for rolling upgrades for version specific information
     * Move host to maintenance with glusterd service stopped
     * Upgrade the gluster packages
-    * Activate the host 
+    * Activate the host
     * Ensure heal is complete. This can be monitored from UI or from cli using `gluster volume heal info`
     * Repeat this for other hosts in cluster
 
@@ -23,12 +23,12 @@ NOTE: If geo-replication is setup on the gluster volumes, the geo-replication ne
 
 ## Removing a host from hyperconverged setup
 
-* Hosts that have a brick cannot be removed - can only be replaced. You will need to first replace the bricks on host with another brick. 
+* Hosts that have a brick cannot be removed - can only be replaced. You will need to first replace the bricks on host with another brick.
     * Add a new host to the cluster
     * Create bricks on the newly added host - the `Create Brick` UI option from the Storage Devices sub-tab can be used to prepare and mount bricks.
     * Replace bricks from the host to be removed using the `Replace Brick` option
     * Once all bricks are replaces, the host can be moved to maintenance and removed.
 
 
-**Prev:** [Chapter: Troubleshooting](../chap-Troubleshooting) <br>
-**Next:** [Chapter: Single Node Hyperconverged](../chap-Single_node_hyperconverged)
+**Prev:** [Chapter: Troubleshooting](chap-Troubleshooting) <br>
+**Next:** [Chapter: Single Node Hyperconverged](chap-Single_node_hyperconverged)

--- a/source/documentation/gluster-hyperconverged/chap-Single_node_hyperconverged.html.md
+++ b/source/documentation/gluster-hyperconverged/chap-Single_node_hyperconverged.html.md
@@ -6,7 +6,7 @@ title: Deploying oVirt and Gluster Single node Hyperconverged
 
 ## Pre-requisites
 
-* A single host with  Enterprise Linux 7 or oVirt Node. Refer [Enterprise Linux Hosts](../install-guide/chap-Enterprise_Linux_Hosts) or [oVirt Nodes](../install-guide/chap-oVirt_Nodes)
+* A single host with  Enterprise Linux 7 or oVirt Node. Refer [Enterprise Linux Hosts](install-guide/chap-Enterprise_Linux_Hosts) or [oVirt Nodes](install-guide/chap-oVirt_Nodes)
 
 * You must have at least 2 interfaces on the host, so that the frontend and backend traffic can be separated out. Having only one network will cause the engine monitoring, client traffic, gluster I/O traffic to all run together and interfere each other. To segregate the backend network, the gluster cluster is formed using the backend network addresses, and the nodes are added to the engine using the frontend network address.
 
@@ -15,7 +15,7 @@ title: Deploying oVirt and Gluster Single node Hyperconverged
 * You must have configured passwordless ssh between the host to itself. gdeploy uses Ansible playbooks and the ability to remotely execute commands is a pre-requisite.
 Follow below steps to configure this.
 ```
-# ssh-keygen 
+# ssh-keygen
 # ssh-copy-id root@<host-address>
 ```
 
@@ -31,14 +31,14 @@ Follow below steps to configure this.
         # yum install http://resources.ovirt.org/pub/yum-repo/ovirt-release42.rpm
 
 2. Install gdeploy and cockpit-ovirt that will provide a UI for the installation of Hosted Engine. gdeploy is a wrapper tool around Ansible that helps to setup gluster volumes. vdsm-gluster is used to manage gluster from oVirt, and pulls in all the required gluster dependencies. Install the oVirt Engine Virtual Appliance package for the Engine virtual machine installation.
-     
+
         # yum install gdeploy cockpit-ovirt-dashboard vdsm-gluster ovirt-engine-appliance
 
 
 ## Deploying on oVirt Node based Hosts
 
 **oVirt Node contains all the required packages to set up the hyperconverged environment.**
-Refer to [oVirt Nodes](../install-guide/chap-oVirt_Nodes) for instructions on installing oVirt Node on the host. You can proceed to setting up the hyperconverged environment if you have an oVirt Node based host.
+Refer to [oVirt Nodes](install-guide/chap-oVirt_Nodes) for instructions on installing oVirt Node on the host. You can proceed to setting up the hyperconverged environment if you have an oVirt Node based host.
 
 ### Setting up the hyperconverged environment
 
@@ -91,7 +91,7 @@ action=create
 vgname=gluster_vg1
 lvname=engine_lv
 lvtype=thick
-size=100GB 
+size=100GB
 mount=/gluster_bricks/engine
 
 [lv2]
@@ -192,11 +192,11 @@ Once the configuration file is edited (the @ @ replaced), the gluster environmen
 gdeploy -c gdeploy.conf
 
 ```
-#### Setting up Hosted Engine 
+#### Setting up Hosted Engine
 
 Use the Ansible based installation flow of Hosted Engine to set up oVirt within a virtual machine. The storage details should be provided as type: ```glusterfs``` and connection path as: ```<hostname>:/engine``` (Replace hostname with address of host on which installation is carried out)
 
-**Prev:**  [Chapter: Maintenance and Upgrading Resources ](../chap-Maintenance_and_Upgrading_Resources) <br>
+**Prev:**  [Chapter: Maintenance and Upgrading Resources ](chap-Maintenance_and_Upgrading_Resources) <br>
 
 
 

--- a/source/documentation/gluster-hyperconverged/chap-Troubleshooting.html.md
+++ b/source/documentation/gluster-hyperconverged/chap-Troubleshooting.html.md
@@ -20,7 +20,7 @@ Brick host3:/rhgs/engine/brick1             49152     0          Y       34750
 Self-heal Daemon on localhost               N/A       N/A        Y       32231
 Self-heal Daemon on host2                   N/A       N/A        Y       22766
 Self-heal Daemon on host3                   N/A       N/A        Y       24766
- 
+
 Task Status of Volume engine
 ------------------------------------------------------------------------------
 There are no active volume tasks
@@ -46,8 +46,8 @@ The volume is read-only or offline if only 1 brick is online or no bricks are li
   State: Peer in Cluster (Connected)
 ```
 
-If the state is other than `Peer in Cluster (Connected)` then there is an issue. 
- 
+If the state is other than `Peer in Cluster (Connected)` then there is an issue.
+
    * You can check that the `glusterd` service is running on all the nodes. If not, try restarting the service using `systemctl restart glusterd`
 
    * Check that the ports required by Gluster are open for communication between the nodes of the cluster
@@ -72,7 +72,7 @@ If the state is other than `Peer in Cluster (Connected)` then there is an issue.
         * Move host to maintenance
         * Reinstall the host choosing the "Hosted Engine deploy" option from the Hosted Engine tab.
 
-Refer [Troubleshooting Self-Hosted Engine](../self-hosted/chap-Deploying_Self-Hosted_Engine)
+Refer [Troubleshooting Self-Hosted Engine](self-hosted/chap-Deploying_Self-Hosted_Engine)
 
-**Prev:** [Chapter: Additional Steps ](../chap-Additional_Steps) <br/>
-**Next:** [Chapter: Maintenance and Upgrading Resources ](../chap-Maintenance_and_Upgrading_Resources)
+**Prev:** [Chapter: Additional Steps ](chap-Additional_Steps) <br/>
+**Next:** [Chapter: Maintenance and Upgrading Resources ](chap-Maintenance_and_Upgrading_Resources)

--- a/source/documentation/install-guide/Installation_Guide.html.md
+++ b/source/documentation/install-guide/Installation_Guide.html.md
@@ -6,44 +6,44 @@ title: oVirt Installation Guide
 
 ## Part I: Introduction to oVirt
 
-### Chapter 1: [Introduction to oVirt](../chap-Introduction_to_oVirt)
+### Chapter 1: [Introduction to oVirt](chap-Introduction_to_oVirt)
 
-### Chapter 2: [System Requirements](../chap-System_Requirements)
+### Chapter 2: [System Requirements](chap-System_Requirements)
 
 ## Part II: Installing oVirt
 
-### Chapter 3: [Installing oVirt](../chap-Installing_oVirt)
+### Chapter 3: [Installing oVirt](chap-Installing_oVirt)
 
-### Chapter 4: [oVirt Engine Related Tasks](../chap-oVirt_Engine_Related_Tasks)
+### Chapter 4: [oVirt Engine Related Tasks](chap-oVirt_Engine_Related_Tasks)
 
 ## Part III: Installing Hosts
 
-### Chapter 5: [Introduction to Hosts](../chap-Introduction_to_Hosts)
+### Chapter 5: [Introduction to Hosts](chap-Introduction_to_Hosts)
 
-### Chapter 6: [oVirt Nodes](../chap-oVirt_Nodes)
+### Chapter 6: [oVirt Nodes](chap-oVirt_Nodes)
 
-### Chapter 7: [Enterprise Linux Hosts](../chap-Enterprise_Linux_Hosts)
+### Chapter 7: [Enterprise Linux Hosts](chap-Enterprise_Linux_Hosts)
 
-### Chapter 8: [Adding a Host to the oVirt Engine](../chap-Adding_a_Host_to_the_oVirt_Engine)
+### Chapter 8: [Adding a Host to the oVirt Engine](chap-Adding_a_Host_to_the_oVirt_Engine)
 
 ## Part IV: Attaching Storage
 
-### Chapter 9: [Configuring Storage](../chap-Configuring_Storage)
+### Chapter 9: [Configuring Storage](chap-Configuring_Storage)
 
 ## Appendixes
 
-### Appendix A: [Changing the Permissions for the Local ISO Domain](../appe-Changing_the_Permissions_for_the_Local_ISO_Domain)
+### Appendix A: [Changing the Permissions for the Local ISO Domain](appe-Changing_the_Permissions_for_the_Local_ISO_Domain)
 
-### Appendix B: [Attaching the Local ISO Domain to a Data Center](../appe-Attaching_the_Local_ISO_Domain_to_a_Data_Center)
+### Appendix B: [Attaching the Local ISO Domain to a Data Center](appe-Attaching_the_Local_ISO_Domain_to_a_Data_Center)
 
-### Appendix C: [Enabling Gluster Processes on Gluster Storage Nodes](../appe-Enabling_Gluster_Processes_on_Gluster_Storage_Nodes)
+### Appendix C: [Enabling Gluster Processes on Gluster Storage Nodes](appe-Enabling_Gluster_Processes_on_Gluster_Storage_Nodes)
 
-### Appendix D: [Preparing a Remote PostgreSQL Database](../appe-Preparing_a_Remote_PostgreSQL_Database)
+### Appendix D: [Preparing a Remote PostgreSQL Database](appe-Preparing_a_Remote_PostgreSQL_Database)
 
-### Appendix E: [Preparing a Local Manually-Configured PostgreSQL Database](../appe-Preparing_a_Local_Manually-Configured_PostgreSQL_Database)
+### Appendix E: [Preparing a Local Manually-Configured PostgreSQL Database](appe-Preparing_a_Local_Manually-Configured_PostgreSQL_Database)
 
-### Appendix F: [Installing a Websocket Proxy on a Separate Machine](../appe-Installing_the_Websocket_Proxy_on_a_dSeparate_Machine)
+### Appendix F: [Installing a Websocket Proxy on a Separate Machine](appe-Installing_the_Websocket_Proxy_on_a_Separate_Machine)
 
-### Appendix G: [Configuring a Host for PCI Passthrough](../appe-Configuring_a_Host_for_PCI_Passthrough)
+### Appendix G: [Configuring a Host for PCI Passthrough](appe-Configuring_a_Host_for_PCI_Passthrough)
 
-### Appendix H: [Preparing a Host for vGPU Installation](../appe-Preparing_a_Host_for_vGPU_Installation)
+### Appendix H: [Preparing a Host for vGPU Installation](appe-Preparing_a_Host_for_vGPU_Installation)

--- a/source/documentation/install-guide/appe-Attaching_the_Local_ISO_Domain_to_a_Data_Center.html.md
+++ b/source/documentation/install-guide/appe-Attaching_the_Local_ISO_Domain_to_a_Data_Center.html.md
@@ -24,7 +24,7 @@ Only one ISO domain can be attached to a data center.
 
 The ISO domain is now attached to the data center and is automatically activated.
 
-**Prev:** [Appendix A: Changing the Permissions for the Local ISO Domain](../appe-Changing_the_Permissions_for_the_Local_ISO_Domain) <br>
-**Next:** [Appendix C: Enabling Gluster Processes on Gluster Storage Nodes](../appe-Enabling_Gluster_Processes_on_Gluster_Storage_Nodes)
+**Prev:** [Appendix A: Changing the Permissions for the Local ISO Domain](appe-Changing_the_Permissions_for_the_Local_ISO_Domain) <br>
+**Next:** [Appendix C: Enabling Gluster Processes on Gluster Storage Nodes](appe-Enabling_Gluster_Processes_on_Gluster_Storage_Nodes)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/installation_guide/appe-attaching_the_local_iso_domain_to_a_data_center)

--- a/source/documentation/install-guide/appe-Changing_the_Permissions_for_the_Local_ISO_Domain.html.md
+++ b/source/documentation/install-guide/appe-Changing_the_Permissions_for_the_Local_ISO_Domain.html.md
@@ -24,7 +24,7 @@ While it is possible to allow read and write access to the entire network, it is
 
 Note that if you manually edit the `/etc/exports` file after running `engine-setup`, running `engine-cleanup` later will not undo the changes.
 
-**Prev:** [Chapter 9: Configuring Storage](../chap-Configuring_Storage) <br>
-**Next:** [Appendix B: Attaching the Local ISO Domain to a Data Center](../appe-Attaching_the_Local_ISO_Domain_to_a_Data_Center)
+**Prev:** [Chapter 9: Configuring Storage](chap-Configuring_Storage) <br>
+**Next:** [Appendix B: Attaching the Local ISO Domain to a Data Center](appe-Attaching_the_Local_ISO_Domain_to_a_Data_Center)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/installation_guide/appe-changing_the_permissions_for_the_local_iso_domain)

--- a/source/documentation/install-guide/appe-Configuring_a_Host_for_PCI_Passthrough.html.md
+++ b/source/documentation/install-guide/appe-Configuring_a_Host_for_PCI_Passthrough.html.md
@@ -8,7 +8,7 @@ Enabling PCI passthrough allows a virtual machine to use a host device as if the
 
 **Prerequisites:**
 
-* Ensure that the host hardware meets the requirements for PCI device passthrough and assignment. See [Chapter 2: System Requirements](../chap-System_Requirements) for more information.
+* Ensure that the host hardware meets the requirements for PCI device passthrough and assignment. See [Chapter 2: System Requirements](chap-System_Requirements) for more information.
 
 **Configuring a Host for PCI Passthrough**
 
@@ -55,7 +55,7 @@ Enabling PCI passthrough allows a virtual machine to use a host device as if the
 
         # reboot
 
-**Prev:** [Appendix F: Installing the Websocket Proxy on a Separate Machine](../appe-Installing_the_Websocket_Proxy_on_a_Separate_Machine)
-**Next:** [Appendix H: Preparing a Host for vGPU Installation](../appe-Preparing_a_Host_for_vGPU_Installation)
+**Prev:** [Appendix F: Installing the Websocket Proxy on a Separate Machine](appe-Installing_the_Websocket_Proxy_on_a_Separate_Machine)
+**Next:** [Appendix H: Preparing a Host for vGPU Installation](appe-Preparing_a_Host_for_vGPU_Installation)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/installation_guide/appe-configuring_a_hypervisor_host_for_pci_passthrough)

--- a/source/documentation/install-guide/appe-Enabling_Gluster_Processes_on_Gluster_Storage_Nodes.html.md
+++ b/source/documentation/install-guide/appe-Enabling_Gluster_Processes_on_Gluster_Storage_Nodes.html.md
@@ -14,7 +14,7 @@ title: Enabling Gluster Processes on Gluster Storage Nodes
 
 It is now possible to add Gluster Storage nodes to the Gluster cluster, and to mount Gluster volumes as storage domains. `iptables` rules no longer block storage domains from being added to the cluster.
 
-**Prev:** [Appendix B: Attaching the Local ISO Domain to a Data Center](../appe-Attaching_the_Local_ISO_Domain_to_a_Data_Center) <br>
-**Next:** [Appendix D: Preparing a Remote PostgreSQL Database](../appe-Preparing_a_Remote_PostgreSQL_Database)
+**Prev:** [Appendix B: Attaching the Local ISO Domain to a Data Center](appe-Attaching_the_Local_ISO_Domain_to_a_Data_Center) <br>
+**Next:** [Appendix D: Preparing a Remote PostgreSQL Database](appe-Preparing_a_Remote_PostgreSQL_Database)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/installation_guide/appe-enabling_gluster_processes_on_red_hat_gluster_storage_nodes)

--- a/source/documentation/install-guide/appe-Installing_the_Websocket_Proxy_on_a_Separate_Machine.html.md
+++ b/source/documentation/install-guide/appe-Installing_the_Websocket_Proxy_on_a_Separate_Machine.html.md
@@ -50,11 +50,11 @@ This section describes how to install and configure the websocket proxy on a sep
 
     i. Press **Enter** to accept the default SSH port number, or enter the port number of the Engine machine.
 
-            ssh port on remote engine server [22]:           
+            ssh port on remote engine server [22]:
 
     ii. Enter the root password to log in to the Engine machine and press **Enter**.
 
-            root password on remote engine server engine_host.example.com:        
+            root password on remote engine server engine_host.example.com:
 
 8. Select whether to review iptables rules if they differ from the current settings.
 
@@ -87,7 +87,7 @@ This section describes how to install and configure the websocket proxy on a sep
         # engine-config -s WebSocketProxy=host.example.com:6100
         # systemctl restart ovirt-engine.service
 
-**Prev:** [Appendix E: Preparing a Local Manually-Configured PostgreSQL Database](../appe-Preparing_a_Local_Manually-Configured_PostgreSQL_Database) <br>
-**Next:** [Appendix G: Configuring a Host for PCI Passthrough](../appe-Configuring_a_Host_for_PCI_Passthrough)
+**Prev:** [Appendix E: Preparing a Local Manually-Configured PostgreSQL Database](appe-Preparing_a_Local_Manually-Configured_PostgreSQL_Database) <br>
+**Next:** [Appendix G: Configuring a Host for PCI Passthrough](appe-Configuring_a_Host_for_PCI_Passthrough)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/installation_guide/appe-installing_the_websocket_proxy_on_a_different_host)

--- a/source/documentation/install-guide/appe-Preparing_a_Host_for_vGPU_Installation.html.md
+++ b/source/documentation/install-guide/appe-Preparing_a_Host_for_vGPU_Installation.html.md
@@ -39,7 +39,7 @@ You can now install vGPUs on the virtual machines running on this host.
 
         # vdsm-client Host hostdevListByCaps
 
-    Available vGPU instances appear in the **mdev** key **available_instances**.    
+    Available vGPU instances appear in the **mdev** key **available_instances**.
 
 2. Install the required virtual machine operating system.
 
@@ -60,6 +60,6 @@ You can now install vGPUs on the virtual machines running on this host.
 
 **Important:** You cannot migrate a virtual machine using a vGPU to a different host. When upgrading the virtual machine, verify the operating system and GPU vendor support in the vendor’s documentation.
 
-**Prev:** [Appendix G: Configuring a Host for PCI Passthrough](../appe-Configuring_a_Host_for_PCI_Passthrough)
+**Prev:** [Appendix G: Configuring a Host for PCI Passthrough](appe-Configuring_a_Host_for_PCI_Passthrough)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/installation_guide/preparing_a_host_for_vgpu_installation)

--- a/source/documentation/install-guide/appe-Preparing_a_Local_Manually-Configured_PostgreSQL_Database.html.md
+++ b/source/documentation/install-guide/appe-Preparing_a_Local_Manually-Configured_PostgreSQL_Database.html.md
@@ -6,7 +6,7 @@ title: Preparing a Local Manually-Configured PostgreSQL Database
 
 You have the option of configuring a local PostgreSQL database on the Engine machine to use as the Engine database. By default, the oVrt Engine’s configuration script, `engine-setup`, creates and configures the Engine database locally on the Engine machine.
 
-To configure the Engine database on a machine that is separate from the machine where the Engine is installed, see [Appendix D: Preparing a Remote PostgreSQL Database](../appe-Preparing_a_Remote_PostgreSQL_Database).
+To configure the Engine database on a machine that is separate from the machine where the Engine is installed, see [Appendix D: Preparing a Remote PostgreSQL Database](appe-Preparing_a_Remote_PostgreSQL_Database).
 
 Use this procedure to set up the Engine database with custom values. Set up this database before you configure the Engine; you must supply the database credentials during `engine-setup`. To set up the database, you must first install the `ovirt-engine` package on the Engine machine; the `postgresql-server` package is installed as a dependency.
 
@@ -73,7 +73,7 @@ The locale settings in the `postgresql.conf` file must be set to `en_US.UTF8`.
 
 Optionally, set up SSL to secure database connections using the instructions at [http://www.postgresql.org/docs/9.5/static/ssl-tcp.html#SSL-FILE-USAGE](http://www.postgresql.org/docs/9.5/static/ssl-tcp.html#SSL-FILE-USAGE.).
 
-**Prev:** [Appendix D: Preparing a Remote PostgreSQL Database](../appe-Preparing_a_Remote_PostgreSQL_Database) <br>
-**Next:** [Appendix F: Installing the Websocket Proxy on a Separate Machine](../appe-Installing_the_Websocket_Proxy_on_a_Separate_Machine)
+**Prev:** [Appendix D: Preparing a Remote PostgreSQL Database](appe-Preparing_a_Remote_PostgreSQL_Database) <br>
+**Next:** [Appendix F: Installing the Websocket Proxy on a Separate Machine](appe-Installing_the_Websocket_Proxy_on_a_Separate_Machine)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/installation_guide/appe-preparing_a_local_manually-configured_postgresql_database)

--- a/source/documentation/install-guide/appe-Preparing_a_Remote_PostgreSQL_Database.html.md
+++ b/source/documentation/install-guide/appe-Preparing_a_Remote_PostgreSQL_Database.html.md
@@ -6,7 +6,7 @@ title: Preparing a Remote PostgreSQL Database
 
 By default, the Engine's configuration script, `engine-setup`, creates and configures the engine_host database locally on the Engine machine.
 
-To set up the Manager database with custom values on the Manager machine, see [Appendix E, Preparing a Local Manually-Configured PostgreSQL Database](../appe-Local_Manually-Configured_PostgreSQL_Database). You should set up a Engin database before you configure the Engine. You must supply the database credentials during `engine-setup`.
+To set up the Manager database with custom values on the Manager machine, see [Appendix E, Preparing a Local Manually-Configured PostgreSQL Database](appe-Local_Manually-Configured_PostgreSQL_Database). You should set up a Engin database before you configure the Engine. You must supply the database credentials during `engine-setup`.
 
 The Data Warehouse’s configuration script offers the choice of creating a local or remote database. However, situations may arise where you might want to configure a remote database for Data Warehouse manually.
 
@@ -83,7 +83,7 @@ The locale settings in the `postgresql.conf` file must be set to `en_US.UTF8`.
 
 Optionally, set up SSL to secure database connections using the instructions at [http://www.postgresql.org/docs/9.5/static/ssl-tcp.html#SSL-FILE-USAGE](http://www.postgresql.org/docs/9.5/static/ssl-tcp.html#SSL-FILE-USAGE.).
 
-**Prev:** [Appendix C: Enabling Gluster Processes on Gluster Storage Nodes](../appe-Enabling_Gluster_Processes_on_Gluster_Storage_Nodes) <br>
-**Next:** [Appendix E: Preparing a Local Manually-Configured PostgreSQL Database](../appe-Preparing_a_Local_Manually-Configured_PostgreSQL_Database)
+**Prev:** [Appendix C: Enabling Gluster Processes on Gluster Storage Nodes](appe-Enabling_Gluster_Processes_on_Gluster_Storage_Nodes) <br>
+**Next:** [Appendix E: Preparing a Local Manually-Configured PostgreSQL Database](appe-Preparing_a_Local_Manually-Configured_PostgreSQL_Database)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/installation_guide/appe-preparing_a_remote_postgresql_database)

--- a/source/documentation/install-guide/chap-Adding_a_Host_to_the_oVirt_Engine.html.md
+++ b/source/documentation/install-guide/chap-Adding_a_Host_to_the_oVirt_Engine.html.md
@@ -34,7 +34,7 @@ Adding a host to your oVirt environment can take some time, as the following ste
 
 The new host displays in the list of hosts with a status of `Installing`, and you can view the progress of the installation in the details pane. After a brief delay the host status changes to **Up**
 
-**Prev:** [Chapter 7: Enterprise Linux Hosts](../chap-Enterprise_Linux_Hosts) <br>
-**Next:** [Chapter 9: Configuring Storage](../chap-Configuring_Storage)
+**Prev:** [Chapter 7: Enterprise Linux Hosts](chap-Enterprise_Linux_Hosts) <br>
+**Next:** [Chapter 9: Configuring Storage](chap-Configuring_Storage)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/installation_guide/adding_a_hypervisor)

--- a/source/documentation/install-guide/chap-Configuring_Storage.html.md
+++ b/source/documentation/install-guide/chap-Configuring_Storage.html.md
@@ -8,7 +8,7 @@ title: Configuring Storage
 
 A storage domain is a collection of images that have a common storage interface. A storage domain contains complete images of templates and virtual machines (including snapshots), ISO files, and metadata about themselves. A storage domain can be made of either block devices (SAN - iSCSI or FCP) or a file system (NAS - NFS, GlusterFS, or other POSIX compliant file systems).
 
-There are Installing_the_Websocket_Proxy_on_a_dSeparate_Machine types of storage domain:
+There are Installing_the_Websocket_Proxy_on_a_Separate_Machine types of storage domain:
 
 * **Data Domain:** A data domain holds the virtual hard disks and OVF files of all the virtual machines and templates in a data center, and cannot be shared across data centers. Data domains of multiple types (iSCSI, NFS, FC, POSIX, and Gluster) can be added to the same data center, provided they are all shared, rather than local, domains.
 
@@ -73,7 +73,7 @@ The following procedure shows you how to attach existing FCP storage to your oVi
 
 The new FCP data domain displays in **Storage** &rarr; **Domains**. It will remain with a `Locked` status while it is being prepared for use. When ready, it is automatically attached to the data center.
 
-**Prev:** [Chapter 8: Adding a Host to the oVirt Engine](../chap-Adding_a_Host_to_the_oVirt_Engine) <br>
-**Next:** [Appendix A: Changing the Permissions for the Local ISO Domain](../appe-Changing_the_Permissions_for_the_Local_ISO_Domain)
+**Prev:** [Chapter 8: Adding a Host to the oVirt Engine](chap-Adding_a_Host_to_the_oVirt_Engine) <br>
+**Next:** [Appendix A: Changing the Permissions for the Local ISO Domain](appe-Changing_the_Permissions_for_the_Local_ISO_Domain)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/installation_guide/chap-configuring_storage)

--- a/source/documentation/install-guide/chap-Enterprise_Linux_Hosts.html.md
+++ b/source/documentation/install-guide/chap-Enterprise_Linux_Hosts.html.md
@@ -8,9 +8,9 @@ title: Enterprise Linux Hosts
 
 An Enterprise Linux host (such as CentOS or RHEL), also known as an EL-based hypervisor is based on a standard basic installation of an Enterprise Linux operating system on a physical server.
 
-The host must meet the minimum Host requirements out lined in [Chapter 2: System Requirements](../chap-System_Requirements).
+The host must meet the minimum Host requirements out lined in [Chapter 2: System Requirements](chap-System_Requirements).
 
-See [Appendix G, Configuring a Host for PCI Passthrough](../appe-Configuring_a_Host_for_PCI_Passthrough) for more information on how to enable the host hardware and software for device passthrough.
+See [Appendix G, Configuring a Host for PCI Passthrough](appe-Configuring_a_Host_for_PCI_Passthrough) for more information on how to enable the host hardware and software for device passthrough.
 
 **Important:** Virtualization must be enabled in your host's BIOS settings. For information on changing your host's BIOS settings, refer to your host's hardware documentation.
 
@@ -23,7 +23,7 @@ You can install a Cockpit user interface for monitoring the host’s resources a
 
 **Installing Cockpit on Enterprise Linux Hosts**
 
-1. By default, when adding a host to the oVirt Engine, the Engine configures the required firewall ports. See Chapter 8: Adding a Host to the oVirt Engine](../chap-Adding_a_Host_to_the_oVirt_Engine) for details. However, if you disable Automatically configure host firewall when adding the host, manually configure the firewall according to the “Host Firewall Requirements” in [Chapter 2: System Requirements](../chap-System_Requirements).
+1. By default, when adding a host to the oVirt Engine, the Engine configures the required firewall ports. See Chapter 8: Adding a Host to the oVirt Engine](chap-Adding_a_Host_to_the_oVirt_Engine) for details. However, if you disable Automatically configure host firewall when adding the host, manually configure the firewall according to the “Host Firewall Requirements” in [Chapter 2: System Requirements](chap-System_Requirements).
 
 2. Install the dashboard packages:
 
@@ -36,7 +36,7 @@ You can install a Cockpit user interface for monitoring the host’s resources a
 
 4. You can log in to the Cockpit user interface at https://HostFQDNorIP:9090.
 
-**Prev:** [Chapter 6: oVirt Nodes](../chap-oVirt_Nodes) <br>
-**Next:** [Chapter 8: Adding a Host to the oVirt Engine](../chap-Adding_a_Host_to_the_oVirt_Engine)
+**Prev:** [Chapter 6: oVirt Nodes](chap-oVirt_Nodes) <br>
+**Next:** [Chapter 8: Adding a Host to the oVirt Engine](chap-Adding_a_Host_to_the_oVirt_Engine)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/installation_guide/chap-red_hat_enterprise_linux_hosts)

--- a/source/documentation/install-guide/chap-Installing_oVirt.html.md
+++ b/source/documentation/install-guide/chap-Installing_oVirt.html.md
@@ -32,9 +32,9 @@ After you have installed the `ovirt-engine` package and dependencies, you must c
 
 By default, `engine-setup` creates and configures the Engine database locally on the Engine machine. Alternatively, you can configure the Engine to use a remote database or a manually-configured local database; however, you must set up that database before running `engine-setup`.
 
-To set up a remote database see [Preparing a Remote PostgreSQL Database](../appe-Preparing_a_Remote_PostgreSQL_Database). To set up a manually-configured local database, see [Preparing a Local Manually-Configured PostgreSQL Database](../appe-Preparing_a_Local_Manually-Configured_PostgreSQL_Database).
+To set up a remote database see [Preparing a Remote PostgreSQL Database](appe-Preparing_a_Remote_PostgreSQL_Database). To set up a manually-configured local database, see [Preparing a Local Manually-Configured PostgreSQL Database](appe-Preparing_a_Local_Manually-Configured_PostgreSQL_Database).
 
-By default, `engine-setup` will configure a websocket proxy on the Engine. However, for security and performance reasons, the user can choose to configure it on a separate host. See [Installing the Websocket Proxy on a different host](../appe-Installing_the_Websocket_Proxy_on_a_different_host) for instructions.
+By default, `engine-setup` will configure a websocket proxy on the Engine. However, for security and performance reasons, the user can choose to configure it on a separate host. See [Installing the Websocket Proxy on a different host](appe-Installing_the_Websocket_Proxy_on_a_different_host) for instructions.
 
 **Important:** The `engine-setup` command guides you through several distinct configuration stages, each comprising several steps that require user input. Suggested configuration defaults are provided in square brackets; if the suggested value is acceptable for a given step, press **Enter** to accept that value.
 
@@ -58,7 +58,7 @@ You can run `engine-setup --accept-defaults` to automatically accept all questio
 
         Configure WebSocket Proxy on this machine? (Yes, No) [Yes]:
 
-    To configure the websocket proxy on a separate machine, select `No` and refer to [Installing the Websocket Proxy on a Separate Machine](../appe-Installing_the_Websocket_Proxy_on_a_Separate_Machine) for configuration instructions.
+    To configure the websocket proxy on a separate machine, select `No` and refer to [Installing the Websocket Proxy on a Separate Machine](appe-Installing_the_Websocket_Proxy_on_a_Separate_Machine) for configuration instructions.
 
 5. Choose whether to configure Data Warehouse on the Engine machine.
 
@@ -202,7 +202,7 @@ You can run `engine-setup --accept-defaults` to automatically accept all questio
 
 21. If you intend to link your oVirt environment with a directory server, configure the date and time to synchronize with the system clock used by the directory server to avoid unexpected account expiry issues.
 
-22. Install the certificate authority according to the instructions provided by your browser. You can get the certificate authority’s certificate by navigating to`http://your-manager-fqdn/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA`, replacing your-manager-fqdn with the fully qualified domain name (FQDN) that you provided during the installation.    
+22. Install the certificate authority according to the instructions provided by your browser. You can get the certificate authority’s certificate by navigating to`http://your-manager-fqdn/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA`, replacing your-manager-fqdn with the fully qualified domain name (FQDN) that you provided during the installation.
 
 Proceed to the next section to connect to the Administration Portal as the `admin@internal` user. Then, proceed with setting up hosts, and attaching storage.
 
@@ -233,7 +233,7 @@ To log out of the oVirt Administration Portal, click your user name in the heade
 
 The next chapter contains additional Engine-related tasks that are optional. If the tasks are not applicable to your environment, proceed to **Part III: Installing Hosts**.
 
-**Prev:** [Chapter 2: System Requirements](../chap-System_Requirements) <br>
-**Next:** [Chapter 4: oVirt Engine Related Tasks](../chap-oVirt_Engine_Related_Tasks)
+**Prev:** [Chapter 2: System Requirements](chap-System_Requirements) <br>
+**Next:** [Chapter 4: oVirt Engine Related Tasks](chap-oVirt_Engine_Related_Tasks)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/installation_guide/chap-red_hat_virtualization_manager)

--- a/source/documentation/install-guide/chap-Introduction_to_Hosts.html.md
+++ b/source/documentation/install-guide/chap-Introduction_to_Hosts.html.md
@@ -19,7 +19,7 @@ oVirt supports two types of hosts: oVirt Node and Enterprise Linux host. Dependi
 
 When you create a new data center, you can set the compatibility version. Select the compatibility version that suits all the hosts in the data center. Once set, version regression is not allowed. For a fresh oVirt installation, the latest compatibility version is set in the default data center and default cluster; to use an earlier compatibility version, you must create additional data centers and clusters.
 
-**Prev:** [Chapter 4: oVirt Engine Related Tasks](../chap-oVirt_Engine_Related_Tasks) <br>
-**Next:** [Chapter 6: oVirt Nodes](../chap-oVirt_Nodes)
+**Prev:** [Chapter 4: oVirt Engine Related Tasks](chap-oVirt_Engine_Related_Tasks) <br>
+**Next:** [Chapter 6: oVirt Nodes](chap-oVirt_Nodes)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/installation_guide/chap-introduction_to_hypervisor_hosts)

--- a/source/documentation/install-guide/chap-Introduction_to_oVirt.html.md
+++ b/source/documentation/install-guide/chap-Introduction_to_oVirt.html.md
@@ -10,6 +10,6 @@ oVirt is an open source server and desktop virtualization platform built on oper
 * The installation and configuration of hosts.
 * Attach existing FCP storage to your oVirt environment. More storage options can be found in the [Administration Guide](/documentation/admin-guide/administration-guide/).
 
-**Next:** [Chapter 2: System Requirements](../chap-System_Requirements)
+**Next:** [Chapter 2: System Requirements](chap-System_Requirements)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/installation_guide/pr01)

--- a/source/documentation/install-guide/chap-System_Requirements.html.md
+++ b/source/documentation/install-guide/chap-System_Requirements.html.md
@@ -74,7 +74,7 @@ SPICE support is divided into tiers:
 
 * Tier 1: Operating systems on which remote-viewer has been fully tested.
 
-* Tier 2: Operating systems on which remote-viewer is partially tested and is likely to work.  
+* Tier 2: Operating systems on which remote-viewer is partially tested and is likely to work.
 
 **Client Operating System SPICE Support**
 
@@ -482,7 +482,7 @@ To disable automatic firewall configuration when adding a new host, clear the **
     <p>Enterprise Linux host(s)</p>
    </td>
    <td>Required, when Open Virtual Network (OVN) is used as a network provider, to allow OVN to create tunnels between hosts.</td>
-  </tr>  
+  </tr>
  </tbody>
 </table>
 
@@ -516,11 +516,11 @@ Similarly, if you plan to access a local or remote Data Warehouse database from 
     <p>Data Warehouse (`ovirt-engine-history`) database server</p>
    </td>
    <td>Default port for PostgreSQL database connections.</td>
-  </tr>  
+  </tr>
  </tbody>
-</table>  
+</table>
 
-**Prev:** [Chapter 1: Introduction to oVirt](../chap-Introduction_to_oVirt)<br>
-**Next:** [Chapter 3: Installing oVirt](../chap-Installing_oVirt)
+**Prev:** [Chapter 1: Introduction to oVirt](chap-Introduction_to_oVirt)<br>
+**Next:** [Chapter 3: Installing oVirt](chap-Installing_oVirt)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/installation_guide/rhv_requirements)

--- a/source/documentation/install-guide/chap-oVirt_Engine_Related_Tasks.html.md
+++ b/source/documentation/install-guide/chap-oVirt_Engine_Related_Tasks.html.md
@@ -39,7 +39,7 @@ You can use the `engine-cleanup` command to remove specific components or all co
         # yum remove rhvm* vdsm-bootstrap
 
 
-**Prev:** [Chapter 3: Installing oVirt](../chap-Installing_oVirt)<br>
-**Next:** [Chapter 5: Introduction to Hosts](../chap-Introduction_to_Hosts)
+**Prev:** [Chapter 3: Installing oVirt](chap-Installing_oVirt)<br>
+**Next:** [Chapter 5: Introduction to Hosts](chap-Introduction_to_Hosts)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/installation_guide/chap-red_hat_virtualization_manager_related_tasks)

--- a/source/documentation/install-guide/chap-oVirt_Nodes.html.md
+++ b/source/documentation/install-guide/chap-oVirt_Nodes.html.md
@@ -8,7 +8,7 @@ title: oVirt Nodes
 
 oVirt Node is a minimal operating system based on CentOS that is designed to provide a simple method for setting up a physical machine to act as a hypervisor in a oVirt environment. The minimal operating system contains only the packages required for the machine to act as a hypervisor, and features a Cockpit user interface for monitoring the host and performing administrative tasks. See [http://cockpit-project.org/running.html](http://cockpit-project.org/running.html) for the minimum browser requirements.
 
-Before you proceed, make sure the machine on which you are installing oVirt Node meets the hardware requirements listed in [Chapter 2: System Requirements](../chap-System_Requirements).
+Before you proceed, make sure the machine on which you are installing oVirt Node meets the hardware requirements listed in [Chapter 2: System Requirements](chap-System_Requirements).
 
 Installing oVirt Node on a physical machine involves three key steps:
 
@@ -58,7 +58,7 @@ Installing oVirt Node on a physical machine involves three key steps:
 
     **Note:** When oVirt Node restarts, `imgbase-motd.service` performs a health check on the host and displays the result when you log in on the command line. The message `imgbase status: OK` or `imgbase status: DEGRADED` indicates the health status. Run `imgbase check` to get more information. The service is enabled by default.
 
-You can now add the host to your oVirt environment. See [Chapter 8: Adding a Host to the oVirt Engine](../chap-Adding_a_Host_to_the_oVirt_Engine).
+You can now add the host to your oVirt environment. See [Chapter 8: Adding a Host to the oVirt Engine](chap-Adding_a_Host_to_the_oVirt_Engine).
 
 ## Advanced Installation
 
@@ -88,7 +88,7 @@ If your installation requires custom partitioning, note that the following restr
 
     /usr must be on a logical volume that is able to change versions along with oVirt Node, and therefore should be left on root (/).
 
-For information about the required storage sizes for each partition, see [Chapter 2: System Requirements](../chap-System_Requirements).
+For information about the required storage sizes for each partition, see [Chapter 2: System Requirements](chap-System_Requirements).
 
 * The /boot directory should be defined as a standard partition.
 
@@ -97,7 +97,7 @@ For information about the required storage sizes for each partition, see [Chapte
 * Only XFS or Ext4 file systems are supported.
 
 
-**Prev:** [Chapter 5: Introduction to Hosts](../chap-Introduction_to_Hosts) <br>
-**Next:** [Chapter 7: Enterprise Linux Hosts](../chap-Enterprise_Linux_Hosts)
+**Prev:** [Chapter 5: Introduction to Hosts](chap-Introduction_to_Hosts) <br>
+**Next:** [Chapter 7: Enterprise Linux Hosts](chap-Enterprise_Linux_Hosts)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/installation_guide/advanced_rhvh_install)

--- a/source/documentation/install-guide/index.html.md
+++ b/source/documentation/install-guide/index.html.md
@@ -1,0 +1,1 @@
+Installation_Guide.html.md

--- a/source/documentation/internal/guest-agent/guest-agent.html.md
+++ b/source/documentation/internal/guest-agent/guest-agent.html.md
@@ -45,8 +45,8 @@ The following actions can be requested from the agent:
 
 * **Lock screen** -- Request locking the user's desktop.
 * **Login** -- Perform a login on the user's behalf.
-* [Automatic login on RHEL](../guest-agent-automatic-login-rhel6)
-* [Automatic login on Microsoft's Windows](../guest-agent-automatic-login-windows)
+* [Automatic login on RHEL](guest-agent-automatic-login-rhel6)
+* [Automatic login on Microsoft's Windows](guest-agent-automatic-login-windows)
 * **Logoff** -- Log off the active user.
 * **Shutdown** -- Shut down the virtual machine.
 

--- a/source/documentation/internal/guest-agent/understanding-guest-agents-and-other-tools.html.md
+++ b/source/documentation/internal/guest-agent/understanding-guest-agents-and-other-tools.html.md
@@ -19,7 +19,7 @@ There are three tools which together can provide the best experience when using 
 
 ### oVirt Guest Agent
 
-The oVirt Guest Agent provides information, notifications, and actions between the oVirt web interface and the guest. A more detailed description can be found at [Guest Agent](../guest-agent). The agent provides the Machine Name, Operating System, IP Addresses, Installed Applications, Network and RAM usage and others details to the web interface. The agent also provides Single Sign On so a authenticated user to the web interface does not need to authenticate again when connected to a VM.
+The oVirt Guest Agent provides information, notifications, and actions between the oVirt web interface and the guest. A more detailed description can be found at [Guest Agent](guest-agent). The agent provides the Machine Name, Operating System, IP Addresses, Installed Applications, Network and RAM usage and others details to the web interface. The agent also provides Single Sign On so a authenticated user to the web interface does not need to authenticate again when connected to a VM.
 
 ### Spice Agent
 

--- a/source/documentation/intro-admin/Introduction_to_the_Administration_Portal.html.md
+++ b/source/documentation/intro-admin/Introduction_to_the_Administration_Portal.html.md
@@ -4,12 +4,12 @@ title: oVirt Introduction to the Administration Portal
 
 # oVirt oVirt Introduction to the Administration Portal
 
-## Chapter 1: [Using the Administration Portal](../chap-using_the_administration_portal)
+## Chapter 1: [Using the Administration Portal](chap-using_the_administration_portal)
 
-## Chapter 2: [Searches](../chap-searches)
+## Chapter 2: [Searches](chap-searches)
 
-## Chapter 3: [Bookmarks](../chap-bookmarks)
+## Chapter 3: [Bookmarks](chap-bookmarks)
 
-## Chapter 4: [Tags](../chap-tags)
+## Chapter 4: [Tags](chap-tags)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/introduction_to_the_administration_portal/)

--- a/source/documentation/intro-admin/chap-bookmarks.html.md
+++ b/source/documentation/intro-admin/chap-bookmarks.html.md
@@ -48,7 +48,7 @@ When a bookmark is no longer needed, remove it.
 
 3. Click **OK**.
 
-**Prev:** [Chapter 2: Searches](../chap-searches)<br>
-**Next:** [Chapter 4: Tags](../chap-tags)
+**Prev:** [Chapter 2: Searches](chap-searches)<br>
+**Next:** [Chapter 4: Tags](chap-tags)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/introduction_to_the_administration_portal/chap-bookmarks)

--- a/source/documentation/intro-admin/chap-searches.html.md
+++ b/source/documentation/intro-admin/chap-searches.html.md
@@ -2057,7 +2057,7 @@ The following table describes all search options you can use to search for event
 
 This example returns a list of events, where the event occurred on the virtual machine named `testdesktop` while it was running on the host `gonzo.example.com`.
 
-**Prev:** [Chapter 1: Using the Administration Portal](../chap-using_the_administration_portal)<br>
-**Next:** [Chapter 3: Bookmarks](../chap-bookmarks)
+**Prev:** [Chapter 1: Using the Administration Portal](chap-using_the_administration_portal)<br>
+**Next:** [Chapter 3: Bookmarks](chap-bookmarks)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/introduction_to_the_administration_portal/chap-searches)

--- a/source/documentation/intro-admin/chap-tags.html.md
+++ b/source/documentation/intro-admin/chap-tags.html.md
@@ -76,6 +76,6 @@ Enter a search query using `tag` as the property and the desired value or set of
 
 The objects tagged with the specified criteria are listed in the results list.
 
-**Prev:** [Chapter 3: Bookmarks](../chap-bookmarks)<br>
+**Prev:** [Chapter 3: Bookmarks](chap-bookmarks)<br>
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/introduction_to_the_administration_portal/chap-tags)

--- a/source/documentation/intro-admin/chap-using_the_administration_portal.html.md
+++ b/source/documentation/intro-admin/chap-using_the_administration_portal.html.md
@@ -109,6 +109,6 @@ When setting up resources such as data centers and clusters, a number of tasks m
 
 ![](/images/intro-admin/GuideMe.png)
 
-**Next:** [Chapter 2: Searches](../chap-searches)
+**Next:** [Chapter 2: Searches](chap-searches)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/introduction_to_the_administration_portal/chap-using_the_administration_portal)

--- a/source/documentation/intro-vm-portal/Viewing_virtual_machines.html.md
+++ b/source/documentation/intro-vm-portal/Viewing_virtual_machines.html.md
@@ -154,6 +154,6 @@ To restore the default icon, click the circular arrow.
 
       * **Smartcard enabled**: Allows you to pass the smartcard from your client machine to the virtual machine.
 
-**Prev:** [Chapter 1: Accessing the VM Portal](../What_is_the_VM_Portal)
+**Prev:** [Chapter 1: Accessing the VM Portal](What_is_the_VM_Portal)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/introduction_to_the_vm_portal/chap-managing_virtual_machines)

--- a/source/documentation/intro-vm-portal/What_is_the_VM_Portal.html.md
+++ b/source/documentation/intro-vm-portal/What_is_the_VM_Portal.html.md
@@ -156,6 +156,6 @@ You can perform common virtual machine tasks, change log-in options, and view me
 
    The virtual machines pane displays the icon, operating system, name, state, and management icons of each virtual machine and pooled virtual machine.
 
-**Next:** [Chapter 2: Managing Virtual Machines](../Viewing_virtual_machines)
+**Next:** [Chapter 2: Managing Virtual Machines](Viewing_virtual_machines)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/introduction_to_the_vm_portal/chap-accessing_the_vm_portal)

--- a/source/documentation/intro-vm-portal/intro-vm-portal.html.md
+++ b/source/documentation/intro-vm-portal/intro-vm-portal.html.md
@@ -4,8 +4,8 @@ title: oVirt Introduction to the VM Portal
 
 # oVirt Introduction to the VM Portal
 
-## Chapter 1: [Accessing the VM Portal](../What_is_the_VM_Portal)
+## Chapter 1: [Accessing the VM Portal](What_is_the_VM_Portal)
 
-## Chapter 2: [Managing Virtual Machines](../Viewing_virtual_machines)
+## Chapter 2: [Managing Virtual Machines](Viewing_virtual_machines)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/introduction_to_the_vm_portal/)

--- a/source/documentation/metrics-install-guide/Introduction.html.md
+++ b/source/documentation/metrics-install-guide/Introduction.html.md
@@ -44,6 +44,6 @@ Ansible is used to install OpenShift Aggregated Logging using OpenShift Ansible 
 
 Ensure that the time stamp in the **/var/log/ovirt-engine/engine.log** file contains a UTC offset suffix, rather than a letter such as Z. For example: 2018-03-27 13:35:06,720+01
 
-**Next:** [Chapter 2: Setting Up the oVirt Engine and Hosts](../Setting_Up_the_oVirt_Engine_and_Hosts)
+**Next:** [Chapter 2: Setting Up the oVirt Engine and Hosts](Setting_Up_the_oVirt_Engine_and_Hosts)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/metrics_store_installation_guide/introduction)

--- a/source/documentation/metrics-install-guide/Setting_Up_OpenShift_Aggregated_Logging.html.md
+++ b/source/documentation/metrics-install-guide/Setting_Up_OpenShift_Aggregated_Logging.html.md
@@ -85,11 +85,11 @@ Install centos-release-ovirt42 to get an updated ansible runtime
 
 Elasticsearch requires persistent storage for the database. By default, Elasticsearch uses ephemeral storage, and therefore you need to manually configure persistent storage.
 
-   **Important:** Before proceeding, ensure you have set up the storage according to the instructions in [Introduction](../Introduction).
+   **Important:** Before proceeding, ensure you have set up the storage according to the instructions in [Introduction](Introduction).
 
 **Configuring Persistent Storage for Elasticsearch**
 
-1. Create the `/lib/elasticsearch` directory that will be used for persistent storage using the `/var` mounted storage partition you created in [Introduction](../Introduction):
+1. Create the `/lib/elasticsearch` directory that will be used for persistent storage using the `/var` mounted storage partition you created in [Introduction](Introduction):
 
        # mkdir -p /var/lib/elasticsearch
 
@@ -199,7 +199,7 @@ On the Engine machine, run the following:
 
    **Note:** Deploying additional hosts after running this script does *not* require running the script again; the Manager configures the hosts automatically.
 
-**Prev:** [Chapter 2: Setting Up the oVirt Engine and Hosts](../Setting_Up_the_oVirt_Engine_and_Hosts)<br>
-**Next:** [Chapter 4: Verifying the Installation](../Verifying_the_Installation)
+**Prev:** [Chapter 2: Setting Up the oVirt Engine and Hosts](Setting_Up_the_oVirt_Engine_and_Hosts)<br>
+**Next:** [Chapter 4: Verifying the Installation](Verifying_the_Installation)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/metrics_store_installation_guide/chap-setting_up_openshift_aggregated_logging)

--- a/source/documentation/metrics-install-guide/Setting_Up_the_oVirt_Engine_and_Hosts.html.md
+++ b/source/documentation/metrics-install-guide/Setting_Up_the_oVirt_Engine_and_Hosts.html.md
@@ -70,7 +70,7 @@ Install a 4.2 environment as described in the _Installation Guide_ or _Self-Host
        # /usr/share/ovirt-engine-metrics/setup/ansible/configure_ovirt_machines_for_metrics.sh \
          --playbook=ovirt-metrics-store-installation.yml
 
-**Prev:** [Chapter 1: Introduction](../Introduction)<br>
-**Next:** [Chapter 3: Setting Up OpenShift Aggregated Logging](../Setting_Up_OpenShift_Aggregated_Logging)
+**Prev:** [Chapter 1: Introduction](Introduction)<br>
+**Next:** [Chapter 3: Setting Up OpenShift Aggregated Logging](Setting_Up_OpenShift_Aggregated_Logging)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/metrics_store_installation_guide/chap-setting_up_rhv_manager_and_hosts)

--- a/source/documentation/metrics-install-guide/Verifying_the_Installation.html.md
+++ b/source/documentation/metrics-install-guide/Verifying_the_Installation.html.md
@@ -10,7 +10,7 @@ Access the Kibana console to view the logs and statistics about clusters, hosts,
 
 1. Access Kibana at https://kibana.*<FQDN>*.
 
-2. In the **Discover** tab, check that you can view the **project.ovirt-logs-_ovirt_env_name_-uuid&#42;** index, where *ovirt_env_name* is the name you defined in [Configuring Collectd and Fluentd](../Configuring_Collectd_and_Fluentd).
+2. In the **Discover** tab, check that you can view the **project.ovirt-logs-_ovirt_env_name_-uuid&#42;** index, where *ovirt_env_name* is the name you defined in [Configuring Collectd and Fluentd](Configuring_Collectd_and_Fluentd).
    See the [Discover](https://www.elastic.co/guide/en/kibana/4.5/discover.html) section in the *Kibana documentation* for more information about working with logs.
 
 3. Use the **Visualization** tab to build visualization for the  **project.ovirt-metrics-_ovirt_env_name_-uuid&#42;**
@@ -20,6 +20,6 @@ See the Metrics User Guide for the available parameters. See the [Visualize](htt
 
     **Note:** You can access the OpenShift portal at https://*FQDN*:8443.
 
-**Prev:** [Chapter 3: Setting Up OpenShift Aggregated Logging](../Setting_Up_OpenShift_Aggregated_Logging)
+**Prev:** [Chapter 3: Setting Up OpenShift Aggregated Logging](Setting_Up_OpenShift_Aggregated_Logging)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/metrics_store_installation_guide/verifying_the_installation)

--- a/source/documentation/metrics-install-guide/metrics-install-guide.html.md
+++ b/source/documentation/metrics-install-guide/metrics-install-guide.html.md
@@ -4,12 +4,12 @@ title: oVirt Metrics Store Installation Guide
 
 # oVirt Metrics Store Installation Guide
 
-## Chapter 1: [Introduction](../Introduction)
+## Chapter 1: [Introduction](Introduction)
 
-## Chapter 2: [Setting Up the oVirt Engine and Hosts](../Setting_Up_the_oVirt_Engine_and_Hosts)
+## Chapter 2: [Setting Up the oVirt Engine and Hosts](Setting_Up_the_oVirt_Engine_and_Hosts)
 
-## Chapter 3: [Setting Up OpenShift Aggregated Logging](../Setting_Up_OpenShift_Aggregated_Logging)
+## Chapter 3: [Setting Up OpenShift Aggregated Logging](Setting_Up_OpenShift_Aggregated_Logging)
 
-## Chapter 4: [Verifying the Installation](../Verifying_the_Installation)
+## Chapter 4: [Verifying the Installation](Verifying_the_Installation)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/metrics_store_installation_guide/)

--- a/source/documentation/metrics-user-guide/Introduction.html.md
+++ b/source/documentation/metrics-user-guide/Introduction.html.md
@@ -4,7 +4,7 @@ title: Introduction
 
 # Chapter 1: Introduction
 
-The Metrics Store collects logs and metrics from oVirt. The data is transferred from oVirt to OpenShift where it is stored and aggregated in Elasticsearch and saved in [indexes](../Index). Elasticsearch is a distributed, RESTful search and analytics engine that lets you perform and combine many types of searches.
+The Metrics Store collects logs and metrics from oVirt. The data is transferred from oVirt to OpenShift where it is stored and aggregated in Elasticsearch and saved in [indexes](Index). Elasticsearch is a distributed, RESTful search and analytics engine that lets you perform and combine many types of searches.
 
 Use Kibana to search, view, and interact with real-time data stored in Elasticsearch indexes. Kibana is an open source analytics and visualization platform designed to work with Elasticsearch. You can easily perform advanced data analysis and visualize your data in a variety of charts and tables.
 
@@ -16,6 +16,6 @@ Kibana enables you to view and preempt critical problems, track system usage and
 
 2. Log in by entering your username and password.
 
-**Next:** [Chapter 2: Analyzing Metrics](../analyzing_metrics)
+**Next:** [Chapter 2: Analyzing Metrics](analyzing_metrics)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/metrics_store_user_guide/introduction)

--- a/source/documentation/metrics-user-guide/Logs.html.md
+++ b/source/documentation/metrics-user-guide/Logs.html.md
@@ -72,7 +72,7 @@ Filtering log data by field enables you to focus on the specific error that inte
    |ovirt.correlationid |For the engine.log only. This ID is used to correlate the multiple parts of a single task performed by the Manager.|
    |ovirt.thread |The name of a Java thread inside which the log record was produced.|
    |tag |Predefined sets of metadata that can be used to filter the data.|
-   |@timestamp |The [time](../Troubleshooting#information-is-missing-from-kibana) that the record was issued.|
+   |@timestamp |The [time](Troubleshooting#information-is-missing-from-kibana) that the record was issued.|
    |_score |N/A|
    |_type |N/A|
    |ipaddr4 | The machine's IP address.|
@@ -117,7 +117,7 @@ You can customize the way that the data is displayed in the Documents table by a
 
 3. Optionally click the **Sort by** arrow ![](/images/metrics-user-guide/arrow.png) that appears next to the column title to sort the results by that column.
 
-**Prev:** [Chapter 2: Analyzing Metrics](../analyzing_metrics)<br>
-**Next:** [Chapter 4: Troubleshooting](../Troubleshooting)
+**Prev:** [Chapter 2: Analyzing Metrics](analyzing_metrics)<br>
+**Next:** [Chapter 4: Troubleshooting](Troubleshooting)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/metrics_store_user_guide/chap-logs)

--- a/source/documentation/metrics-user-guide/Troubleshooting.html.md
+++ b/source/documentation/metrics-user-guide/Troubleshooting.html.md
@@ -24,8 +24,8 @@ If Kibana is not displaying metric or log information as expected, you can use `
 
         # journalctl -u fluentd
 
-    **Note:** To learn about the other journalctl options refer to the man page.  
+    **Note:** To learn about the other journalctl options refer to the man page.
 
-**Prev:** [Chapter 3: Analyzing Logs](../Logs)
+**Prev:** [Chapter 3: Analyzing Logs](Logs)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/metrics_store_user_guide/chap-troubleshooting)

--- a/source/documentation/metrics-user-guide/analyzing_metrics.html.md
+++ b/source/documentation/metrics-user-guide/analyzing_metrics.html.md
@@ -114,7 +114,7 @@ Use the visualization editor to create visualizations by:
 
 Use the toolbar to perform search queries based on the Lucene query parser syntax. For a detailed explanation of this syntax, see [Apache Lucene - Query Parser Syntax](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html).
 
-### Selecting Metrics and Aggregations  
+### Selecting Metrics and Aggregations
 
 Use the aggregation builder to define which metrics to display, how to aggregate the data, and how to group the results.
 
@@ -134,7 +134,7 @@ The aggregation builder performs two types of aggregations, metric and bucket, w
 
       **Note:** The order in which you define the buckets determines the order in which they will be executed, so the first aggregation determines the data set for any subsequent aggregations. For more information, see [Aggregation Builder](https://www.elastic.co/guide/en/kibana/4.5/visualize.html#aggregation-builder) in the Kibana documentation.
 
-   ii. Select the metric you want to display from the **Field** drop-down list. For details about each of the available metrics, see [Metrics Schema](../Metrics_Schema).
+   ii. Select the metric you want to display from the **Field** drop-down list. For details about each of the available metrics, see [Metrics Schema](Metrics_Schema).
 
    iii. Select the required interval from the **Interval** field.
 
@@ -292,7 +292,7 @@ The following table describes the CPU load metrics reported by the **Load** plug
 
 * **interval:** 10
 
-* **collectd.dstypes:** [Guide](../Gauge)
+* **collectd.dstypes:** [Guide](Gauge)
 
 ### Disk Consumption Metrics
 
@@ -369,7 +369,7 @@ The following table describes the disk operation metrics reported by the **Disk*
 
 ### Entropy Metrics
 
-Entropy metrics display the available entropy pool size on the host. Entropy is important for generating random numbers, which are used for encryption, authorization, and similar tasks.  
+Entropy metrics display the available entropy pool size on the host. Entropy is important for generating random numbers, which are used for encryption, authorization, and similar tasks.
 
 The following table describes the entropy metrics reported by the **Entropy** plugin.
 
@@ -770,22 +770,22 @@ The following table describes the process metrics reported by the **Processes** 
 |Metric Name |collectd.type |collectd.dstypes|
 |-
 |collectd.processes.ps_state |ps_state |Gauge|
-|collectd.processes.ps_disk_ops.read |ps_disk_ops |[Derive](../Derive)|
-|collectd.processes.ps_disk_ops.write |ps_disk_ops |[Derive](../Derive)|
+|collectd.processes.ps_disk_ops.read |ps_disk_ops |[Derive](Derive)|
+|collectd.processes.ps_disk_ops.write |ps_disk_ops |[Derive](Derive)|
 |collectd.processes.ps_vm |ps_vm |Gauge|
 |collectd.processes.ps_rss|ps_rss|Gauge|
 |collectd.processes.ps_data|ps_data|Gauge|
 |collectd.processes.ps_code|ps_code|Gauge|
 |collectd.processes.ps_stacksize|ps_stacksize|Gauge|
-|collectd.processes.ps_cputime.syst|ps_cputime|[Derive](../Derive)|
-|collectd.processes.ps_cputime.user|ps_cputime|[Derive](../Derive)|
+|collectd.processes.ps_cputime.syst|ps_cputime|[Derive](Derive)|
+|collectd.processes.ps_cputime.user|ps_cputime|[Derive](Derive)|
 |collectd.processes.ps_count.processes|ps_count|Gauge|
 |collectd.processes.ps_count.threads|ps_count|Gauge|
-|collectd.processes.ps_pagefaults.majfltadd |ps_pagefaults|[Derive](../Derive)|
-|collectd.processes.ps_pagefaults.minflt |ps_pagefaults|[Derive](../Derive)|
-|collectd.processes.ps_disk_octets.write |ps_disk_octets |[Derive](../Derive)|
-| collectd.processes.ps_disk_octets.read|ps_disk_octets |[Derive](../Derive)|
-|collectd.processes.fork_rate |fork_rate |[Derive](../Derive)|
+|collectd.processes.ps_pagefaults.majfltadd |ps_pagefaults|[Derive](Derive)|
+|collectd.processes.ps_pagefaults.minflt |ps_pagefaults|[Derive](Derive)|
+|collectd.processes.ps_disk_octets.write |ps_disk_octets |[Derive](Derive)|
+| collectd.processes.ps_disk_octets.read|ps_disk_octets |[Derive](Derive)|
+|collectd.processes.fork_rate |fork_rate |[Derive](Derive)|
 
 **Additional Values**
 
@@ -818,7 +818,7 @@ The following table describes the Swap metrics reported by the **Swap** plugin.
 |Metric Name |collectd.type |collectd.type_instance|collectd.dstypes |Description|
 |-
 |collectd.swap.swap |swap |used / free /  cached|Gauge|The used, available, and cached swap space (in bytes). |
-|collectd.swap.swap_io|swap_io |in / out |[Derive](../Derive) |The number of swap pages written and read per second.\
+|collectd.swap.swap_io|swap_io |in / out |[Derive](Derive) |The number of swap pages written and read per second.\
 |collectd.swap.percent|percent |used / free / cached |Gauge |The percentage of used, available, and cached swap space.|
 
 **Additional Fields**
@@ -845,27 +845,27 @@ The following table describes the virtual machine metrics reported by the **Virt
 
 |Metric Name |collectd.type |collectd.type_instance |collectd.dstypes
 |-
-|collectd.virt.ps_cputime.syst |ps_cputime.syst |N/A |[Derive](../Derive)|
+|collectd.virt.ps_cputime.syst |ps_cputime.syst |N/A |[Derive](Derive)|
 |collectd.virt.percent |percent |virt_cpu_total |Gauge|
-|collectd.virt.ps_cputime.user |ps_cputime.user |N/A |[Derive](../Derive)|
-|collectd.virt.virt_cpu_total |virt_cpu_total |CPU number |[Derive](../Derive)|
-|collectd.virt.virt_vcpu |virt_vcpu |CPU number |[Derive](../Derive)|
+|collectd.virt.ps_cputime.user |ps_cputime.user |N/A |[Derive](Derive)|
+|collectd.virt.virt_cpu_total |virt_cpu_total |CPU number |[Derive](Derive)|
+|collectd.virt.virt_vcpu |virt_vcpu |CPU number |[Derive](Derive)|
 |collectd.virt.disk_octets.read |disk_octets.read |disk name |Gauge|
 |collectd.virt.disk_ops.read |disk_ops.read |disk name |Gauge|
 |collectd.virt.disk_octets.write |disk_octets.write |disk name |Gauge|
 |collectd.virt.disk_ops.write |disk_ops.write |disk name |Gauge|
-|collectd.virt.if_octets.rx |if_octets.rx |network name |[Derive](../Derive)|
-|collectd.virt.if_dropped.rx |if_dropped.rx |network name |[Derive](../Derive)|
-|collectd.virt.if_errors.rx|if_errors.rx |network name |[Derive](../Derive)|
-|collectd.virt.if_octets.tx|if_octets.tx |network name |[Derive](../Derive)|
-|collectd.virt.if_dropped.tx |if_dropped.tx |network name |[Derive](../Derive)|
-|collectd.virt.if_errors.tx |if_errors.tx |network name |[Derive](../Derive)|
-|collectd.virt.if_packets.rx |if_packets.rx |network name |[Derive](../Derive)|
-|collectd.virt.if_packets.tx |if_packets.tx |network name |[Derive](../Derive)|
+|collectd.virt.if_octets.rx |if_octets.rx |network name |[Derive](Derive)|
+|collectd.virt.if_dropped.rx |if_dropped.rx |network name |[Derive](Derive)|
+|collectd.virt.if_errors.rx|if_errors.rx |network name |[Derive](Derive)|
+|collectd.virt.if_octets.tx|if_octets.tx |network name |[Derive](Derive)|
+|collectd.virt.if_dropped.tx |if_dropped.tx |network name |[Derive](Derive)|
+|collectd.virt.if_errors.tx |if_errors.tx |network name |[Derive](Derive)|
+|collectd.virt.if_packets.rx |if_packets.rx |network name |[Derive](Derive)|
+|collectd.virt.if_packets.tx |if_packets.tx |network name |[Derive](Derive)|
 |collectd.virt.memory|memory |rss / total /actual_balloon / available / unused / usable / last_update / major_fault / minor_fault / swap_in / swap_out |Gauge|
-|collectd.virt.total_requests |total_requests |flush-DISK |[Derive](../Derive)|
-|collectd.virt.total_time_in_ms |total_time_in_ms |flush-DISK |[Derive](../Derive)|
-|collectd.virt.total_time_in_ms |total_time_in_ms |flush-DISK |[Derive](../Derive)|
+|collectd.virt.total_requests |total_requests |flush-DISK |[Derive](Derive)|
+|collectd.virt.total_time_in_ms |total_time_in_ms |flush-DISK |[Derive](Derive)|
+|collectd.virt.total_time_in_ms |total_time_in_ms |flush-DISK |[Derive](Derive)|
 
 **Additional Values**
 
@@ -911,7 +911,7 @@ When using the **Discover** page, select the index named project.ovirt-logs-&lt;
 
 In the **Visualization** page select project.ovirt-metrics-&lt;ovirt-env-name>.uuid for metrics data or project.ovirt-logs-&lt;ovirt-env-name>.uuid for log data.
 
-**Prev:** [Chapter 1: Introduction](../Introduction)<br>
-**Next:** [Chapter 3: Analyzing Logs](../Logs)
+**Prev:** [Chapter 1: Introduction](Introduction)<br>
+**Next:** [Chapter 3: Analyzing Logs](Logs)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/metrics_store_user_guide/chap-metrics)

--- a/source/documentation/metrics-user-guide/metrics-user-guide.html.md
+++ b/source/documentation/metrics-user-guide/metrics-user-guide.html.md
@@ -4,12 +4,12 @@ title: Metrics Store User Guide
 
 # Metrics Store User Guide
 
-## Chapter 1: [Introduction](../Introduction)
+## Chapter 1: [Introduction](Introduction)
 
-## Chapter 2: [Analyzing Metrics](../analyzing_metrics)
+## Chapter 2: [Analyzing Metrics](analyzing_metrics)
 
-## Chapter 3: [Analyzing Logs](../Logs)
+## Chapter 3: [Analyzing Logs](Logs)
 
-## Chapter 4: [Troubleshooting](../Troubleshooting)
+## Chapter 4: [Troubleshooting](Troubleshooting)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/metrics_store_user_guide/index)

--- a/source/documentation/self-hosted/Self-Hosted_Engine_Guide.html.md
+++ b/source/documentation/self-hosted/Self-Hosted_Engine_Guide.html.md
@@ -4,20 +4,20 @@ title: oVirt Self-Hosted Engine Guide
 
 # oVirt Self-Hosted Engine Guide
 
-## Chapter 1: [Introduction](../chap-Introduction)
+## Chapter 1: [Introduction](chap-Introduction)
 
-## Chapter 2: [Deploying Self-Hosted Engine](../chap-Deploying_Self-Hosted_Engine)
+## Chapter 2: [Deploying Self-Hosted Engine](chap-Deploying_Self-Hosted_Engine)
 
-## Chapter 3: [Troubleshooting a Self-Hosted Engine Deployment](../chap-Troubleshooting)
+## Chapter 3: [Troubleshooting a Self-Hosted Engine Deployment](chap-Troubleshooting)
 
-## Chapter 4: [Migrating from Bare Metal to an EL-Based Self-Hosted Environment](../chap-Migrating_from_Bare_Metal_to_an_EL-Based_Self-Hosted_Environment)
+## Chapter 4: [Migrating from Bare Metal to an EL-Based Self-Hosted Environment](chap-Migrating_from_Bare_Metal_to_an_EL-Based_Self-Hosted_Environment)
 
-## Chapter 5: [Administering the Self-Hosted Engine](../chap-Maintenance_and_Upgrading_Resources)
+## Chapter 5: [Administering the Self-Hosted Engine](chap-Maintenance_and_Upgrading_Resources)
 
-## Chapter 6: [Upgrading the Self-Hosted Engine](../chap-upgrading_the_self-hosted_engine)
+## Chapter 6: [Upgrading the Self-Hosted Engine](chap-upgrading_the_self-hosted_engine)
 
-## Chapter 7: [Backing up and Restoring an EL-Based Self-Hosted Environment](../chap-Backing_up_and_Restoring_an_EL-Based_Self-Hosted_Environment)
+## Chapter 7: [Backing up and Restoring an EL-Based Self-Hosted Environment](chap-Backing_up_and_Restoring_an_EL-Based_Self-Hosted_Environment)
 
-## Chapter 8: [Migrating the Self-Hosted Engine Database to a Remote Server Database](../chap-Migrating_Databases)
+## Chapter 8: [Migrating the Self-Hosted Engine Database to a Remote Server Database](chap-Migrating_Databases)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/self-hosted_engine_guide/)

--- a/source/documentation/self-hosted/chap-Backing_up_and_Restoring_an_EL-Based_Self-Hosted_Environment.html.md
+++ b/source/documentation/self-hosted/chap-Backing_up_and_Restoring_an_EL-Based_Self-Hosted_Environment.html.md
@@ -44,7 +44,7 @@ This procedure provides an example of the workflow for restoring the self-hosted
 
     Any standard RHEL-based hosts - hosts that are present in the environment but are not self-hosted engine hosts - that are operational will become active, and the virtual machines that were active at the time of backup will now be running on these hosts and available in the Engine.
 
-2. `Host 2` and `Host 3` are not recoverable in their current state. These hosts need to be removed from the environment, and then added again to the environment using the hosted-engine deployment script. For more information on these actions, see the Removing Non-Operational Hosts from a Restored Self-Hosted Engine Environment section below and [Chapter 7: Installing Additional Hosts to a Self-Hosted Environment](../chap-Installing_Additional_Hosts_to_a_Self-Hosted_Environment).
+2. `Host 2` and `Host 3` are not recoverable in their current state. These hosts need to be removed from the environment, and then added again to the environment using the hosted-engine deployment script. For more information on these actions, see the Removing Non-Operational Hosts from a Restored Self-Hosted Engine Environment section below and [Chapter 7: Installing Additional Hosts to a Self-Hosted Environment](chap-Installing_Additional_Hosts_to_a_Self-Hosted_Environment).
 
     ![](/images/self-hosted/RHEV_SHE_bkup_03.png)
 
@@ -165,9 +165,9 @@ You can restore a self-hosted engine on hardware that was used in the backed-up 
 
         **Note:** If you wish to specify more than one iSCSI target, you must enable multipathing before deploying the self-hosted engine. There is also a Multipath Helper tool that generates a script to install and configure multipath with different options.
 
-            Please specify the iSCSI portal IP address:           
-            Please specify the iSCSI portal port [3260]:           
-            Please specify the iSCSI portal user:           
+            Please specify the iSCSI portal IP address:
+            Please specify the iSCSI portal port [3260]:
+            Please specify the iSCSI portal user:
             Please specify the iSCSI portal password:
             Please specify the target name (auto-detected values) [default]:
 
@@ -217,7 +217,7 @@ You can restore a self-hosted engine on hardware that was used in the backed-up 
     The script creates a virtual machine to be configured as the new Engine virtual machine. Specify the boot device and, if applicable, the path name of the installation media, the image alias, the CPU type, the number of virtual CPUs, and the disk size. Specify a MAC address for the Engine virtual machine, or accept a randomly generated one. The MAC address can be used to update your DHCP server prior to installing the operating system on the Engine virtual machine. Specify memory size and console connection type for the creation of Engine virtual machine.
 
         Please specify the device to boot the VM from (cdrom, disk, pxe) [cdrom]:
-        Please specify an alias for the Hosted Engine image [hosted_engine]:  
+        Please specify an alias for the Hosted Engine image [hosted_engine]:
         The following CPU types are supported by this host:
                   - model_Penryn: Intel Penryn Family
                   - model_Conroe: Intel Conroe Family
@@ -811,7 +811,7 @@ Once a host has been fenced in the Administration Portal, it can be forcefully r
 
 The host can now be re-installed to the self-hosted engine environment.
 
-**Prev:** [Chapter 6: Upgrading the Self-Hosted Engine](../chap-upgrading_the_self-hosted_engine)<br>
-**Next:** [Chapter 8: Migrating the Self-Hosted Engine Database to a Remote Server Database](../chap-Migrating_Databases)
+**Prev:** [Chapter 6: Upgrading the Self-Hosted Engine](chap-upgrading_the_self-hosted_engine)<br>
+**Next:** [Chapter 8: Migrating the Self-Hosted Engine Database to a Remote Server Database](chap-Migrating_Databases)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/self-hosted_engine_guide/chap-backing_up_and_restoring_a_rhel-based_self-hosted_environment)

--- a/source/documentation/self-hosted/chap-Data_Warehouse_and_Reports.html.md
+++ b/source/documentation/self-hosted/chap-Data_Warehouse_and_Reports.html.md
@@ -28,4 +28,4 @@ To force `engine-setup` to present both options again, run `engine-setup --recon
 
 **Note:** To configure only the currently installed Data Warehouse packages, and prevent setup from applying package updates found in enabled repositories, add the `--offline` option .
 
-**Prev:** [Chapter 8: Migrating Databases](../chap-Migrating_Databases)
+**Prev:** [Chapter 8: Migrating Databases](chap-Migrating_Databases)

--- a/source/documentation/self-hosted/chap-Deploying_Self-Hosted_Engine.html.md
+++ b/source/documentation/self-hosted/chap-Deploying_Self-Hosted_Engine.html.md
@@ -348,9 +348,9 @@ When the deployment completes successfully, one data center, cluster, host, stor
 
 The Engine virtual machine, the host running it, and the self-hosted engine storage domain are flagged with a gold crown in the Administration Portal.
 
-See [Chapter 3: Troubleshooting](../chap-Troubleshooting) for more information.
+See [Chapter 3: Troubleshooting](chap-Troubleshooting) for more information.
 
-**Prev:** [Chapter 1: Introduction](../chap-Introduction) <br>
-**Next:** [Chapter 3: Troubleshooting a Self-Hosted Engine Deployment](../chap-Troubleshooting)
+**Prev:** [Chapter 1: Introduction](chap-Introduction) <br>
+**Next:** [Chapter 3: Troubleshooting a Self-Hosted Engine Deployment](chap-Troubleshooting)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/self-hosted_engine_guide/chap-deploying_self-hosted_engine)

--- a/source/documentation/self-hosted/chap-Installing_Additional_Hosts_to_a_Self-Hosted_Environment.html.md
+++ b/source/documentation/self-hosted/chap-Installing_Additional_Hosts_to_a_Self-Hosted_Environment.html.md
@@ -10,7 +10,7 @@ Additional self-hosted engine hosts are added in the same way as a regular host,
 
 * For a oVirt Node-based self-hosted engine environment, you must have prepared a freshly installed oVirt Node system on a physical host. See "oVirt Nodes" in the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
-* If you are reusing a self-hosted engine host, remove its existing self-hosted engine configuration. See the Removing a Host from a Self-Hosted Engine Environment section in [Chapter 5: Maintenance and Upgrading Resources](../chap-Maintenance_and_Upgrading_Resources).
+* If you are reusing a self-hosted engine host, remove its existing self-hosted engine configuration. See the Removing a Host from a Self-Hosted Engine Environment section in [Chapter 5: Maintenance and Upgrading Resources](chap-Maintenance_and_Upgrading_Resources).
 
 **Adding an Additional Self-Hosted Engine Host**
 
@@ -40,5 +40,5 @@ Additional self-hosted engine hosts are added in the same way as a regular host,
 
 _Note: To add the ability to deploy the Self-Hosted Engine on an existing host, you must select **Installation** and choose **Reinstall** on the host and repeat the above steps._
 
-**Prev:** [Chapter 6: Backing up and Restoring an EL-Based Self-Hosted Environment](../chap-Backing_up_and_Restoring_an_EL-Based_Self-Hosted_Environment) <br>
-**Next:** [Chapter 8: Migrating Databases](../chap-Migrating_Databases)
+**Prev:** [Chapter 6: Backing up and Restoring an EL-Based Self-Hosted Environment](chap-Backing_up_and_Restoring_an_EL-Based_Self-Hosted_Environment) <br>
+**Next:** [Chapter 8: Migrating Databases](chap-Migrating_Databases)

--- a/source/documentation/self-hosted/chap-Introduction.html.md
+++ b/source/documentation/self-hosted/chap-Introduction.html.md
@@ -20,6 +20,6 @@ For hardware requirements, see "Hypervisor Requirements" in the [Installation Gu
 
     **Important:** It is important to synchronize the system clocks of the hosts, Engine, and other servers in the environment to avoid potential timing or authentication issues. To do this, configure the Network Time Protocol (NTP) on each system to synchronize with the same NTP server.
 
-**Next:** [Chapter 2: Deploying Self-Hosted Engine](../chap-Deploying_Self-Hosted_Engine)
+**Next:** [Chapter 2: Deploying Self-Hosted Engine](chap-Deploying_Self-Hosted_Engine)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/self-hosted_engine_guide/chap-introduction)

--- a/source/documentation/self-hosted/chap-Maintenance_and_Upgrading_Resources.html.md
+++ b/source/documentation/self-hosted/chap-Maintenance_and_Upgrading_Resources.html.md
@@ -168,7 +168,7 @@ If you wish to remove a self-hosted engine host from your environment, you will 
 
 6. Optionally, click **Remove** to open the **Remove Host(s)** confirmation window and click **OK**.
 
-**Prev:** [Chapter 4: Migrating from Bare Metal to an EL-Based Self-Hosted Environment](../chap-Migrating_from_Bare_Metal_to_an_EL-Based_Self-Hosted_Environment) <br>
-**Next:** [Chapter 6: Upgrading the Self-Hosted Engine](../chap-upgrading_the_self-hosted_engine)
+**Prev:** [Chapter 4: Migrating from Bare Metal to an EL-Based Self-Hosted Environment](chap-Migrating_from_Bare_Metal_to_an_EL-Based_Self-Hosted_Environment) <br>
+**Next:** [Chapter 6: Upgrading the Self-Hosted Engine](chap-upgrading_the_self-hosted_engine)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/self-hosted_engine_guide/chap-administering_the_self-hosted_engine)

--- a/source/documentation/self-hosted/chap-Migrating_Databases.html.md
+++ b/source/documentation/self-hosted/chap-Migrating_Databases.html.md
@@ -40,6 +40,6 @@ You can migrate the engine database of a self-hosted engine to a remote database
 
         # hosted-engine --set-maintenance --mode=none
 
-**Prev:** [Chapter 7: Backing up and Restoring an EL-Based Self-Hosted Environment](../chap-Backing_up_and_Restoring_an_EL-Based_Self-Hosted_Environment)
+**Prev:** [Chapter 7: Backing up and Restoring an EL-Based Self-Hosted Environment](chap-Backing_up_and_Restoring_an_EL-Based_Self-Hosted_Environment)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/self-hosted_engine_guide/chap-migrating_databases)

--- a/source/documentation/self-hosted/chap-Migrating_from_Bare_Metal_to_an_EL-Based_Self-Hosted_Environment.html.md
+++ b/source/documentation/self-hosted/chap-Migrating_from_Bare_Metal_to_an_EL-Based_Self-Hosted_Environment.html.md
@@ -20,7 +20,7 @@ The migration involves the following key actions:
 
 **Prerequisites**
 
-* Prepare a new host with the `ovirt-hosted-engine-setup` package installed. See [Chapter 2: Deploying Self-Hosted Engine](../chap-Deploying_Self-Hosted_Engine) for more information on subscriptions and package installation. The host must be a supported version of the current oVirt environment.
+* Prepare a new host with the `ovirt-hosted-engine-setup` package installed. See [Chapter 2: Deploying Self-Hosted Engine](chap-Deploying_Self-Hosted_Engine) for more information on subscriptions and package installation. The host must be a supported version of the current oVirt environment.
 
     **Note:** If you intend to use an existing host, place the host in maintenance and remove it from the existing environment. See "Removing a Host" in the [Administration Guide](/documentation/admin-guide/administration-guide/) for more information.
 
@@ -69,9 +69,9 @@ The migration involves the following key actions:
 
         **Note:** If you wish to specify more than one iSCSI target, you must enable multipathing before deploying the self-hosted engine. There is also a Multipath Helper tool that generates a script to install and configure multipath with different options.
 
-            Please specify the iSCSI portal IP address:           
-            Please specify the iSCSI portal port [3260]:           
-            Please specify the iSCSI portal user:           
+            Please specify the iSCSI portal IP address:
+            Please specify the iSCSI portal port [3260]:
+            Please specify the iSCSI portal user:
             Please specify the iSCSI portal password:
             Please specify the target name (auto-detected values) [default]:
 
@@ -248,7 +248,7 @@ The migration involves the following key actions:
     SSH password authentication is not enabled by default on the oVirt Engine Virtual Appliance. Connect to HostedEngine-VM via VNC and enable SSH password authentication so that you can access the virtual machine via SSH later to restore the BareMetal-Engine backup file and configure the new Engine. Verify that the `sshd` service is running. Edit `/etc/ssh/sshd_config` and change the following two options to `yes`:
 
         [...]
-        PermitRootLogin yes       
+        PermitRootLogin yes
         [...]
         PasswordAuthentication yes
 
@@ -408,7 +408,7 @@ The migration involves the following key actions:
 
 Your oVirt Engine has been migrated to a self-hosted engine setup. The Engine is now operating on a virtual machine on Host-HE1, called HostedEngine-VM in the environment. As HostedEngine-VM is highly available, it is migrated to other hosts in the environment when applicable.
 
-**Prev:** [Chapter 3: Troubleshooting](../chap-Troubleshooting) <br>
-**Next:** [Chapter 5: Administering the Self-Hosted Engine](../chap-Maintenance_and_Upgrading_Resources)
+**Prev:** [Chapter 3: Troubleshooting](chap-Troubleshooting) <br>
+**Next:** [Chapter 5: Administering the Self-Hosted Engine](chap-Maintenance_and_Upgrading_Resources)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/self-hosted_engine_guide/chap-migrating_from_bare_metal_to_a_rhel-based_self-hosted_environment)

--- a/source/documentation/self-hosted/chap-Troubleshooting.html.md
+++ b/source/documentation/self-hosted/chap-Troubleshooting.html.md
@@ -128,7 +128,7 @@ If a self-hosted engine deployment was interrupted, subsequent deployments will 
 
 3. Redeploy the self-hosted engine.
 
-**Prev:** [Chapter 2: Deploying Self-Hosted Engine](../chap-Deploying_Self-Hosted_Engine) <br>
-**Next:** [Chapter 4: Migrating from Bare Metal to an EL-Based Self-Hosted Environment](../chap-Migrating_from_Bare_Metal_to_an_EL-Based_Self-Hosted_Environment)
+**Prev:** [Chapter 2: Deploying Self-Hosted Engine](chap-Deploying_Self-Hosted_Engine) <br>
+**Next:** [Chapter 4: Migrating from Bare Metal to an EL-Based Self-Hosted Environment](chap-Migrating_from_Bare_Metal_to_an_EL-Based_Self-Hosted_Environment)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/self-hosted_engine_guide/troubleshooting)

--- a/source/documentation/self-hosted/chap-upgrading_the_self-hosted_engine.html.md
+++ b/source/documentation/self-hosted/chap-upgrading_the_self-hosted_engine.html.md
@@ -210,7 +210,7 @@ Upgrading from a oVirt 3.6 self-hosted engine environment with oVirt Node 3.6 ho
 
 5. Upgrade the Engine from 4.1 to 4.2 and then upgrade the final remaining oVirt Node 4.0 host to 4.2 using the instructions in Upgrading a Self-Hosted Engine Environment.
 
-**Prev:** [Chapter 5: Migrating from Bare Metal to an EL-Based Self-Hosted Environment](../chap-Migrating_from_Bare_Metal_to_an_EL-Based_Self-Hosted_Environment) <br>
-**Next:** [Chapter 7: Backing up and Restoring an EL-Based Self-Hosted Environment](../chap-Backing_up_and_Restoring_an_EL-Based_Self-Hosted_Environment)
+**Prev:** [Chapter 5: Migrating from Bare Metal to an EL-Based Self-Hosted Environment](chap-Migrating_from_Bare_Metal_to_an_EL-Based_Self-Hosted_Environment) <br>
+**Next:** [Chapter 7: Backing up and Restoring an EL-Based Self-Hosted Environment](chap-Backing_up_and_Restoring_an_EL-Based_Self-Hosted_Environment)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/self-hosted_engine_guide/chap-upgrading_the_self-hosted_engine)

--- a/source/documentation/upgrade-guide/appe-Manually_Updating_Hosts.html.md
+++ b/source/documentation/upgrade-guide/appe-Manually_Updating_Hosts.html.md
@@ -36,6 +36,6 @@ You can use the `yum` command to update your hosts. Update your systems regularl
 
 Repeat this process for each host in the Red Hat Virtualization environment.
 
-**Prev:** [Appendix C: Manually Updating Hosts](../appe-Manually_Updating_Hosts)
+**Prev:** [Appendix C: Manually Updating Hosts](appe-Manually_Updating_Hosts)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/upgrade_guide/manually_updating_hosts_upgrade)

--- a/source/documentation/upgrade-guide/appe-Updating_an_Offline_oVirt_Engine.html.md
+++ b/source/documentation/upgrade-guide/appe-Updating_an_Offline_oVirt_Engine.html.md
@@ -14,9 +14,9 @@ If your oVirt Engine is hosted on a system that receives packages via FTP from a
 
    This command may download a large number of packages, and take a long time to complete.
 
-2. Ensure that the repository is available on the Engine system, and then update or upgrade the Engine system. See [Chapter 9: Updates Between Minor Releases](../chap-Updates_between_Minor_Releases/) for information on updating the Engine between minor versions.
+2. Ensure that the repository is available on the Engine system, and then update or upgrade the Engine system. See [Chapter 9: Updates Between Minor Releases](chap-Updates_between_Minor_Releases/) for information on updating the Engine between minor versions.
 
-**Prev:** [Chapter 9: Updates Between Minor Releases](../chap-Updates_between_Minor_Releases/)<br>
-**Next:** [Appendix B: Upgrading to oVirt Engine 4.2 with ovirt-fast-forward-upgrade](../appe-Upgrading_to_oVirt_Engine_4.2_with_ovirt-fast-forward-upgrade.html.md)
+**Prev:** [Chapter 9: Updates Between Minor Releases](chap-Updates_between_Minor_Releases/)<br>
+**Next:** [Appendix B: Upgrading to oVirt Engine 4.2 with ovirt-fast-forward-upgrade](appe-Upgrading_to_oVirt_Engine_4.2_with_ovirt-fast-forward-upgrade.html.md)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/upgrade_guide/appe-updating_an_offline_red_hat_enterprise_virtualization_manager)

--- a/source/documentation/upgrade-guide/appe-Upgrading_to_oVirt_Engine_4.2_with_ovirt-fast-forward-upgrade.html.md
+++ b/source/documentation/upgrade-guide/appe-Upgrading_to_oVirt_Engine_4.2_with_ovirt-fast-forward-upgrade.html.md
@@ -6,7 +6,7 @@ title: Updating an Offline oVirt Engine
 
 If you have oVirt 4.0 or later installed, you can upgrade the Engine to the latest version with the `ovirt-fast-forward-upgrade` tool. `ovirt-fast-forward-upgrade` detects the current version of the Engine and checks for available upgrades. If an upgrade is available, the tool upgrades the Manager to the next major version, and continues to upgrade the Manager until the latest version is installed.
 
-    **Note:** ovirt-fast-forward-upgrade upgrades the Manager. See [Appendix C: Manually Updating Hosts](../appe-Manually_Updating_Hosts) to upgrade the hosts.
+    **Note:** ovirt-fast-forward-upgrade upgrades the Manager. See [Appendix C: Manually Updating Hosts](appe-Manually_Updating_Hosts) to upgrade the hosts.
 
 **Upgrading with `ovirt-fast-forward-upgrade`**
 
@@ -34,7 +34,7 @@ If you have oVirt 4.0 or later installed, you can upgrade the Engine to the late
 
 3. If there are errors, check the log: `/var/log/ovirt-engine/ovirt-fast-forward-upgrade.log`.
 
-**Prev:** [Appendix B: Upgrading to oVirt Engine 4.2 with ovirt-fast-forward-upgrade](../appe-Upgrading_to_oVirt_Engine_4.2_with_ovirt-fast-forward-upgrade.html.md)<br>
-**Next:** [Appendix C: Manually Updating Hosts](../appe-Manually_Updating_Hosts)
+**Prev:** [Appendix B: Upgrading to oVirt Engine 4.2 with ovirt-fast-forward-upgrade](appe-Upgrading_to_oVirt_Engine_4.2_with_ovirt-fast-forward-upgrade.html.md)<br>
+**Next:** [Appendix C: Manually Updating Hosts](appe-Manually_Updating_Hosts)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/upgrade_guide/upgrading_with_ovirt-fast-forward-upgrade)

--- a/source/documentation/upgrade-guide/chap-Post-Upgrade_Tasks.html.md
+++ b/source/documentation/upgrade-guide/chap-Post-Upgrade_Tasks.html.md
@@ -204,9 +204,9 @@ If you installed an Open Virtual Network (OVN) provider in oVirt 4.1, you must m
 
 3. Click the **Networking Plugin** text field and select **oVirt Network Provider for OVN** from the drop-down list.
 
-4. Click **OK**.  
+4. Click **OK**.
 
-**Prev:** [Chapter 7: Upgrading a Remote Database Environment from 4.1 to oVirt 4.2](../chap-Upgrading_a_Remote_Database_Environment_from_4.1_to_oVirt_4.2)<br>
-**Next:** [Chapter 9: Updates Between Minor Releases](../chap-Updates_between_Minor_Releases/)
+**Prev:** [Chapter 7: Upgrading a Remote Database Environment from 4.1 to oVirt 4.2](chap-Upgrading_a_Remote_Database_Environment_from_4.1_to_oVirt_4.2)<br>
+**Next:** [Chapter 9: Updates Between Minor Releases](chap-Updates_between_Minor_Releases/)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/upgrade_guide/chap-post-upgrade_tasks)

--- a/source/documentation/upgrade-guide/chap-Updates_between_Minor_Releases.html.md
+++ b/source/documentation/upgrade-guide/chap-Updates_between_Minor_Releases.html.md
@@ -125,9 +125,9 @@ If the command fails, the host is oVirt Node 3.6. If the command succeeds, the h
 
 Repeat this procedure for each host in the oVirt environment.
 
-The oVirt Project recommends updating the hosts from the Engine; however, you can also update the hosts using `yum update`. See [Appendix C: Manually Updating Hosts](../appe-Manually_Updating_Hosts) for more information.
+The oVirt Project recommends updating the hosts from the Engine; however, you can also update the hosts using `yum update`. See [Appendix C: Manually Updating Hosts](appe-Manually_Updating_Hosts) for more information.
 
-**Prev:** [Chapter 8: Post-Upgrade Tasks](../chap-Post-Upgrade_Tasks/)<br>
-**Next:** [Appendix A: Updating an Offline oVirt Engine](../appe-Updating_an_Offline_oVirt_Engine/)
+**Prev:** [Chapter 8: Post-Upgrade Tasks](chap-Post-Upgrade_Tasks/)<br>
+**Next:** [Appendix A: Updating an Offline oVirt Engine](appe-Updating_an_Offline_oVirt_Engine/)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/upgrade_guide/updates_between_minor_releases)

--- a/source/documentation/upgrade-guide/chap-Updating_the_oVirt_Environment.html.md
+++ b/source/documentation/upgrade-guide/chap-Updating_the_oVirt_Environment.html.md
@@ -12,7 +12,7 @@ This guide explains how to upgrade your current environment to 4.2. Two upgrade 
 
 * **Remote Database:** Data Warehouse is on a separate machine.
 
-To upgrade a self-hosted engine, see "Upgrading a Self-Hosted Engine Environment" in the [Self-Hosted Engine Guide](../self-hosted/Self-Hosted_Engine_Guide).
+To upgrade a self-hosted engine, see "Upgrading a Self-Hosted Engine Environment" in the [Self-Hosted Engine Guide](self-hosted/Self-Hosted_Engine_Guide).
 
 Select the appropriate instructions for your environment from the following table. Note that the source version refers to the Engine version. If your Engine and host versions differ (if you have previously upgraded the Engine but not the hosts), follow the instructions that match the Engine’s version.
 
@@ -31,36 +31,36 @@ Select the appropriate instructions for your environment from the following tabl
    <td>3.6</td>
    <td>4.2</td>
    <td>
-   <p><b>Local database environment:</b> [Chapter 2, Upgrading from 3.6 to oVirt 4.2](../chap-Upgrading_from_3.6_to_oVirt_4.2)</p>
-   <p><b>Remote database environment:</b> [Chapter 5, Upgrading a Remote Database Environment from 3.6 to oVirt 4.2](../chap-Upgrading_a_Remote_Database_Environment_from_3.6_to_oVirt_4.2)</p>
+   <p><b>Local database environment:</b> [Chapter 2, Upgrading from 3.6 to oVirt 4.2](chap-Upgrading_from_3.6_to_oVirt_4.2)</p>
+   <p><b>Remote database environment:</b> [Chapter 5, Upgrading a Remote Database Environment from 3.6 to oVirt 4.2](chap-Upgrading_a_Remote_Database_Environment_from_3.6_to_oVirt_4.2)</p>
   </td>
   </tr>
   <tr>
    <td>4.0</td>
    <td>4.2</td>
    <td>
-   <p><b>Local database environment:</b> [Chapter 3, Upgrading from 4.0 to oVirt 4.2](../chap-Upgrading_from_4.0_to_oVirt_4.2)</p>
-   <p><b>Remote database environment:</b> [Chapter 6, Upgrading a Remote Database Environment from 4.0 to oVirt 4.2](../chap-Upgrading_a_Remote_Database_Environment_from_4.0_to_oVirt_4.2)</p>
+   <p><b>Local database environment:</b> [Chapter 3, Upgrading from 4.0 to oVirt 4.2](chap-Upgrading_from_4.0_to_oVirt_4.2)</p>
+   <p><b>Remote database environment:</b> [Chapter 6, Upgrading a Remote Database Environment from 4.0 to oVirt 4.2](chap-Upgrading_a_Remote_Database_Environment_from_4.0_to_oVirt_4.2)</p>
   </td>
   </tr>
   <tr>
    <td>4.1</td>
    <td>4.2</td>
    <td>
-   <p><b>Local database environment:</b> [Chapter 4, Upgrading from 4.1 to oVirt 4.2](../chap-Upgrading_from_4.1_to_oVirt_4.2)</p>
-   <p><b>Remote database environment:</b> [Chapter 7, Upgrading a Remote Database Environment from 4.1 to oVirt 4.2](../chap-Upgrading_a_Remote_Database_Environment_from_4.1_to_oVirt_4.2)</p>
+   <p><b>Local database environment:</b> [Chapter 4, Upgrading from 4.1 to oVirt 4.2](chap-Upgrading_from_4.1_to_oVirt_4.2)</p>
+   <p><b>Remote database environment:</b> [Chapter 7, Upgrading a Remote Database Environment from 4.1 to oVirt 4.2](chap-Upgrading_a_Remote_Database_Environment_from_4.1_to_oVirt_4.2)</p>
   </td>
   </tr>
   <tr>
    <td>4.2.x</td>
    <td>4.2.y</td>
-   <td>[Chapter 9, Updates Between Minor Releases](../chap-Updates_between_Minor_Releases/)</td>
+   <td>[Chapter 9, Updates Between Minor Releases](chap-Updates_between_Minor_Releases/)</td>
   </tr>
  </tbody>
 </table>
 
-To upgrade a oVirt Node 3.6 host that uses local storage, see the “Upgrading from 3.6 to oVirt Node While Preserving Local Storage” section in [Chapter 2, Upgrading from 3.6 to oVirt 4.2](../chap-Upgrading_from_3.6_to_oVirt_4.2)
+To upgrade a oVirt Node 3.6 host that uses local storage, see the “Upgrading from 3.6 to oVirt Node While Preserving Local Storage” section in [Chapter 2, Upgrading from 3.6 to oVirt 4.2](chap-Upgrading_from_3.6_to_oVirt_4.2)
 
-**Next:** [Chapter 2, Upgrading from 3.6 to oVirt 4.2](../chap-Upgrading_from_3.6_to_oVirt_4.2)
+**Next:** [Chapter 2, Upgrading from 3.6 to oVirt 4.2](chap-Upgrading_from_3.6_to_oVirt_4.2)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/upgrade_guide/chap-updating_the_red_hat_enterprise_virtualization_environment)

--- a/source/documentation/upgrade-guide/chap-Upgrading_a_Remote_Database_Environment_from_3.6_to_oVirt_4.2.html.md
+++ b/source/documentation/upgrade-guide/chap-Upgrading_a_Remote_Database_Environment_from_3.6_to_oVirt_4.2.html.md
@@ -20,7 +20,7 @@ You cannot upgrade the Engine directly from 3.6 to 4.2. You must upgrade your en
 
 6. Upgrade the hosts
 
-7. Perform [post-upgrade tasks](../chap-Post-Upgrade_Tasks/)
+7. Perform [post-upgrade tasks](chap-Post-Upgrade_Tasks/)
 
 ## Update the oVirt Engine
 
@@ -64,7 +64,7 @@ oVirt Engine 4.0 is only supported on Enterprise Linux 7. A clean installation o
 
     **Important:** Directory servers configured using the domain management tool are not supported after oVirt 3.6. If your directory servers are configured using the domain management tool, migrate to the new extension-based provider before backing up the environment.
 
-After the Engine has been upgraded, you can upgrade the hosts. See [Chapter 9: Updates between Minor Releases](../chap-Updates_between_Minor_Releases). Then the cluster compatibility level can be updated to 4.0. See [Chapter 8: Post-Upgrade Tasks](../chap-Post-Upgrade_Tasks).
+After the Engine has been upgraded, you can upgrade the hosts. See [Chapter 9: Updates between Minor Releases](chap-Updates_between_Minor_Releases). Then the cluster compatibility level can be updated to 4.0. See [Chapter 8: Post-Upgrade Tasks](chap-Post-Upgrade_Tasks).
 
     **Note:** Connected hosts and virtual machines can continue to work while the Engine is being upgraded.
 
@@ -129,7 +129,7 @@ You may now update the hosts, then change the cluster and data center compatibil
 
 You must upgrade the Manager to 4.1 before upgrading it to 4.2.
 
-The following procedure outlines the process for upgrading oVirt Engine 4.0 to oVirt Engine 4.1 in a standard deployment. See "Upgrading a Self-Hosted Engine Environment" in the [Self-Hosted Engine Guide](../../self-hosted/Self-Hosted_Engine_Guide/) for more information about upgrading the Engine in a Self-hosted Engine deployment.
+The following procedure outlines the process for upgrading oVirt Engine 4.0 to oVirt Engine 4.1 in a standard deployment. See "Upgrading a Self-Hosted Engine Environment" in the [Self-Hosted Engine Guide](../self-hosted/Self-Hosted_Engine_Guide/) for more information about upgrading the Engine in a Self-hosted Engine deployment.
 
 This procedure assumes that the system on which the Engine is installed is subscribed to the entitlements for receiving oVirt 4.0 packages.
 
@@ -330,7 +330,7 @@ If the command fails, the host is oVirt Node 3.6. If the command succeeds, the h
 
 Repeat this procedure for each host in the oVirt environment.
 
-**Prev:** [Chapter 4: Upgrading from 4.1 to oVirt 4.2](../chap-Upgrading_from_4.1_to_oVirt_4.2)<br>
-**Next:** [Chapter 6: Upgrading a Remote Database Environment from 4.0 to oVirt 4.2](../chap-Upgrading_a_Remote_Database_Environment_from_4.0_to_oVirt_4.2)
+**Prev:** [Chapter 4: Upgrading from 4.1 to oVirt 4.2](chap-Upgrading_from_4.1_to_oVirt_4.2)<br>
+**Next:** [Chapter 6: Upgrading a Remote Database Environment from 4.0 to oVirt 4.2](chap-Upgrading_a_Remote_Database_Environment_from_4.0_to_oVirt_4.2)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/upgrade_guide/chap-upgrading_to_red_hat_virtualization_4.2)

--- a/source/documentation/upgrade-guide/chap-Upgrading_a_Remote_Database_Environment_from_4.0_to_oVirt_4.2.html.md
+++ b/source/documentation/upgrade-guide/chap-Upgrading_a_Remote_Database_Environment_from_4.0_to_oVirt_4.2.html.md
@@ -18,7 +18,7 @@ You cannot upgrade the Engine directly from 4.0 to 4.2. You must upgrade your en
 
 5. Upgrade the hosts
 
-6. Perform [post-upgrade tasks](../chap-Post-Upgrade_Tasks/)
+6. Perform [post-upgrade tasks](chap-Post-Upgrade_Tasks/)
 
 ## Update the oVirt Engine
 
@@ -56,7 +56,7 @@ Updates to the oVirt Engine are released through the oVirt repositories.
 
 You must upgrade the Manager to 4.1 before upgrading it to 4.2.
 
-The following procedure outlines the process for upgrading oVirt Engine 4.0 to oVirt Engine 4.1 in a standard deployment. See "Upgrading a Self-Hosted Engine Environment" in the [Self-Hosted Engine Guide](../../self-hosted/Self-Hosted_Engine_Guide/) for more information about upgrading the Engine in a Self-hosted Engine deployment.
+The following procedure outlines the process for upgrading oVirt Engine 4.0 to oVirt Engine 4.1 in a standard deployment. See "Upgrading a Self-Hosted Engine Environment" in the [Self-Hosted Engine Guide](../self-hosted/Self-Hosted_Engine_Guide/) for more information about upgrading the Engine in a Self-hosted Engine deployment.
 
 This procedure assumes that the system on which the Engine is installed is subscribed to the entitlements for receiving oVirt 4.0 packages.
 
@@ -257,7 +257,7 @@ If the command fails, the host is oVirt Node 3.6. If the command succeeds, the h
 
 Repeat this procedure for each host in the oVirt environment.
 
-**Prev:** [Chapter 5: Upgrading a Remote Database Environment from 3.6 to oVirt 4.2](../chap-Upgrading_a_Remote_Database_Environment_from_3.6_to_oVirt_4.2)<br>
-**Next:** [Chapter 7: Upgrading a Remote Database Environment from 4.1 to oVirt 4.2](../chap-Upgrading_a_Remote_Database_Environment_from_4.1_to_oVirt_4.2)
+**Prev:** [Chapter 5: Upgrading a Remote Database Environment from 3.6 to oVirt 4.2](chap-Upgrading_a_Remote_Database_Environment_from_3.6_to_oVirt_4.2)<br>
+**Next:** [Chapter 7: Upgrading a Remote Database Environment from 4.1 to oVirt 4.2](chap-Upgrading_a_Remote_Database_Environment_from_4.1_to_oVirt_4.2)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/upgrade_guide/chap-remote_upgrading_from_4.0_to_red_hat_virtualization_4.2)

--- a/source/documentation/upgrade-guide/chap-Upgrading_a_Remote_Database_Environment_from_4.1_to_oVirt_4.2.html.md
+++ b/source/documentation/upgrade-guide/chap-Upgrading_a_Remote_Database_Environment_from_4.1_to_oVirt_4.2.html.md
@@ -16,7 +16,7 @@ Upgrading your environment from 4.1 to 4.2 includes the following steps:
 
 4. Upgrade the hosts
 
-5. Perform [post-upgrade tasks](../chap-Post-Upgrade_Tasks/)
+5. Perform [post-upgrade tasks](chap-Post-Upgrade_Tasks/)
 
 ## Upgrading Remote Databases
 
@@ -222,7 +222,7 @@ If the command fails, the host is oVirt Node 3.6. If the command succeeds, the h
 
 Repeat this procedure for each host in the oVirt environment.
 
-**Prev:** [Chapter 6: Upgrading a Remote Database Environment from 4.0 to oVirt 4.2](../chap-Upgrading_a_Remote_Database_Environment_from_4.0_to_oVirt_4.2)<br>
-**Next:** [Chapter 8: Post-Upgrade Tasks](../chap-Post-Upgrade_Tasks/)
+**Prev:** [Chapter 6: Upgrading a Remote Database Environment from 4.0 to oVirt 4.2](chap-Upgrading_a_Remote_Database_Environment_from_4.0_to_oVirt_4.2)<br>
+**Next:** [Chapter 8: Post-Upgrade Tasks](chap-Post-Upgrade_Tasks/)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/upgrade_guide/chap-remote_upgrading_to_red_hat_virtualization_4.2)

--- a/source/documentation/upgrade-guide/chap-Upgrading_from_3.6_to_oVirt_4.2.html.md
+++ b/source/documentation/upgrade-guide/chap-Upgrading_from_3.6_to_oVirt_4.2.html.md
@@ -20,7 +20,7 @@ You cannot upgrade the Engine directly from 3.6 to 4.2. You must upgrade your en
 
     **Note:** If you are upgrading hosts that use local storage, see the “Upgrading from 3.6 to oVirt Node While Preserving Local Storage” section below.
 
-6. Perform [post-upgrade tasks](../chap-Post-Upgrade_Tasks/)
+6. Perform [post-upgrade tasks](chap-Post-Upgrade_Tasks/)
 
 ## Update the oVirt Engine
 
@@ -62,7 +62,7 @@ oVirt Engine 4.0 is only supported on Enterprise Linux 7. A clean installation o
 
     **Important:** Directory servers configured using the domain management tool are not supported after oVirt 3.6. If your directory servers are configured using the domain management tool, migrate to the new extension-based provider before backing up the environment.
 
-After the Engine has been upgraded, you can upgrade the hosts. See [Chapter 9: Updates between Minor Releases](../chap-Updates_between_Minor_Releases). Then the cluster compatibility level can be updated to 4.0. See [Chapter 8: Post-Upgrade Tasks](../chap-Post-Upgrade_Tasks).
+After the Engine has been upgraded, you can upgrade the hosts. See [Chapter 9: Updates between Minor Releases](chap-Updates_between_Minor_Releases). Then the cluster compatibility level can be updated to 4.0. See [Chapter 8: Post-Upgrade Tasks](chap-Post-Upgrade_Tasks).
 
     **Note:** Connected hosts and virtual machines can continue to work while the Engine is being upgraded.
 
@@ -127,7 +127,7 @@ You may now update the hosts, then change the cluster and data center compatibil
 
 You must upgrade the Manager to 4.1 before upgrading it to 4.2.
 
-The following procedure outlines the process for upgrading oVirt Engine 4.0 to oVirt Engine 4.1 in a standard deployment. See "Upgrading a Self-Hosted Engine Environment" in the [Self-Hosted Engine Guide](../../self-hosted/Self-Hosted_Engine_Guide/) for more information about upgrading the Engine in a Self-hosted Engine deployment.
+The following procedure outlines the process for upgrading oVirt Engine 4.0 to oVirt Engine 4.1 in a standard deployment. See "Upgrading a Self-Hosted Engine Environment" in the [Self-Hosted Engine Guide](../self-hosted/Self-Hosted_Engine_Guide/) for more information about upgrading the Engine in a Self-hosted Engine deployment.
 
 This procedure assumes that the system on which the Engine is installed is subscribed to the entitlements for receiving oVirt 4.0 packages.
 
@@ -265,6 +265,6 @@ Environments with local storage cannot migrate virtual machines to a host in ano
     Select the **Reassign Bad MACs** check box to reassign new MAC addresses to all problematic virtual machines. See Importing Virtual Machines from Imported Data Storage Domains in the Administration Guide for more information.
 
 **Prev:** [Chapter 1: Updating the oVirt Environment](http://www.ovirt.org/documentation/upgrade-guide/chap-Updating_the_oVirt_Environment)<br>
-**Next:** [Chapter 3: Upgrading from 4.0 to oVirt 4.2](../chap-Upgrading_from_4.0_to_oVirt_4.2)
+**Next:** [Chapter 3: Upgrading from 4.0 to oVirt 4.2](chap-Upgrading_from_4.0_to_oVirt_4.2)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/upgrade_guide/chap-updating_the_red_hat_enterprise_virtualization_environment)

--- a/source/documentation/upgrade-guide/chap-Upgrading_from_4.0_to_oVirt_4.2.html.md
+++ b/source/documentation/upgrade-guide/chap-Upgrading_from_4.0_to_oVirt_4.2.html.md
@@ -16,7 +16,7 @@ You cannot upgrade the Manager directly from 4.0 to 4.2. You must upgrade your e
 
 4. Upgrade the hosts
 
-5. Perform [post-upgrade tasks](../chap-Post-Upgrade_Tasks/)
+5. Perform [post-upgrade tasks](chap-Post-Upgrade_Tasks/)
 
 ## Update the oVirt Engine
 
@@ -52,7 +52,7 @@ Updates to the oVirt Engine are released through the oVirt repositories.
 
 You must upgrade the Manager to 4.1 before upgrading it to 4.2.
 
-The following procedure outlines the process for upgrading oVirt Engine 4.0 to oVirt Engine 4.1 in a standard deployment. See "Upgrading a Self-Hosted Engine Environment" in the [Self-Hosted Engine Guide](../../self-hosted/Self-Hosted_Engine_Guide/) for more information about upgrading the Engine in a Self-hosted Engine deployment.
+The following procedure outlines the process for upgrading oVirt Engine 4.0 to oVirt Engine 4.1 in a standard deployment. See "Upgrading a Self-Hosted Engine Environment" in the [Self-Hosted Engine Guide](../self-hosted/Self-Hosted_Engine_Guide/) for more information about upgrading the Engine in a Self-hosted Engine deployment.
 
 This procedure assumes that the system on which the Engine is installed is subscribed to the entitlements for receiving oVirt 4.0 packages.
 
@@ -182,7 +182,7 @@ If the command fails, the host is oVirt Node 3.6. If the command succeeds, the h
 
 Repeat this procedure for each host in the oVirt environment.
 
-**Prev:** [Chapter 2: Upgrading from 3.6 to oVirt 4.2](../chap-Upgrading_from_3.6_to_oVirt_4.2)<br>
-**Next:** [Chapter 4: Upgrading from 4.1 to oVirt 4.2](../chap-Upgrading_from_4.1_to_oVirt_4.2)
+**Prev:** [Chapter 2: Upgrading from 3.6 to oVirt 4.2](chap-Upgrading_from_3.6_to_oVirt_4.2)<br>
+**Next:** [Chapter 4: Upgrading from 4.1 to oVirt 4.2](chap-Upgrading_from_4.1_to_oVirt_4.2)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/upgrade_guide/chap-upgrading_from_4.0_to_red_hat_virtualization_4.2)

--- a/source/documentation/upgrade-guide/chap-Upgrading_from_4.1_to_oVirt_4.2.html.md
+++ b/source/documentation/upgrade-guide/chap-Upgrading_from_4.1_to_oVirt_4.2.html.md
@@ -14,7 +14,7 @@ Upgrading your environment from 4.1 to 4.2 includes the following steps:
 
 3. Upgrade the hosts
 
-4. Perform [post-upgrade tasks](../chap-Post-Upgrade_Tasks/)
+4. Perform [post-upgrade tasks](chap-Post-Upgrade_Tasks/)
 
 ## Update the oVirt Engine
 
@@ -146,7 +146,7 @@ If the command fails, the host is oVirt Node 3.6. If the command succeeds, the h
 
 Repeat this procedure for each host in the oVirt environment.
 
-**Prev:** [Chapter 3: Upgrading from 4.0 to oVirt 4.2](../chap-Upgrading_from_4.0_to_oVirt_4.2)<br>
-**Next:** [Chapter 5: Upgrading a Remote Database Environment from 3.6 to oVirt 4.2](../chap-Upgrading_a_Remote_Database_Environment_from_3.6_to_oVirt_4.2)
+**Prev:** [Chapter 3: Upgrading from 4.0 to oVirt 4.2](chap-Upgrading_from_4.0_to_oVirt_4.2)<br>
+**Next:** [Chapter 5: Upgrading a Remote Database Environment from 3.6 to oVirt 4.2](chap-Upgrading_a_Remote_Database_Environment_from_3.6_to_oVirt_4.2)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/upgrade_guide/chap-upgrading_to_red_hat_virtualization_4.2)

--- a/source/documentation/upgrade-guide/chap-Upgrading_to_oVirt_4.0.html.md
+++ b/source/documentation/upgrade-guide/chap-Upgrading_to_oVirt_4.0.html.md
@@ -24,7 +24,7 @@ oVirt Engine 4.0 is only supported on Red Hat Enterprise Linux 7. A clean instal
 
 **Important:** All data centers and clusters in the environment must have the cluster compatibility level set to version 3.6 before attempting the procedure.
 
-After the Engine has been upgraded, you can upgrade the hosts. See [Chapter 2: Updates between Minor Releases](../chap-Updates_between_Minor_Releases). Then the cluster compatibility level can be updated to 4.0. See [Chapter 4: Post-Upgrade Tasks](../chap-Post-Upgrade_Tasks).
+After the Engine has been upgraded, you can upgrade the hosts. See [Chapter 2: Updates between Minor Releases](chap-Updates_between_Minor_Releases). Then the cluster compatibility level can be updated to 4.0. See [Chapter 4: Post-Upgrade Tasks](chap-Post-Upgrade_Tasks).
 
 **Note:** Connected hosts and virtual machines can continue to work while the Engine is being upgraded.
 
@@ -84,5 +84,5 @@ To upgrade a Red Hat Enterprise Linux-based self-hosted environment, see "Upgrad
 
 To upgrade an oVirt Hypervisor-based self-hosted environment to an oVirt Node-based self-hosted environment, see "Upgrading an oVirt Node-Based Self-Hosted Engine Environment" in the [Self-Hosted Engine Guide](/documentation/self-hosted/Self-Hosted_Engine_Guide/).
 
-**Prev:** [Chapter 2: Updates Between Minor Releases](../chap-Updates_between_Minor_Releases) <br>
-**Next:** [Chapter 4: Post-Upgrade Tasks](../chap-Post-Upgrade_Tasks)
+**Prev:** [Chapter 2: Updates Between Minor Releases](chap-Updates_between_Minor_Releases) <br>
+**Next:** [Chapter 4: Post-Upgrade Tasks](chap-Post-Upgrade_Tasks)

--- a/source/documentation/upgrade-guide/upgrade-guide.md
+++ b/source/documentation/upgrade-guide/upgrade-guide.md
@@ -8,24 +8,24 @@ This guide covers updating your oVirt environment between minor releases, and up
 
 ## Chapter 1: [Updating the oVirt Environment](http://www.ovirt.org/documentation/upgrade-guide/chap-Updating_the_oVirt_Environment)
 
-## Chapter 2: [Upgrading from 3.6 to oVirt 4.2](../chap-Upgrading_from_3.6_to_oVirt_4.2)
+## Chapter 2: [Upgrading from 3.6 to oVirt 4.2](chap-Upgrading_from_3.6_to_oVirt_4.2)
 
-## Chapter 3: [Upgrading from 4.0 to oVirt 4.2](../chap-Upgrading_from_4.0_to_oVirt_4.2)
+## Chapter 3: [Upgrading from 4.0 to oVirt 4.2](chap-Upgrading_from_4.0_to_oVirt_4.2)
 
-## Chapter 4: [Upgrading from 4.1 to oVirt 4.2](../chap-Upgrading_from_4.1_to_oVirt_4.2)
+## Chapter 4: [Upgrading from 4.1 to oVirt 4.2](chap-Upgrading_from_4.1_to_oVirt_4.2)
 
-## Chapter 5: [Upgrading a Remote Database Environment from 3.6 to oVirt 4.2](../chap-Upgrading_a_Remote_Database_Environment_from_3.6_to_oVirt_4.2)
+## Chapter 5: [Upgrading a Remote Database Environment from 3.6 to oVirt 4.2](chap-Upgrading_a_Remote_Database_Environment_from_3.6_to_oVirt_4.2)
 
-## Chapter 6: [Upgrading a Remote Database Environment from 4.0 to oVirt 4.2](../chap-Upgrading_a_Remote_Database_Environment_from_4.0_to_oVirt_4.2)
+## Chapter 6: [Upgrading a Remote Database Environment from 4.0 to oVirt 4.2](chap-Upgrading_a_Remote_Database_Environment_from_4.0_to_oVirt_4.2)
 
-## Chapter 7: [Upgrading a Remote Database Environment from 4.1 to oVirt 4.2](../chap-Upgrading_a_Remote_Database_Environment_from_4.1_to_oVirt_4.2)
+## Chapter 7: [Upgrading a Remote Database Environment from 4.1 to oVirt 4.2](chap-Upgrading_a_Remote_Database_Environment_from_4.1_to_oVirt_4.2)
 
-## Chapter 8: [Post-Upgrade Tasks](../chap-Post-Upgrade_Tasks/)
+## Chapter 8: [Post-Upgrade Tasks](chap-Post-Upgrade_Tasks/)
 
-## Chapter 9: [Updates Between Minor Releases](../chap-Updates_between_Minor_Releases/)
+## Chapter 9: [Updates Between Minor Releases](chap-Updates_between_Minor_Releases/)
 
-## Appendix A: [Updating an Offline oVirt Engine](../appe-Updating_an_Offline_oVirt_Engine/)
+## Appendix A: [Updating an Offline oVirt Engine](appe-Updating_an_Offline_oVirt_Engine/)
 
-## Appendix B: [Upgrading to oVirt Engine 4.2 with ovirt-fast-forward-upgrade](../appe-Upgrading_to_oVirt_Engine_4.2_with_ovirt-fast-forward-upgrade.html.md)
+## Appendix B: [Upgrading to oVirt Engine 4.2 with ovirt-fast-forward-upgrade](appe-Upgrading_to_oVirt_Engine_4.2_with_ovirt-fast-forward-upgrade.html.md)
 
-## Appendix C: [Manually Updating Hosts](../appe-Manually_Updating_Hosts)
+## Appendix C: [Manually Updating Hosts](appe-Manually_Updating_Hosts)

--- a/source/documentation/vmm-guide/Virtual_Machine_Management_Guide.html.md
+++ b/source/documentation/vmm-guide/Virtual_Machine_Management_Guide.html.md
@@ -4,20 +4,20 @@ title: oVirt Virtual Machine Management Guide
 
 # oVirt Virtual Machine Management Guide
 
-## Chapter 1: [Introduction](../chap-Introduction)
+## Chapter 1: [Introduction](chap-Introduction)
 
-## Chapter 2: [Installing Linux Virtual Machines](../chap-Installing_Linux_Virtual_Machines)
+## Chapter 2: [Installing Linux Virtual Machines](chap-Installing_Linux_Virtual_Machines)
 
-## Chapter 3: [Installing Windows Virtual Machines](../chap-Installing_Windows_Virtual_Machines)
+## Chapter 3: [Installing Windows Virtual Machines](chap-Installing_Windows_Virtual_Machines)
 
-## Chapter 4: [Additional Configuration](../chap-Additional_Configuration)
+## Chapter 4: [Additional Configuration](chap-Additional_Configuration)
 
-## Chapter 5: [Editing Virtual Machines](../chap-Editing_Virtual_Machines)
+## Chapter 5: [Editing Virtual Machines](chap-Editing_Virtual_Machines)
 
-## Chapter 6: [Administrative Tasks](../chap-Administrative_Tasks)
+## Chapter 6: [Administrative Tasks](chap-Administrative_Tasks)
 
-## Chapter 7: [Templates](../chap-Templates)
+## Chapter 7: [Templates](chap-Templates)
 
-## Appendix A: [Reference Settings in Administration Portal and User Portal Windows](../appe-Reference_Settings_in_Administration_Portal_and_User_Portal_Windows)
+## Appendix A: [Reference Settings in Administration Portal and User Portal Windows](appe-Reference_Settings_in_Administration_Portal_and_User_Portal_Windows)
 
-## Appendix B: [virt-sysprep Operations](../appe-virt-sysprep_Operations)
+## Appendix B: [virt-sysprep Operations](appe-virt-sysprep_Operations)

--- a/source/documentation/vmm-guide/appe-Reference_Settings_in_Administration_Portal_and_User_Portal_Windows.html.md
+++ b/source/documentation/vmm-guide/appe-Reference_Settings_in_Administration_Portal_and_User_Portal_Windows.html.md
@@ -53,7 +53,7 @@ The following table details the options available on the **General** tab of the 
   <tr>
    <td><b>VM ID</b></td>
    <td>The virtual machine ID. The virtual machine's creator can set a custom ID for that virtual machine. If no ID is specified during creation a UUID will be automatically assigned. For both custom and automatically-generated IDs, changes are not possible after virtual machine creation.</td>
-  </tr>    
+  </tr>
   <tr>
    <td><b>Description</b></td>
    <td>A meaningful description of the new virtual machine.</td>
@@ -1377,7 +1377,7 @@ The following table details the settings for the **New Template** window.
 							</p>
 							 </td></tr></tbody></table>
 
-**Prev:** [Chapter 7: Templates](../chap-Templates)
+**Prev:** [Chapter 7: Templates](chap-Templates)
 **Next:** [Appendix B: virt-sysprep Operations]((../appe-virt-sysprep_Operations)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/virtual_machine_management_guide/appe-reference_settings_in_administration_portal_and_user_portal_windows)

--- a/source/documentation/vmm-guide/appe-virt-sysprep_Operations.html.md
+++ b/source/documentation/vmm-guide/appe-virt-sysprep_Operations.html.md
@@ -48,6 +48,6 @@ Only operations marked with `*` are performed during the template sealing proces
         utmp * Remove the utmp file
         yum-uuid * Remove the yum UUID
 
-**Prev:** [Appendix A: Reference Settings in Administration Portal and User Portal Windows](../appe-Reference_Settings_in_Administration_Portal_and_User_Portal_Windows)
+**Prev:** [Appendix A: Reference Settings in Administration Portal and User Portal Windows](appe-Reference_Settings_in_Administration_Portal_and_User_Portal_Windows)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/virtual_machine_management_guide/appe-virt_sysprep_operations)

--- a/source/documentation/vmm-guide/chap-Additional_Configuration.html.md
+++ b/source/documentation/vmm-guide/chap-Additional_Configuration.html.md
@@ -953,7 +953,7 @@ Pinning topology:
 
 Pools do not support IO and emulator threads pinning.
 
-    **Warning:** If a host CPU is pinned to both a vCPU and IO/emulator threads, a warning will appear in the log and you will be asked to consider changing the CPU pinning topology to avoid this situation.                    
+    **Warning:** If a host CPU is pinned to both a vCPU and IO/emulator threads, a warning will appear in the log and you will be asked to consider changing the CPU pinning topology to avoid this situation.
 
 ####  High Performance Icons
 
@@ -1243,7 +1243,7 @@ You can now install vGPUs on the virtual machines running on this host.
 
     **Important:** You cannot migrate a virtual machine using a vGPU to a different host. When upgrading the virtual machine, verify the operating system and GPU vendor support in the vendor’s documentation.
 
-**Prev:** [Chapter 3: Installing Windows Virtual Machines](../chap-Installing_Windows_Virtual_Machines) <br>
-**Next:** [Chapter 5: Editing Virtual Machines](../chap-Editing_Virtual_Machines)
+**Prev:** [Chapter 3: Installing Windows Virtual Machines](chap-Installing_Windows_Virtual_Machines) <br>
+**Next:** [Chapter 5: Editing Virtual Machines](chap-Editing_Virtual_Machines)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/virtual_machine_management_guide/chap-additional_configuration)

--- a/source/documentation/vmm-guide/chap-Administrative_Tasks.html.md
+++ b/source/documentation/vmm-guide/chap-Administrative_Tasks.html.md
@@ -827,7 +827,7 @@ The `virt-v2v` package must be installed on at least one host (referred to in th
 
 8. Optionally, select a Xen provider **External Provider** from the drop-down list. The URI will be pre-filled with the correct URI.
 
-9. Enter the **URI** of the Xen host. The required format is pre-filled; you must replace `<hostname>` with the host name of the Xen host.  
+9. Enter the **URI** of the Xen host. The required format is pre-filled; you must replace `<hostname>` with the host name of the Xen host.
 
 10. Select the proxy host from the **Proxy Host** drop-down list.
 
@@ -1131,7 +1131,7 @@ Each event has a corresponding subdirectory: `before_migration` and `after_migra
 
 The executing user on Linux systems is `ovirtagent`. If the script needs `root` permissions, the elevation must be executed by the creator of the hook script.
 
-The executing user on Windows systems is the `System Service` user.    
+The executing user on Windows systems is the `System Service` user.
 
 ### Automatic Virtual Machine Migration
 
@@ -1502,7 +1502,7 @@ The table below lists versions of Enterprise Linux and the parameters required f
 | 3.9 x86 | Additional parameters are not required |
 
 
-**Prev:** [Chapter 5: Editing Virtual Machines](../chap-Editing_Virtual_Machines) <br>
-**Next:** [Chapter 7: Templates](../chap-Templates)
+**Prev:** [Chapter 5: Editing Virtual Machines](chap-Editing_Virtual_Machines) <br>
+**Next:** [Chapter 7: Templates](chap-Templates)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/virtual_machine_management_guide/chap-administrative_tasks)

--- a/source/documentation/vmm-guide/chap-Editing_Virtual_Machines.html.md
+++ b/source/documentation/vmm-guide/chap-Editing_Virtual_Machines.html.md
@@ -535,7 +535,7 @@ The oVirt Project does not provide PKCS #11 support to Windows clients. Librarie
 
         modutil -dbdir %PROGRAMDATA%\pki\nssdb -add "module name" -libfile C:\Path\to\module.dll
 
-**Prev:** [Chapter 4: Additional Configuration](../chap-Additional_Configuration) <br>
-**Next:** [Chapter 6: Administrative Tasks](../chap-Administrative_Tasks)
+**Prev:** [Chapter 4: Additional Configuration](chap-Additional_Configuration) <br>
+**Next:** [Chapter 6: Administrative Tasks](chap-Administrative_Tasks)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/virtual_machine_management_guide/chap-editing_virtual_machines)

--- a/source/documentation/vmm-guide/chap-Installing_Linux_Virtual_Machines.html.md
+++ b/source/documentation/vmm-guide/chap-Installing_Linux_Virtual_Machines.html.md
@@ -308,7 +308,7 @@ The ovirt guest agents and drivers are installed on Enterprise Linux virtual mac
 
 The guest agent now passes usage information to the ovirt Engine. The ovirt agent runs as a service called **ovirt-guest-agent** that you can configure via the **ovirt-guest-agent.conf** configuration file in the **/etc/** directory.
 
-**Prev:** [Chapter 1: Introduction](../chap-Introduction)<br>
-**Next:** [Chapter 3: Installing Windows Virtual Machines](../chap-Installing_Windows_Virtual_Machines)
+**Prev:** [Chapter 1: Introduction](chap-Introduction)<br>
+**Next:** [Chapter 3: Installing Windows Virtual Machines](chap-Installing_Windows_Virtual_Machines)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/virtual_machine_management_guide/chap-installing_linux_virtual_machines)

--- a/source/documentation/vmm-guide/chap-Installing_Windows_Virtual_Machines.html.md
+++ b/source/documentation/vmm-guide/chap-Installing_Windows_Virtual_Machines.html.md
@@ -236,7 +236,7 @@ Once the APT service has successfully installed or upgraded the guest tools on a
 
     **Note:** The *oVirt-apt* service can be stopped immediately after install by clearing the `Start oVirt-apt Service` check box. You can stop, start, or restart the service at any time using the **Services** window.
 
-**Prev:** [Chapter 2: Installing Linux Virtual Machines](../chap-Installing_Linux_Virtual_Machines) <br>
-**Next:** [Chapter 4: Additional Configuration](../chap-Additional_Configuration)
+**Prev:** [Chapter 2: Installing Linux Virtual Machines](chap-Installing_Linux_Virtual_Machines) <br>
+**Next:** [Chapter 4: Additional Configuration](chap-Additional_Configuration)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/virtual_machine_management_guide/chap-installing_windows_virtual_machines)

--- a/source/documentation/vmm-guide/chap-Introduction.html.md
+++ b/source/documentation/vmm-guide/chap-Introduction.html.md
@@ -307,6 +307,6 @@ Remote Viewer is installed and can be accessed via `Remote Viewer` in the **Virt
 
 5. Click **Yes** if prompted by User Account Control.
 
-**Next:** [Chapter 2: Installing Linux Virtual Machines](../chap-Installing_Linux_Virtual_Machines)
+**Next:** [Chapter 2: Installing Linux Virtual Machines](chap-Installing_Linux_Virtual_Machines)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/virtual_machine_management_guide/chap-introduction)

--- a/source/documentation/vmm-guide/chap-Templates.html.md
+++ b/source/documentation/vmm-guide/chap-Templates.html.md
@@ -598,7 +598,7 @@ Cloned virtual machines are similar to virtual machines based on templates. Howe
 
 The virtual machine is created and displayed in the **Virtual Machines** tab. You can now assign users to it, and can begin using it when the clone operation is complete.
 
-**Prev:** [Chapter 6: Administrative Tasks](../chap-Administrative_Tasks)<br>
-**Next:** [Appendix A: Reference Settings in Administration Portal and VM Portal Windows](../appe-Reference_Settings_in_Administration_Portal_and_User_Portal_Windows)
+**Prev:** [Chapter 6: Administrative Tasks](chap-Administrative_Tasks)<br>
+**Next:** [Appendix A: Reference Settings in Administration Portal and VM Portal Windows](appe-Reference_Settings_in_Administration_Portal_and_User_Portal_Windows)
 
 [Adapted from RHV 4.2 documentation - CC-BY-SA](https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html/virtual_machine_management_guide/chap-templates)

--- a/source/layouts/feature.html.haml
+++ b/source/layouts/feature.html.haml
@@ -241,21 +241,6 @@
             end
           end
 
-          related = related_all
-            .each_with_object(Hash.new(0)) { |str, count| count[str] += 1 }
-            .sort_by { |_, count| count }.reverse # Sort by incidences
-            .reject { |_, count| count < 2 } # Require at least 2 modules
-            .map {|str, count| str} # Bake down to a simple array
-
-        - if related.count > 0
-          .related-features
-            %h2 Related features
-
-            %ul
-              - related.each do |fragment|
-                %li
-                  %a{href: feature_url(fragment)}= clean_title feature_info(fragment).title
-
 :coffee
   $featureSidebar = $('.feature-sidebar')
   $form = $('#feature-search')


### PR DESCRIPTION
The site was previously configured to generate "pretty URLs" for
every single path by making everything a directory and dropping
'index.html' in each directory. This created a mess on the webserver
and was over-complicated for newcomers.

Documentation all assumed this mechanism, so remove '../' from documentation
paths.

Add mod_rewrite rule so people's links aren't broken. For example,
/develop/dev-process/devprocess.html exists now, and
/develop/dev-process/devprocess and /develop/dev-process/devprocess/
both now redirect to /develop/dev-process/devprocess.html

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @gregsheremeta 
