### PR TITLE
Fix incorrect example for ovirt-imageio-proxy.conf

### DIFF
--- a/source/documentation/admin-guide/appe-oVirt_and_SSL.html.md
+++ b/source/documentation/admin-guide/appe-oVirt_and_SSL.html.md
@@ -94,7 +94,7 @@ The internal CA stores the internally generated key and certificate in a **P12**
 
 10. Edit the **/etc/ovirt-imageio-proxy/ovirt-imageio-proxy.conf** file:
         
-        # vi /etc/ovirt-engine/ovirt-websocket-proxy.conf.d/10-setup.conf
+        # vi /etc/ovirt-imageio-proxy/ovirt-imageio-proxy.conf
 
     Make the following changes and save the file:
 


### PR DESCRIPTION
This patch fixes wrong filepath in the example code
from 10-setup.conf to ovirt-imageio-proxy.conf

Closes-Bug: #2005

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @mkowalski
