### PR TITLE
Fix typo and additional required step

### DIFF
--- a/source/documentation/admin-guide/appe-oVirt_and_SSL.html.md
+++ b/source/documentation/admin-guide/appe-oVirt_and_SSL.html.md
@@ -89,14 +89,18 @@ The internal CA stores the internally generated key and certificate in a **P12**
 
    Make the following changes and save the file:
 
-        SSL_CERTIFICATE=/etc/pki/ovirt-engine/apache.cer
+        SSL_CERTIFICATE=/etc/pki/ovirt-engine/certs/apache.cer
         SSL_KEY=/etc/pki/ovirt-engine/keys/apache.key.nopass
 
 10. Restart the `ovirt-provider-ovn` service:
 
         # systemctl restart ovirt-provider-ovn.service
+        
+11. Restart the `ovirt-websocket-proxy` service:
 
-11. Restart the ovirt-engine service:
+        # systemctl restart ovirt-websocket-proxy
+      
+12. Restart the ovirt-engine service:
 
         # systemctl restart ovirt-engine.service
 


### PR DESCRIPTION
 Changes proposed in this pull request:

- SSL_CERTIFICATE should point to the file in `certs` folder
-  the websocket proxy should be restarted too.


I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @yeya

This pull request needs review by: @gregsheremeta
