### PR TITLE
Fixed Squid Proxy auth bug in documentation

### DIFF
--- a/source/documentation/admin-guide/chap-Proxies.html.md
+++ b/source/documentation/admin-guide/chap-Proxies.html.md
@@ -170,7 +170,7 @@ This section explains how to install and configure a Squid proxy to the User Por
 14. Replace the existing Squid configuration file with the following:
 
         https_port 443 key=/etc/squid/proxy.key cert=/etc/squid/proxy.cer ssl-bump defaultsite=engine.example.com
-        cache_peer engine.example.com parent 443 0 no-query originserver ssl sslcafile=/etc/squid/ca.pem name=engine
+        cache_peer engine.example.com parent 443 0 no-query originserver ssl sslcafile=/etc/squid/ca.pem name=engine login=PASSTHRU
         cache_peer_access engine allow all
         ssl_bump allow all
         http_access allow all


### PR DESCRIPTION
Changes proposed in this pull request:

- Added option to Squid Proxy configuration `cache_peer`, otherwise it won't send Basic Auth headers to peer

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @mention yourself to sign)

This pull request needs review by: @gregsheremeta 
