### PR TITLE
a JS engine is still needed for coffee scripts

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,12 +4,12 @@ git submodule init && git submodule update
 #setup for RedHat
 if [ -f /etc/redhat-release ]; then
   
-  sudo yum install -y ruby-devel rubygems-devel gcc-c++ curl-devel rubygem-bundler patch zlib-devel redhat-rpm-config openssl
+  sudo yum install -y ruby-devel rubygems-devel gcc-c++ curl-devel rubygem-bundler patch zlib-devel redhat-rpm-config openssl nodejs
 
 # setup for Debian 
 elif [ -f /etc/debian_version ]; then
   
-  sudo apt install -y build-essential ruby-bundler libcurl4-openssl-dev zlib1g-dev ruby-dev
+  sudo apt install -y build-essential ruby-bundler libcurl4-openssl-dev zlib1g-dev ruby-dev nodejs
 
 else
     echo "Could not verify system is RedHat or Debian."


### PR DESCRIPTION
install nodejs instead of the crashing and unmaintained therubyracer
gem.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @duck-rh 
