### PR TITLE
tweak footer links

### DIFF
--- a/source/layouts/_footer.haml
+++ b/source/layouts/_footer.haml
@@ -32,10 +32,10 @@
 
   .edit-this-page
     - issue_url = "https://github.com/#{data.site.github}/issues/new?labels=#{labels}&title=Issue:%20#{source_file}&template=#{issue_template}"
-    = link_to "#{icon}Report an issue on GitHub", issue_url, {target: '_blank'}
+    = link_to "#{icon}Report an issue with this page", issue_url, {target: '_blank'}
   .edit-this-page
     - edit_url = "https://github.com/#{data.site.github}/edit/master#{source_file}"
-    = link_to "#{icon}Edit this page on GitHub", edit_url, {target: '_blank'}
+    = link_to "#{icon}Edit this page", edit_url, {target: '_blank'}
 
   .last-modified
     - modified_time = `git log --pretty=format:%ai #{current_page.source_file}`.split(/\n/).first rescue nil


### PR DESCRIPTION
tweak footer links

 - Remove reference to gitbub from footer issue links
 - change page issue link to clarify that _this_ page has
   the issue

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @gregsheremeta 
