### PR TITLE
Remove page last modified info feature

### DIFF
--- a/source/layouts/_footer.haml
+++ b/source/layouts/_footer.haml
@@ -37,10 +37,4 @@
     - edit_url = "https://github.com/#{data.site.github}/edit/master#{source_file}"
     = link_to "#{icon}Edit this page", edit_url, {target: '_blank'}
 
-  .last-modified
-    - modified_time = `git log --pretty=format:%ai #{current_page.source_file}`.split(/\n/).first rescue nil
-
-    - if modified_time
-      Page last modified
-      = Time.parse(modified_time).utc.strftime('%a %-d %b %Y %H:%M %Z')
   = insert_piwik_tracker

--- a/source/stylesheets/lib/site.sass
+++ b/source/stylesheets/lib/site.sass
@@ -190,9 +190,6 @@ header.masthead .navbar-collapse.in
       .icon
         opacity: 1
 
-  .last-modified
-    display: none
-
   li
     display: inline
     list-type: none


### PR DESCRIPTION
Display was disabled but the code was still there and ran `git log` for
each and every page, which was crazy time consuming.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @duck-rh 
