### PR TITLE
Adds an entry in the troubleshooting section

### DIFF
--- a/source/develop/troubleshooting-nfs-storage-issues.html.md
+++ b/source/develop/troubleshooting-nfs-storage-issues.html.md
@@ -166,3 +166,13 @@ In this case it is a good idea to set the tcp window parameters on the NFS serve
 To activate these settings for the running server reload them with
 
        # sysctl -p 
+
+### Permissions issues
+
+On RHEL 7, starting the `nfs-server` service changes back the ownership of the directory from `vdsm:kvm` to `root:root`. 
+Rerun the `chown` command **after** starting the service:
+
+```
+# systemctl start nfs-server
+# chown -R vdsm:kvm /storage
+```


### PR DESCRIPTION
I have been fighting with installation errors for a little while, until I discovered that starting the `nfs-server` service reverts the permissions. I don't know if this is expected or not.

Changes proposed in this pull request:

- Adds a new troubleshooting entry for NFS that explains how the `nfs-server` service reverts permissions.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @rmahroua

This pull request needs review by: (please @mention the reviewer if relevant)
