### PR TITLE
add redirect to fix blog link

### DIFF
--- a/source/.htaccess.haml
+++ b/source/.htaccess.haml
@@ -356,6 +356,10 @@ directory_index: false
   RewriteCond %{REQUEST_URI} /download/ovirt-live.*
   RewriteRule ^(.*)$ /documentation/ovirt-orb/ [R=301,L]
 
+  # /blog/ -> blog.html
+  RewriteCond %{REQUEST_URI} /blog/$
+  RewriteRule ^(.*)$ /blog.html [R=301,L]
+
 
   ##
 


### PR DESCRIPTION
the blog generator doesn't put a proper index.html file in
/blog, so redirect /blog/ -> blog.html

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @gregsheremeta 
