### PR TITLE
Add ovirt guest agent info for Atomic hosts

### DIFF
--- a/source/documentation/vmm-guide/chap-Installing_Linux_Virtual_Machines.html.md
+++ b/source/documentation/vmm-guide/chap-Installing_Linux_Virtual_Machines.html.md
@@ -308,20 +308,20 @@ The ovirt guest agents and drivers are installed on Enterprise Linux virtual mac
 
 The guest agent now passes usage information to the ovirt Engine. The ovirt agent runs as a service called **ovirt-guest-agent** that you can configure via the **ovirt-guest-agent.conf** configuration file in the **/etc/** directory.
 
-### Installing the Guest Agent on an Atomic Host 
+### Installing the Guest Agent on an Atomic Host
 
 The ovirt guest agent should be installed as a [system container on Atomic hosts](https://github.com/projectatomic/atomic-system-containers/blob/master/USAGE.md)
 
 **Installing the Guest Agent on an Atomic Host**
 
    The commands for a Centos7 Atomic host are essentially:
-   
+
          # atomic pull --storage=ostree ovirtguestagent/centos7-atomic
          # atomic install --system --system-package=no --name=ovirt-guest-agent ovirtguestagent/centos7-atomic
          # systemctl status ovirt-guest-agent
          # systemctl start ovirt-guest-agent
 
-   Note: there is [official documentation and separate image registry](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/managing_containers/running_system_containers#using_the_ovirt_guest_agent_system_container_image_for_red_hat_virtualization) for those with a RHEV subscription.
+   Note: there is [official documentation and separate image registry](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/managing_containers/running_system_containers#using_the_ovirt_guest_agent_system_container_image_for_red_hat_virtualization) for those with a RHV subscription.
 
 
 **Prev:** [Chapter 1: Introduction](chap-Introduction)<br>

--- a/source/documentation/vmm-guide/chap-Installing_Linux_Virtual_Machines.html.md
+++ b/source/documentation/vmm-guide/chap-Installing_Linux_Virtual_Machines.html.md
@@ -308,6 +308,22 @@ The ovirt guest agents and drivers are installed on Enterprise Linux virtual mac
 
 The guest agent now passes usage information to the ovirt Engine. The ovirt agent runs as a service called **ovirt-guest-agent** that you can configure via the **ovirt-guest-agent.conf** configuration file in the **/etc/** directory.
 
+### Installing the Guest Agent on an Atomic Host 
+
+The ovirt guest agent should be installed as a [system container on Atomic hosts](https://github.com/projectatomic/atomic-system-containers/blob/master/USAGE.md)
+
+**Installing the Guest Agent on an Atomic Host**
+
+   The commands for a Centos7 Atomic host are essentially:
+   
+         # atomic pull --storage=ostree ovirtguestagent/centos7-atomic
+         # atomic install --system --system-package=no --name=ovirt-guest-agent ovirtguestagent/centos7-atomic
+         # systemctl status ovirt-guest-agent
+         # systemctl start ovirt-guest-agent
+
+   Note: there is [official documentation and separate image registry](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/managing_containers/running_system_containers#using_the_ovirt_guest_agent_system_container_image_for_red_hat_virtualization) for those with a RHEV subscription.
+
+
 **Prev:** [Chapter 1: Introduction](chap-Introduction)<br>
 **Next:** [Chapter 3: Installing Windows Virtual Machines](chap-Installing_Windows_Virtual_Machines)
 


### PR DESCRIPTION
No information is easily available for getting the ovirt-guest-agent running on Atomic (or any other container distributions) - having these pointer commands may help others save a couple of hours.

*Note*: at the time of writing, the guest agent doesn't start since the OCI spec is old.  I'm not sure how to file a bug for this.  Basically, it seems the Docker Hub image at https://hub.docker.com/r/ovirtguestagent/centos7-atomic/ isn't up-to-date with the repo. Specifically, the config.json file isn't in-line with https://github.com/projectatomic/atomic-system-containers/blame/master/ovirt-guest-agent-centos/config.json.template

Changes proposed in this pull request:
- add small section for ovirt guest agent on atomic hosts

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @lambfrier