### PR TITLE
remove unnecessary 'less' format support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,10 +59,6 @@ gem "bootstrap-sass"
 #####
 # Formats
 
-# less (css)
-gem "therubyracer"
-gem "less"
-
 # asciidoctor
 gem "asciidoctor"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,6 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    commonjs (0.2.7)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -71,9 +70,6 @@ GEM
     icalendar (1.5.4)
     json (1.8.6)
     kramdown (1.15.0)
-    less (2.6.0)
-      commonjs (~> 0.2.7)
-    libv8 (3.16.14.19)
     listen (2.10.1)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
@@ -154,7 +150,6 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    ref (2.0.0)
     rouge (2.2.1)
     ruby18_source_location (0.2)
     sass (3.4.25)
@@ -171,9 +166,6 @@ GEM
       tilt (~> 1.1)
     stringex (2.7.1)
     temple (0.8.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (1.4.1)
@@ -200,7 +192,6 @@ DEPENDENCIES
   font-awesome-middleman
   icalendar (~> 1.5)
   kramdown
-  less
   middleman (~> 3.3.10)
   middleman-favicon-maker
   middleman-livereload
@@ -217,7 +208,6 @@ DEPENDENCIES
   rails-assets-momentjs
   ruby18_source_location
   stringex
-  therubyracer
   wdm (~> 0.1.0)
 
 BUNDLED WITH


### PR DESCRIPTION
we do not use this format and its underlying engine, therubyracer, is
crashing under more recent Ruby versions, preventing from upgrading the
builde.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @duck-rh 
