### PR TITLE
add 'sudo' to subscription-manager commands

### DIFF
--- a/source/download/index.html.md
+++ b/source/download/index.html.md
@@ -82,9 +82,9 @@ Instead of or in addition to oVirt Node, you can use a standard Enterprise Linux
 1.  Enable the Base, Optional, and Extra repositories (Red Hat Enterprise Linux only):
 
         # RHEL only -- they are enabled by default on CentOS and oVirt Node
-        subscription-manager repos --enable="rhel-7-server-rpms"
-        subscription-manager repos --enable="rhel-7-server-optional-rpms"
-        subscription-manager repos --enable="rhel-7-server-extras-rpms"
+        sudo subscription-manager repos --enable="rhel-7-server-rpms"
+        sudo subscription-manager repos --enable="rhel-7-server-optional-rpms"
+        sudo subscription-manager repos --enable="rhel-7-server-extras-rpms"
 
 2.  Install Cockpit and the cockpit-ovirt-dashboard plugin:
 


### PR DESCRIPTION
add 'sudo' to subscription-manager commands. Now matching all of the other commands on the page, which have it.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @gregsheremeta 
