### PR TITLE
Change to Atomic ovirt-guest-agent instructions

### DIFF
--- a/source/documentation/vmm-guide/chap-Installing_Linux_Virtual_Machines.html.md
+++ b/source/documentation/vmm-guide/chap-Installing_Linux_Virtual_Machines.html.md
@@ -316,8 +316,8 @@ The ovirt guest agent should be installed as a [system container on Atomic hosts
 
    The commands for a Centos7 Atomic host are essentially:
 
-         # atomic pull --storage=ostree gscrivano/ovirt-guest-agent-centos
-         # atomic install --system --system-package=no --name=ovirt-guest-agent gscrivano/ovirt-guest-agent-centos
+         # atomic pull --storage=ostree quay.io/nyoxi/ovirt-guest-agent
+         # atomic install --system --system-package=no --name=ovirt-guest-agent quay.io/nyoxi/ovirt-guest-agent
          # systemctl status ovirt-guest-agent
          # systemctl start ovirt-guest-agent
 

--- a/source/documentation/vmm-guide/chap-Installing_Linux_Virtual_Machines.html.md
+++ b/source/documentation/vmm-guide/chap-Installing_Linux_Virtual_Machines.html.md
@@ -316,8 +316,8 @@ The ovirt guest agent should be installed as a [system container on Atomic hosts
 
    The commands for a Centos7 Atomic host are essentially:
 
-         # atomic pull --storage=ostree ovirtguestagent/centos7-atomic
-         # atomic install --system --system-package=no --name=ovirt-guest-agent ovirtguestagent/centos7-atomic
+         # atomic pull --storage=ostree gscrivano/ovirt-guest-agent-centos
+         # atomic install --system --system-package=no --name=ovirt-guest-agent gscrivano/ovirt-guest-agent-centos
          # systemctl status ovirt-guest-agent
          # systemctl start ovirt-guest-agent
 


### PR DESCRIPTION
Could not get `ovirtguestagent/centos7-atomic` version of ovirt-guest-agent to work.  Found `github.com/projectatomic/atomic-system-containers` contained a guest agent installer which I managed to reference with `gscrivano/ovirt-guest-agent-centos`.

When I used these sources instead the service started with no issue and oVirt reports ovirt-guest-agent-common-1.0.13-2.el7 as it's installed application


Changes proposed in this pull request:

- Change atomic ovirt-guest-agent install instructions




I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @mention yourself to sign)

This pull request needs review by: (please @mention the reviewer if relevant)
