### PR TITLE
change footer pencil icon to github icon

### DIFF
--- a/source/layouts/_footer.haml
+++ b/source/layouts/_footer.haml
@@ -21,7 +21,7 @@
     - "documentation"
   - else
     - "content"
-  - icon = '<i class="icon fa fa-pencil"></i>'
+  - icon = '<i class="icon fa fa-github"></i>'
 
   .edit-this-page
     - issue_url = "https://github.com/#{data.site.github}/issues/new?labels=#{labels}&title=Issue:%20#{source_file}"

--- a/source/stylesheets/lib/site.sass
+++ b/source/stylesheets/lib/site.sass
@@ -71,9 +71,9 @@ header.masthead
     padding: 0 0 0 3em
 
     .icon
-      font-size: 16px
+      font-size: 20px
       vertical-align: middle
-      margin: 0 0.75ex 2px 0
+      margin: 0 6px 2px 0
       opacity: 0.8
       transition: 300ms all
 


### PR DESCRIPTION
change footer pencil icon to github icon

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @gregsheremeta 
