### PR TITLE
remove gregsheremeta from default reviewer on docs issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template_documentation.md
+++ b/.github/ISSUE_TEMPLATE/issue_template_documentation.md
@@ -8,5 +8,3 @@ Is this documentation Issue something you can help fix? If you'd like to contrib
 Documentation issue
 
 [ Enter a detailed description of the documentation problem. If you have suggestions for improvements, please include them (and open a Pull Request too, if you'd like!). Please include links to users list discussions, external documentation, or anything else that might be helpful. Delete this section before submitting your Issue. ]  Enter details ...
-
-#### Request review from: @gregsheremeta


### PR DESCRIPTION
remove gregsheremeta from default reviewer on docs issues

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @gregsheremeta 
