### PR TITLE
Remove oVirt conference banner from home page

### DIFF
--- a/source/index.haml
+++ b/source/index.haml
@@ -26,11 +26,6 @@ hide_metadata: true
   }
   </style>
 
-%div.banner
-  %a(href="https://www.eventbrite.it/e/biglietti-ovirt-conference-2019-innovate-the-datacenter-with-open-virtualization-71510039453#")
-    %img#rome(src="/images/banners/https___cdn.evbuc.com_images_72213595_278319565097_1_original.jpeg" style="display:block; margin-left: auto; margin-right: auto; align-items: center; margin-bottom: 50px;")
-
-
 %section.intro(style="font-family: 'Open Sans', sans-serif !important; color: #666; text-align: center; min-height: 50vh; display: flex; align-items: center;")
   .container
     .row


### PR DESCRIPTION
Changes proposed in this pull request:

- Removing banner for oVirt conference, successfully completed yesterday

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 