### PR TITLE
ci: fail build if obsolete wiki headers are reintroduced

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: ruby
 rvm:
-- "2.0"
+  - "2.0"
 sudo: false
 cache: bundler
-script: bundle exec middleman build --verbose
+script:
+  - |
+    if grep -rEi "^wiki_[^ ]+: " source/; then
+      echo '/!\ Wiki headers are obsolete (see previous log entries)'
+      exit 2
+    fi
+  - bundle exec middleman build --verbose
 dist: precise

--- a/source/develop/release-management/features/infra/link-following.html.md
+++ b/source/develop/release-management/features/infra/link-following.html.md
@@ -2,10 +2,6 @@
 title: API Link Following
 category: feature
 authors: oliel
-wiki_category: Feature
-wiki_title: API Link Following
-wiki_revision_count: 0
-wiki_last_updated: 2017-7-7
 feature_name: Link Following
 feature_modules: api (engine)
 feature_status: Released

--- a/source/develop/release-management/features/sla/affinity-labels-management-via-admin-portal.html.md
+++ b/source/develop/release-management/features/sla/affinity-labels-management-via-admin-portal.html.md
@@ -2,7 +2,6 @@
 title: Affinity Labels Management via the Administration Portal
 category: feature
 authors: phbailey
-wiki_category: SLA
 feature_name: Affinity Labels Management via the Administration Portal
 feature_modules: Administration Portal
 feature_status: Complete


### PR DESCRIPTION
Fixes #1289

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @duck-rh 
