### PR TITLE
Specify bundle path on setup

### DIFF
--- a/run-server.sh
+++ b/run-server.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -e
 
-bundle install --quiet
+bundle install --quiet --path vendor/bundle
 bundle exec jekyll s -t -l $@

--- a/setup.sh
+++ b/setup.sh
@@ -16,6 +16,4 @@ else
     exit 1
 fi 
 
-mkdir -p vendor/bundle
-
 bundle install --path vendor/bundle

--- a/setup.sh
+++ b/setup.sh
@@ -16,4 +16,6 @@ else
     exit 1
 fi 
 
-bundle install
+mkdir -p vendor/bundle
+
+bundle install --path vendor/bundle


### PR DESCRIPTION
Changes proposed in this pull request:

- specify bundle path avoiding to require sudo rights.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @duck-rh 
