### PR TITLE
docuementation: add warning to old developer documentation

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -125,6 +125,19 @@ with_layout :feature do
   page "/develop/release-management/features/*"
 end
 
+with_layout :developer_outdated do
+  page "/develop/api/*"
+  page "/develop/architecture/*"
+  page "/develop/infra/*"
+  page "/develop/internal/*"
+  page "/develop/networking/*"
+  page "/develop/resources/*"
+  page "/develop/sdk/*"
+  page "/develop/security/*"
+  page "/develop/sla/*"
+  page "/develop/storage/*"
+end
+
 # Don't make these URLs have pretty URLs
 page '/404.html', directory_index: false
 page '/.htacces.html', directory_index: false

--- a/source/layouts/developer_outdated.html.haml
+++ b/source/layouts/developer_outdated.html.haml
@@ -1,0 +1,35 @@
+~ wrap_layout :basic do
+
+  - unless current_page.data.hide_header || request['params']['contentonly']
+    = partial "header"
+
+  %section#page-wrap.page-wrap
+
+    %section#page.page
+
+      - if data.site.breadcrumbs
+        = partial :breadcrumbs
+
+      %section#content.content{class: current_page.data.no_container ? '' : 'container' }
+
+
+        %div.alert.alert-warning
+          This developer documentation is
+          %strong
+            outdated
+          , but provides historical context.
+          %br
+          %br
+          It is
+          %strong
+            not
+          user documentation and should not be treated as such.
+          %br
+          %br
+          %a(href="/documentation/")Documentation is available here.
+
+        -# Render actual page content
+        = yield
+
+  - unless data.page.hide_footer || request['params']['contentonly']
+    = partial "footer"


### PR DESCRIPTION
add warning message to all old developer documentation
that it is outdated and the official documentation should
be consulted.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @gregsheremeta 