### PR TITLE
Update Dockerfile to use Centos 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos
+FROM centos:7
 MAINTAINER Garrett LeSage <garrett@redhat.com>
 
 # User & group IDs — should match local user


### PR DESCRIPTION
With Centos8 now the default centos image in docker hub, the existing setup doesn't work.  Easiest fix is to force docker to use centos 7.  Another option would be to find the right set of packages to get it working on centos 8.

Fixes #2117

Changes proposed in this pull request:

- `Dockerfile` to use `centos:7` instead of `centos` / `centos:latest`

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sjd78
