### PR TITLE
Add 3rd-party SSL certificates for imageio-proxy

### DIFF
--- a/source/documentation/admin-guide/appe-oVirt_and_SSL.html.md
+++ b/source/documentation/admin-guide/appe-oVirt_and_SSL.html.md
@@ -92,7 +92,7 @@ The internal CA stores the internally generated key and certificate in a **P12**
         SSL_CERTIFICATE=/etc/pki/ovirt-engine/certs/apache.cer
         SSL_KEY=/etc/pki/ovirt-engine/keys/apache.key.nopass
 
-10. Edit the **/etc/ovirt-imageio-proxy/ovirt-imageio-proxy.conf** 
+10. Edit the **/etc/ovirt-imageio-proxy/ovirt-imageio-proxy.conf** file:
         
         # vi /etc/ovirt-engine/ovirt-websocket-proxy.conf.d/10-setup.conf
 
@@ -100,7 +100,7 @@ The internal CA stores the internally generated key and certificate in a **P12**
 
         # Key file for SSL connections
         ssl_key_file = /etc/pki/ovirt-engine/keys/apache.key.nopass
-
+        
         # Certificate file for SSL connections
         ssl_cert_file = /etc/pki/ovirt-engine/certs/apache.cer
 
@@ -108,11 +108,15 @@ The internal CA stores the internally generated key and certificate in a **P12**
 
         # systemctl restart ovirt-provider-ovn.service
         
-12. Restart the `ovirt-websocket-proxy` service:
+12. Restart the `ovirt-imageio-proxy` service:
+
+        # systemctl restart ovirt-imageio-proxy
+
+13. Restart the `ovirt-websocket-proxy` service:
 
         # systemctl restart ovirt-websocket-proxy
       
-13. Restart the ovirt-engine service:
+14. Restart the ovirt-engine service:
 
         # systemctl restart ovirt-engine.service
 

--- a/source/documentation/admin-guide/appe-oVirt_and_SSL.html.md
+++ b/source/documentation/admin-guide/appe-oVirt_and_SSL.html.md
@@ -96,11 +96,10 @@ The internal CA stores the internally generated key and certificate in a **P12**
         
         # vi /etc/ovirt-engine/ovirt-websocket-proxy.conf.d/10-setup.conf
 
-   Make the following changes and save the file:
+    Make the following changes and save the file:
 
         # Key file for SSL connections
         ssl_key_file = /etc/pki/ovirt-engine/keys/apache.key.nopass
-        
         # Certificate file for SSL connections
         ssl_cert_file = /etc/pki/ovirt-engine/certs/apache.cer
 

--- a/source/documentation/admin-guide/appe-oVirt_and_SSL.html.md
+++ b/source/documentation/admin-guide/appe-oVirt_and_SSL.html.md
@@ -92,15 +92,27 @@ The internal CA stores the internally generated key and certificate in a **P12**
         SSL_CERTIFICATE=/etc/pki/ovirt-engine/certs/apache.cer
         SSL_KEY=/etc/pki/ovirt-engine/keys/apache.key.nopass
 
-10. Restart the `ovirt-provider-ovn` service:
+10. Edit the **/etc/ovirt-imageio-proxy/ovirt-imageio-proxy.conf** 
+        
+        # vi /etc/ovirt-engine/ovirt-websocket-proxy.conf.d/10-setup.conf
+
+   Make the following changes and save the file:
+
+        # Key file for SSL connections
+        ssl_key_file = /etc/pki/ovirt-engine/keys/apache.key.nopass
+
+        # Certificate file for SSL connections
+        ssl_cert_file = /etc/pki/ovirt-engine/certs/apache.cer
+
+11. Restart the `ovirt-provider-ovn` service:
 
         # systemctl restart ovirt-provider-ovn.service
         
-11. Restart the `ovirt-websocket-proxy` service:
+12. Restart the `ovirt-websocket-proxy` service:
 
         # systemctl restart ovirt-websocket-proxy
       
-12. Restart the ovirt-engine service:
+13. Restart the ovirt-engine service:
 
         # systemctl restart ovirt-engine.service
 


### PR DESCRIPTION
---
title: Add 3rd-party SSL certificates for imageio-proxy
authors: pmartin
---

Without the 3rd party certificates in place to match those in apache, the certificate authentication can fail.

By matching with the apache certificates it passes the same certificates and authentication, allowing admins to upload ISOs.

Changes proposed in this pull request:

- Add references for 3rd party certificates for imageio 

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @mention yourself to sign)
@paulmartincsi
This pull request needs review by: anyone
