### PR TITLE
fix broken links

### DIFF
--- a/source/develop/release-management/features/integration/websocketproxy-on-a-separate-host.html.md
+++ b/source/develop/release-management/features/integration/websocketproxy-on-a-separate-host.html.md
@@ -62,7 +62,7 @@ Under this assumptions it can works this way:
 
     5.  engine-setup also asks engine fqdn in order to automatically download the engine cert
 
-At the end WebSocket Proxy runs on a different host, in order to connect to it from your browser trusting the engine cert it's not enough (cause we now have two host) so the user has to download the CA cert end explicitly trust it in his browser. The CA cert can be downloaded from <http://><enginehost>/ca.crt
+At the end WebSocket Proxy runs on a different host, in order to connect to it from your browser trusting the engine cert it's not enough (cause we now have two host) so the user has to download the CA cert end explicitly trust it in his browser. The CA cert can be downloaded from http://\<enginehost>/ca.crt
 
 # Example setup
 
@@ -356,7 +356,7 @@ That's it...
       [ INFO  ] Stage: Termination
       [ INFO  ] Execution of setup completed successfully
 
-WebSocket Proxy now runs on a different host, in order to connect to it from your browser trusting the engine cert it's not enough (cause we have two host) so the user has to download the CA cert end explicitly trust it in his browser. The CA cert can be downloaded from <http://><enginehost>/ca.crt
+WebSocket Proxy now runs on a different host, in order to connect to it from your browser trusting the engine cert it's not enough (cause we have two host) so the user has to download the CA cert end explicitly trust it in his browser. The CA cert can be downloaded from http://\<enginehost>/ca.crt
 
 ## Benefit to oVirt
 

--- a/source/develop/release-management/releases/3.5.2/index.html.md
+++ b/source/develop/release-management/releases/3.5.2/index.html.md
@@ -171,7 +171,7 @@ Following exception prevents host monitoring but affected host stays in status '
 **Fixed in oVirt 3.5.2 RC2 / Final release**
  - font and tab case don't match
  - [EL7] ovirt-optimizer is missing dependencies
- - link to jquery is '<http://>'
+ - fixed link to jquery
 
 ### VDSM
 


### PR DESCRIPTION
<http://> generates an empty link, not very useful.

Btw the right way to escape <this> is like \<that>. So this also fix the
display of the variable part of the URLs in the examples.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @duck-rh 