### PR TITLE
Network failures during automated tests analysis

### DIFF
--- a/source/develop/release-management/features/network/spikes/cannot_activate_host.html.md
+++ b/source/develop/release-management/features/network/spikes/cannot_activate_host.html.md
@@ -1,0 +1,181 @@
+## Error of first failed test
+
+Cannot activate Host. Related operation is currently in progress. Please try again later.
+
+## Analysis and suggested solution
+
+The test removes a network which has been attached to a NIC on a host during the setup. This invokes a setup-network
+operation which prevented the internal refresh-caps from acquiring the VDS lock. When it finally succeeded it prevented
+the activate host action from acquiring the VDS lock which failed the test.
+
+Possible solution is to make ActivateVds wait for the VDS lock with a timeout.
+
+
+## Logs
+
+### engine.log
+
+* Internal refresh-caps invoked by VdsEventListener but failed to acquire HOST_NETWORK lock for ~2sec
+
+<pre>
+2019-08-02 23:40:43,499-04 DEBUG [org.ovirt.vdsm.jsonrpc.client.internal.ResponseWorker] (ResponseWorker) [] Event arrived from 192.168.201.2 containing {"notify_time":4297129460}
+2019-08-02 23:40:43,502-04 DEBUG [org.ovirt.engine.core.common.di.interceptor.DebugLoggingInterceptor] (ForkJoinPool-1-worker-5) [] method: getEventListener, params: [], timeElapsed: 0ms
+2019-08-02 23:40:43,507-04 DEBUG [org.ovirt.engine.core.bll.RefreshHostCapabilitiesCommand] (ForkJoinPool-1-worker-5) [bd6206a] Permission check skipped for internal action RefreshHostCapabilities.
+2019-08-02 23:40:43,507-04 INFO  [org.ovirt.engine.core.bll.RefreshHostCapabilitiesCommand] (ForkJoinPool-1-worker-5) [bd6206a] Before acquiring and wait lock 'EngineLock:{exclusiveLocks='[0702b222-f6c9-4035-903b-3ab57cd62dd6=VDS, HOST_NETWORK0702b222-f6c9-4035-903b-3ab57cd62dd6=HOST_NETWORK]', sharedLocks=''}'
+2019-08-02 23:40:43,507-04 DEBUG [org.ovirt.engine.core.bll.lock.InMemoryLockManager] (ForkJoinPool-1-worker-5) [bd6206a] Before acquiring and wait lock 'EngineLock:{exclusiveLocks='[0702b222-f6c9-4035-903b-3ab57cd62dd6=VDS, HOST_NETWORK0702b222-f6c9-4035-903b-3ab57cd62dd6=HOST_NETWORK]', sharedLocks=''}'
+2019-08-02 23:40:43,507-04 DEBUG [org.ovirt.engine.core.bll.lock.InMemoryLockManager] (ForkJoinPool-1-worker-5) [bd6206a] Failed to acquire lock. Exclusive lock is taken for key 'HOST_NETWORK0702b222-f6c9-4035-903b-3ab57cd62dd6', value 'HOST_NETWORK'
+</pre>
+
+* ...then succeeded and acquired both VDS and HOST_NETWORK locks (and monitor lock) and started executing
+
+<pre>
+2019-08-02 23:40:45,009-04 INFO  [org.ovirt.engine.core.bll.RefreshHostCapabilitiesCommand] (ForkJoinPool-1-worker-5) [bd6206a] Lock-wait acquired to object 'EngineLock:{exclusiveLocks='[0702b222-f6c9-4035-903b-3ab57cd62dd6=VDS, HOST_NETWORK0702b222-f6c9-4035-903b-3ab57cd62dd6=HOST_NETWORK]', sharedLocks=''}'
+2019-08-02 23:40:45,018-04 DEBUG [org.ovirt.engine.core.common.di.interceptor.DebugLoggingInterceptor] (ForkJoinPool-1-worker-5) [bd6206a] method: get, params: [0702b222-f6c9-4035-903b-3ab57cd62dd6], timeElapsed: 9ms
+2019-08-02 23:40:45,022-04 INFO  [org.ovirt.engine.core.bll.RefreshHostCapabilitiesCommand] (ForkJoinPool-1-worker-5) [bd6206a] Running command: RefreshHostCapabilitiesCommand(VdsId = 0702b222-f6c9-4035-903b-3ab57cd62dd6, RunSilent = false) internal: true. Entities affected :  ID: 0702b222-f6c9-4035-903b-3ab57cd62dd6 Type: VDSAction group MANIPULATE_HOST with role type ADMIN
+2019-08-02 23:40:45,022-04 INFO  [org.ovirt.engine.core.bll.RefreshHostCapabilitiesCommand] (ForkJoinPool-1-worker-5) [bd6206a] Running command: RefreshHostCapabilitiesCommand(VdsId = 0702b222-f6c9-4035-903b-3ab57cd62dd6, RunSilent = false) internal: true. Entities affected :  ID: 0702b222-f6c9-4035-903b-3ab57cd62dd6 Type: VDSAction group MANIPULATE_HOST with role type ADMIN
+2019-08-02 23:40:45,022-04 INFO  [org.ovirt.engine.core.bll.RefreshHostCapabilitiesCommand] (ForkJoinPool-1-worker-5) [bd6206a] Before acquiring lock in order to prevent monitoring for host 'lago-network-suite-4-3-host-1' from data-center 'Default'
+2019-08-02 23:40:45,023-04 DEBUG [org.ovirt.engine.core.bll.lock.InMemoryLockManager] (ForkJoinPool-1-worker-5) [bd6206a] Before acquiring and wait lock 'HostEngineLock:{exclusiveLocks='[0702b222-f6c9-4035-903b-3ab57cd62dd6=VDS_INIT]', sharedLocks=''}'
+2019-08-02 23:40:45,023-04 DEBUG [org.ovirt.engine.core.bll.lock.InMemoryLockManager] (ForkJoinPool-1-worker-5) [bd6206a] Success acquiring lock 'HostEngineLock:{exclusiveLocks='[0702b222-f6c9-4035-903b-3ab57cd62dd6=VDS_INIT]', sharedLocks=''}'
+2019-08-02 23:40:45,023-04 INFO  [org.ovirt.engine.core.bll.RefreshHostCapabilitiesCommand] (ForkJoinPool-1-worker-5) [bd6206a] Lock acquired, from now a monitoring of host will be skipped for host 'lago-network-suite-4-3-host-1' from data-center 'Default'
+2019-08-02 23:40:45,023-04 DEBUG [org.ovirt.engine.core.common.di.interceptor.DebugLoggingInterceptor] (ForkJoinPool-1-worker-5) [bd6206a] method: getVdsManager, params: [0702b222-f6c9-4035-903b-3ab57cd62dd6], timeElapsed: 0ms
+2019-08-02 23:40:45,026-04 DEBUG [org.ovirt.engine.core.vdsbroker.vdsbroker.GetCapabilitiesVDSCommand] (ForkJoinPool-1-worker-5) [bd6206a] START, GetCapabilitiesVDSCommand(HostName = lago-network-suite-4-3-host-1, VdsIdAndVdsVDSCommandParametersBase:{hostId='0702b222-f6c9-4035-903b-3ab57cd62dd6', vds='Host[lago-network-suite-4-3-host-1,0702b222-f6c9-4035-903b-3ab57cd62dd6]'}), log id: 184bca19
+</pre>
+
+* Activate Vds invoked from test but failed to acquire VDS lock so was revoked
+
+<pre>
+2019-08-02 23:40:45,153-04 DEBUG [org.ovirt.engine.core.bll.Backend] (default task-1) [] Executing command ActivateVds for user admin@internal-authz.
+2019-08-02 23:40:45,166-04 DEBUG [org.ovirt.engine.core.bll.ActivateVdsCommand] (default task-1) [a7b956d3-3c24-4e58-a32f-b003ec8a2124] Checking whether user 'ce08b410-b59b-11e9-a994-5452c0a8c904' or one of the groups he is member of, have the following permissions:  ID: 0702b222-f6c9-4035-903b-3ab57cd62dd6 Type: VDSAction group MANIPULATE_HOST with role type ADMIN
+2019-08-02 23:40:45,167-04 DEBUG [org.ovirt.engine.core.bll.ActivateVdsCommand] (default task-1) [a7b956d3-3c24-4e58-a32f-b003ec8a2124] Found permission 'ce08d3aa-b59b-11e9-a995-5452c0a8c904' for user when running 'ActivateVds', on 'Host' with id '0702b222-f6c9-4035-903b-3ab57cd62dd6'
+2019-08-02 23:40:45,167-04 DEBUG [org.ovirt.engine.core.bll.lock.InMemoryLockManager] (default task-1) [a7b956d3-3c24-4e58-a32f-b003ec8a2124] Before acquiring lock 'EngineLock:{exclusiveLocks='[0702b222-f6c9-4035-903b-3ab57cd62dd6=VDS]', sharedLocks=''}'
+2019-08-02 23:40:45,167-04 DEBUG [org.ovirt.engine.core.bll.lock.InMemoryLockManager] (default task-1) [a7b956d3-3c24-4e58-a32f-b003ec8a2124] Failed to acquire lock. Exclusive lock is taken for key '0702b222-f6c9-4035-903b-3ab57cd62dd6', value 'VDS'
+2019-08-02 23:40:45,168-04 INFO  [org.ovirt.engine.core.bll.ActivateVdsCommand] (default task-1) [a7b956d3-3c24-4e58-a32f-b003ec8a2124] Failed to Acquire Lock to object 'EngineLock:{exclusiveLocks='[0702b222-f6c9-4035-903b-3ab57cd62dd6=VDS]', sharedLocks=''}'
+2019-08-02 23:40:45,168-04 WARN  [org.ovirt.engine.core.bll.ActivateVdsCommand] (default task-1) [a7b956d3-3c24-4e58-a32f-b003ec8a2124] Validation of action 'ActivateVds' failed for user admin@internal-authz. Reasons: VAR__ACTION__ACTIVATE,VAR__TYPE__HOST,ACTION_TYPE_FAILED_OBJECT_LOCKED
+2019-08-02 23:40:45,173-04 DEBUG [org.ovirt.engine.core.common.di.interceptor.DebugLoggingInterceptor] (default task-1) [a7b956d3-3c24-4e58-a32f-b003ec8a2124] method: runAction, params: [ActivateVds, VdsActionParameters:{commandId='6c69d350-bfd1-46ee-82be-fd34692c606f', user='null', commandType='Unknown'}], timeElapsed: 21ms
+2019-08-02 23:40:45,174-04 ERROR [org.ovirt.engine.api.restapi.resource.AbstractBackendResource] (default task-1) [] Operation Failed: [Cannot activate Host. Related operation is currently in progress. Please try again later.]
+</pre>
+
+* External refresh-caps terminated
+
+<pre>
+2019-08-02 23:40:47,178-04 DEBUG [org.ovirt.engine.core.vdsbroker.vdsbroker.GetCapabilitiesVDSCommand] (ForkJoinPool-1-worker-5) [bd6206a] FINISH, GetCapabilitiesVDSCommand, return: Host[lago-network-suite-4-3-host-1,0702b222-f6c9-4035-903b-3ab57cd62dd6], log id: 184bca19
+2019-08-02 23:40:47,178-04 DEBUG [org.ovirt.engine.core.common.di.interceptor.DebugLoggingInterceptor] (ForkJoinPool-1-worker-5) [bd6206a] method: runVdsCommand, params: [GetCapabilities, VdsIdAndVdsVDSCommandParametersBase:{hostId='0702b222-f6c9-4035-903b-3ab57cd62dd6', vds='Host[lago-network-suite-4-3-host-1,0702b222-f6c9-4035-903b-3ab57cd62dd6]'}], timeElapsed: 2155ms
+2019-08-02 23:40:47,180-04 INFO  [org.ovirt.engine.core.vdsbroker.vdsbroker.GetHardwareInfoAsyncVDSCommand] (ForkJoinPool-1-worker-5) [bd6206a] START, GetHardwareInfoAsyncVDSCommand(HostName = lago-network-suite-4-3-host-1, VdsIdAndVdsVDSCommandParametersBase:{hostId='0702b222-f6c9-4035-903b-3ab57cd62dd6', vds='Host[lago-network-suite-4-3-host-1,0702b222-f6c9-4035-903b-3ab57cd62dd6]'}), log id: 20746c12
+2019-08-02 23:40:47,181-04 DEBUG [org.ovirt.vdsm.jsonrpc.client.reactors.stomp.impl.Message] (ForkJoinPool-1-worker-5) [bd6206a] SEND
+</pre>
+
+
+## Test code: network-suite/test_required_network.test_required_network_host_non_operational
+
+<pre>
+def test_required_network_host_non_operational(req_net,
+                                               cluster_net,
+                                               optionally_non_spm_host):
+    cluster_net.update(required=True)
+    optionally_non_spm_host.remove_networks((req_net,))
+    optionally_non_spm_host.wait_for_non_operational_status()
+    cluster_net.update(required=False)
+    optionally_non_spm_host.activate()
+    optionally_non_spm_host.wait_for_up_status()
+</pre>
+
+
+## Stacktrace
+
+<pre>
+
+----------------
+Failed Tests:
+-----------------
+1 tests failed.
+FAILED:  network-suite-4.3.tests.test_required_network.test_required_network_host_non_operational
+
+Error Message:
+Error: Fault reason is "Operation Failed". Fault detail is "[Cannot activate Host. Related operation is currently in progress. Please try again later.]". HTTP response code is 409.
+
+Stack Trace:
+req_net = <ovirtlib.netlib.Network object at 0x7fb514e58450>
+cluster_net = <ovirtlib.clusterlib.ClusterNetwork object at 0x7fb514e58c90>
+optionally_non_spm_host = <ovirtlib.hostlib.Host object at 0x7fb5162b53d0>
+
+    def test_required_network_host_non_operational(req_net,
+                                                   cluster_net,
+                                                   optionally_non_spm_host):
+        cluster_net.update(required=True)
+        optionally_non_spm_host.remove_networks((req_net,))
+        optionally_non_spm_host.wait_for_non_operational_status()
+        cluster_net.update(required=False)
+>       optionally_non_spm_host.activate()
+
+network-suite-4.3/tests/test_required_network.py:103:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+network-suite-4.3/ovirtlib/hostlib.py:110: in activate
+    self._service.activate()
+/usr/lib64/python2.7/site-packages/ovirtsdk4/services.py:38763: in activate
+    return self._internal_action(action, 'activate', None, headers, query, wait)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:299: in _internal_action
+    return future.wait() if wait else future
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:55: in wait
+    return self._code(response)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:296: in callback
+    self._check_fault(response)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:134: in _check_fault
+    self._raise_error(response, body.fault)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+response = <ovirtsdk4.http.Response object at 0x7fb5162b5050>
+detail = <ovirtsdk4.types.Fault object at 0x7fb5162b5550>
+
+    @staticmethod
+    def _raise_error(response, detail=None):
+        """
+            Creates and raises an error containing the details of the given HTTP
+            response and fault.
+
+            This method is intended for internal use by other components of the
+            SDK. Refrain from using it directly, as backwards compatibility isn't
+            guaranteed.
+            """
+        fault = detail if isinstance(detail, types.Fault) else None
+
+        msg = ''
+        if fault:
+            if fault.reason:
+                if msg:
+                    msg += ' '
+                msg = msg + 'Fault reason is "%s".' % fault.reason
+            if fault.detail:
+                if msg:
+                    msg += ' '
+                msg = msg + 'Fault detail is "%s".' % fault.detail
+        if response:
+            if response.code:
+                if msg:
+                    msg += ' '
+                msg = msg + 'HTTP response code is %s.' % response.code
+            if response.message:
+                if msg:
+                    msg += ' '
+                msg = msg + 'HTTP response message is "%s".' % response.message
+
+        if isinstance(detail, six.string_types):
+            if msg:
+                msg += ' '
+            msg = msg + detail + '.'
+
+        class_ = Error
+        if response is not None:
+            if response.code in [401, 403]:
+                class_ = AuthError
+            elif response.code == 404:
+                class_ = NotFoundError
+
+        error = class_(msg)
+        error.code = response.code if response else None
+        error.fault = fault
+>       raise error
+E       Error: Fault reason is "Operation Failed". Fault detail is "[Cannot activate Host. Related operation is currently in progress. Please try again later.]". HTTP response code is 409.
+
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:118: Error
+
+</pre>

--- a/source/develop/release-management/features/network/spikes/cannot_add_network.html.md
+++ b/source/develop/release-management/features/network/spikes/cannot_add_network.html.md
@@ -1,0 +1,525 @@
+## Error of first failed test
+
+Cannot add network רשת עם שם ארוך מאוד to network interface eth1. Network interface has an unmanaged network attached.
+
+## Analysis
+
+* 'req-net' from test_required_network.test_required_network_host_non_operational is removed from host-1 but removal not
+even attempted on host-0. Then when network is removed from DC, an unmanaged network is left on host-0/eth1.
+* vdsm.log and supervdsm.log terminate ~2sec before engine.log terminates
+
+
+
+## Logs
+
+### engine.log
+
+* 'req-net' is reported by get-caps on 23:28:09 - long after the test_required_network and the test following it
+(test_sync_across_cluster) have ended
+
+<pre>
+
+2019-07-30 23:26:26,312-04 INFO  [org.ovirt.engine.core.dal.dbbroker.auditloghandling.AuditLogDirector] (default task-2) [f764c94a-85f7-4aa7-b942-49e21af39ea6] EVENT_ID: EXTERNAL_EVENT_NORMAL(9,801), OST invoked: network-suite-4.3/tests/test_required_network.py::test_required_network_host_non_operational
+2019-07-30 23:26:35,165-04 INFO  [org.ovirt.engine.core.vdsbroker.SetVdsStatusVDSCommand] (default task-2) [304b1a38] START, SetVdsStatusVDSCommand(HostName = lago-network-suite-4-3-host-1, SetVdsStatusVDSCommandParameters:{hostId='3553b88c-c34f-450d-ab41-423a7c2898e3', status='NonOperational', nonOperationalReason='NETWORK_UNREACHABLE', stopSpmFailureLogged='false', maintenanceReason='null'}), log id: 307e67dc
+2019-07-30 23:26:35,269-04 WARN  [org.ovirt.engine.core.dal.dbbroker.auditloghandling.AuditLogDirector] (default task-2) [304b1a38] EVENT_ID: VDS_SET_NONOPERATIONAL_NETWORK(519), Host lago-network-suite-4-3-host-1 does not comply with the cluster Default networks, the following networks are missing on host: 'req-net'
+
+2019-07-30 23:26:43,771-04 DEBUG [org.ovirt.engine.core.common.di.interceptor.DebugLoggingInterceptor] (default task-2) [5e3fc7e0-d999-492f-8f98-e3b93274eeec] method: runAction, params: [HostSetupNetworks, HostSetupNetworksParameters:{commandId='9a7bba4d-5269-4b51-ae57-3ffd9d2c2951', user='null', commandType='Unknown'}], timeElapsed: 52ms
+2019-07-30 23:26:43,773-04 ERROR [org.ovirt.engine.api.restapi.resource.AbstractBackendResource] (default task-2) [] Operation Failed: [Cannot setup Networks. Another Setup Networks or Host Refresh process in progress on the host. Please try later.]
+2019-07-30 23:26:44,017-04 INFO  [org.ovirt.engine.core.bll.network.host.HostSetupNetworksCommand] (default task-2) [a4c7663f-dd65-45c4-aaff-4b73f9fe5fa2] No changes were detected in setup networks for host 'lago-network-suite-4-3-host-1' (ID: '3553b88c-c34f-450d-ab41-423a7c2898e3')
+2019-07-30 23:26:44,127-04 INFO  [org.ovirt.engine.core.bll.network.cluster.DetachNetworkFromClusterInternalCommand] (default task-2) [0bc4b9b3-8c76-4fcd-8937-f73c9308f389] Running command: DetachNetworkFromClusterInternalCommand(Network = Network:{id='485b8a1f-1453-4400-8b9d-496b2492c4d9', description='', comment='', vdsmName='req-net', subnet='null', gateway='null', type='null', vlanId='null', stp='false', dataCenterId='c9336034-b33e-11e9-b8d9-5452c0a8c904', mtu='0', vmNetwork='false', cluster='NetworkCluster:{id='NetworkClusterId:{clusterId='null', networkId='null'}', status='OPERATIONAL', display='false', required='false', migration='false', management='false', gluster='false', defaultRoute='false'}', providedBy='null', label='null', qosId='null', dnsResolverConfiguration='null'}, NetworkCluster = NetworkCluster:{id='NetworkClusterId:{clusterId='c935ee4e-b33e-11e9-888f-5452c0a8c904', networkId='485b8a1f-1453-4400-8b9d-496b2492c4d9'}', status='NON_OPERATIONAL', display='false', required='false', migration='false', management='false', gluster='false', defaultRoute='false'}, ClusterId = c935ee4e-b33e-11e9-888f-5452c0a8c904) internal: true. Entities affected :  ID: c935ee4e-b33e-11e9-888f-5452c0a8c904 Type: Cluster
+2019-07-30 23:26:44,170-04 INFO  [org.ovirt.engine.core.dal.dbbroker.auditloghandling.AuditLogDirector] (default task-2) [0bc4b9b3-8c76-4fcd-8937-f73c9308f389] EVENT_ID: NETWORK_DETACH_NETWORK_TO_CLUSTER(948), Network <UNKNOWN> detached from Cluster Default
+2019-07-30 23:26:44,172-04 DEBUG [org.ovirt.engine.core.common.di.interceptor.DebugLoggingInterceptor] (default task-2) [0bc4b9b3-8c76-4fcd-8937-f73c9308f389] method: runAction, params: [DetachNetworkToCluster, AttachNetworkToClusterParameter:{commandId='8b72f257-2837-4149-b62c-94630b2a4808', user='null', commandType='Unknown'}], timeElapsed: 118ms
+2019-07-30 23:26:44,193-04 DEBUG [org.ovirt.engine.core.bll.Backend] (default task-2) [] Executing command RemoveNetwork for user admin@internal-authz.
+2019-07-30 23:26:44,266-04 INFO  [org.ovirt.engine.core.bll.network.dc.RemoveNetworkCommand] (default task-2) [e942f3c4-3e3c-49c4-87e0-bbb708176354] Running command: RemoveNetworkCommand(RemoveFromNetworkProvider = false, Id = 485b8a1f-1453-4400-8b9d-496b2492c4d9) internal: false. Entities affected :  ID: 485b8a1f-1453-4400-8b9d-496b2492c4d9 Type: NetworkAction group CONFIGURE_STORAGE_POOL_NETWORK with role type ADMIN
+2019-07-30 23:26:44,313-04 INFO  [org.ovirt.engine.core.dal.dbbroker.auditloghandling.AuditLogDirector] (default task-2) [e942f3c4-3e3c-49c4-87e0-bbb708176354] EVENT_ID: NETWORK_REMOVE_NETWORK(944), Network req-net was removed from Data Center: Default
+2019-07-30 23:26:44,314-04 DEBUG [org.ovirt.engine.core.common.di.interceptor.DebugLoggingInterceptor] (default task-2) [e942f3c4-3e3c-49c4-87e0-bbb708176354] method: runAction, params: [RemoveNetwork, RemoveNetworkParameters:{commandId='9cef90fa-25fd-4e9e-98f0-91eaa418b962', user='null', commandType='Unknown'}], timeElapsed: 122ms
+
+2019-07-30 23:26:49,877-04 INFO  [org.ovirt.engine.core.dal.dbbroker.auditloghandling.AuditLogDirector] (default task-2) [eeb484fa-95f3-4fbf-8e58-d5963d79c886] EVENT_ID: EXTERNAL_EVENT_NORMAL(9,801), OST invoked: network-suite-4.3/tests/test_sync_all_hosts.py::test_sync_across_cluster
+
+2019-07-30 23:28:09,603-04 DEBUG [org.ovirt.vdsm.jsonrpc.client.internal.ResponseWorker] (ResponseWorker) [] Message received: {"jsonrpc": "2.0", "id": 
+....
+"req-net": {"iface": "eth1", "ipv6autoconf": false, "addr": "192.0.3.2", "dhcpv6": false, "ipv6addrs": [], "switch": "legacy", "bridged": false, "mtu": "1500", "dhcpv4": false, "netmask": "255.255.255.0", "ipv4defaultroute": false, "ipv4addrs": ["192.0.3.2/24"], "interface": "eth1", "southbound": "eth1", "ipv6gateway": "::", "gateway": ""}}
+....
+}
+
+2019-07-30 23:28:19,164-04 WARN  [org.ovirt.engine.core.bll.network.host.HostSetupNetworksCommand] (default task-1) [96abdfe9-ce8c-48a3-b48c-27777662275e] Validation of action 'HostSetupNetworks' failed for user admin@internal-authz. Reasons: VAR__ACTION__SETUP,VAR__TYPE__NETWORKS,ACTION_TYPE_FAILED_HOST_NETWORK_ATTACHEMENT_ON_UNMANAGED_NETWORK,$network רשת עם שם ארוך מאוד,$nic eth1
+2019-07-30 23:28:19,172-04 ERROR [org.ovirt.engine.api.restapi.resource.AbstractBackendResource] (default task-1) [] Operation Failed: [Cannot add network רשת עם שם ארוך מאוד to network interface eth1. Network interface has an unmanaged network attached.]
+2019-07-30 23:28:20,512-04 INFO  [org.ovirt.engine.core.bll.network.dc.RemoveNetworkCommand] (default task-1) [6be1d9cc-f4c2-43d0-9d58-0c444bb5020d] Running command: RemoveNetworkCommand(RemoveFromNetworkProvider = false, Id = 5a3ae1e6-6075-4c5a-ad24-12ae195b4be7) internal: false. Entities affected :  ID: 5a3ae1e6-6075-4c5a-ad24-12ae195b4be7 Type: NetworkAction group CONFIGURE_STORAGE_POOL_NETWORK with role type ADMIN
+2019-07-30 23:28:20,538-04 INFO  [org.ovirt.engine.core.dal.dbbroker.auditloghandling.AuditLogDirector] (default task-1) [6be1d9cc-f4c2-43d0-9d58-0c444bb5020d] EVENT_ID: NETWORK_REMOVE_NETWORK(944), Network רשת עם שם ארוך מאוד was removed from Data Center: Default
+2019-07-30 23:28:20,539-04 DEBUG [org.ovirt.engine.core.common.di.interceptor.DebugLoggingInterceptor] (default task-1) [6be1d9cc-f4c2-43d0-9d58-0c444bb5020d] method: runAction, params: [RemoveNetwork, RemoveNetworkParameters:{commandId='bb44c908-8b11-4875-a988-7644d97b91a6', user='null', commandType='Unknown'}], timeElapsed: 53ms
+
+</pre>
+
+### vdsm.log - host-1
+
+<pre>
+2019-07-30 23:26:27,708-0400 INFO  (jsonrpc/0) [api.network] START setupNetworks(networks={u'req-net': {u'remove': u'true'}}, bondings={}, options={u'connectivityCheck': u'true', u'connectivityTimeout': 120, u'commitOnSuccess': False}) from=::ffff:192.168.201.4,55906 (api:48)
+2019-07-30 23:26:31,847-0400 INFO  (jsonrpc/0) [api.network] FINISH setupNetworks return={'status': {'message': 'Done', 'code': 0}} from=::ffff:192.168.201.4,55906 (api:54)
+</pre>
+
+
+## Stacktrace
+
+<pre>
+
+-----------------
+Failed Tests:
+-----------------
+5 tests failed.
+FAILED:  network-suite-4.3.tests.test_unrestricted_display_network_name.test_run_vm_with_unrestricted_display_network_name
+
+Error Message:
+test setup failure
+
+Stack Trace:
+host_0_up = <ovirtlib.hostlib.Host object at 0x7f72fb5d8250>
+display_network = <ovirtlib.netlib.Network object at 0x7f72f9f3d910>
+
+    @pytest.fixture(scope='module')
+    def display_network_attached_to_host_0(host_0_up, display_network):
+        ETH1 = 'eth1'
+        DISP_NET_IPv4_ADDR_1 = '192.0.3.1'
+        DISP_NET_IPv4_MASK = '255.255.255.0'
+
+        ip_assign = netattachlib.StaticIpAssignment(
+            addr=DISP_NET_IPv4_ADDR_1, mask=DISP_NET_IPv4_MASK)
+        disp_att_data = netattachlib.NetworkAttachmentData(
+            display_network, ETH1, [ip_assign])
+>       host_0_up.setup_networks([disp_att_data])
+
+network-suite-4.3/tests/test_unrestricted_display_network_name.py:62:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+network-suite-4.3/ovirtlib/hostlib.py:174: in setup_networks
+    check_connectivity=True
+/usr/lib64/python2.7/site-packages/ovirtsdk4/services.py:39714: in setup_networks
+    return self._internal_action(action, 'setupnetworks', None, headers, query, wait)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:299: in _internal_action
+    return future.wait() if wait else future
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:55: in wait
+    return self._code(response)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:296: in callback
+    self._check_fault(response)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:132: in _check_fault
+    self._raise_error(response, body)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+response = <ovirtsdk4.http.Response object at 0x7f72f9f33c90>
+detail = <ovirtsdk4.types.Fault object at 0x7f72f9f33e10>
+
+    @staticmethod
+    def _raise_error(response, detail=None):
+        """
+            Creates and raises an error containing the details of the given HTTP
+            response and fault.
+
+            This method is intended for internal use by other components of the
+            SDK. Refrain from using it directly, as backwards compatibility isn't
+            guaranteed.
+            """
+        fault = detail if isinstance(detail, types.Fault) else None
+
+        msg = ''
+        if fault:
+            if fault.reason:
+                if msg:
+                    msg += ' '
+                msg = msg + 'Fault reason is "%s".' % fault.reason
+            if fault.detail:
+                if msg:
+                    msg += ' '
+                msg = msg + 'Fault detail is "%s".' % fault.detail
+        if response:
+            if response.code:
+                if msg:
+                    msg += ' '
+                msg = msg + 'HTTP response code is %s.' % response.code
+            if response.message:
+                if msg:
+                    msg += ' '
+                msg = msg + 'HTTP response message is "%s".' % response.message
+
+        if isinstance(detail, six.string_types):
+            if msg:
+                msg += ' '
+            msg = msg + detail + '.'
+
+        class_ = Error
+        if response is not None:
+            if response.code in [401, 403]:
+                class_ = AuthError
+            elif response.code == 404:
+                class_ = NotFoundError
+
+        error = class_(msg)
+        error.code = response.code if response else None
+        error.fault = fault
+>       raise error
+E       Error: Fault reason is "Operation Failed". Fault detail is "[Cannot add network רשת עם שם ארוך מאוד to network interface eth1. Network interface has an unmanaged network attached.]". HTTP response code is 400.
+
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:118: Error
+
+FAILED:  network-suite-4.3.tests.test_vm_operations.test_live_vm_migration_using_dedicated_network
+
+Error Message:
+test setup failure
+
+Stack Trace:
+migration_network = <ovirtlib.netlib.Network object at 0x7f72f835d710>
+host_0_up = <ovirtlib.hostlib.Host object at 0x7f72fb5d8250>
+
+    @pytest.fixture
+    def host_0_with_mig_net(migration_network, host_0_up):
+        ip_assign = netattachlib.StaticIpAssignment(
+            addr=MIG_NET_IPv4_ADDR_1, mask=MIG_NET_IPv4_MASK)
+        mig_att_data = netattachlib.NetworkAttachmentData(
+            migration_network, ETH1, [ip_assign])
+>       host_0_up.setup_networks([mig_att_data])
+
+network-suite-4.3/tests/test_vm_operations.py:81:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+network-suite-4.3/ovirtlib/hostlib.py:174: in setup_networks
+    check_connectivity=True
+/usr/lib64/python2.7/site-packages/ovirtsdk4/services.py:39714: in setup_networks
+    return self._internal_action(action, 'setupnetworks', None, headers, query, wait)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:299: in _internal_action
+    return future.wait() if wait else future
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:55: in wait
+    return self._code(response)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:296: in callback
+    self._check_fault(response)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:132: in _check_fault
+    self._raise_error(response, body)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+response = <ovirtsdk4.http.Response object at 0x7f72f9f15550>
+detail = <ovirtsdk4.types.Fault object at 0x7f72f9f152d0>
+
+    @staticmethod
+    def _raise_error(response, detail=None):
+        """
+            Creates and raises an error containing the details of the given HTTP
+            response and fault.
+
+            This method is intended for internal use by other components of the
+            SDK. Refrain from using it directly, as backwards compatibility isn't
+            guaranteed.
+            """
+        fault = detail if isinstance(detail, types.Fault) else None
+
+        msg = ''
+        if fault:
+            if fault.reason:
+                if msg:
+                    msg += ' '
+                msg = msg + 'Fault reason is "%s".' % fault.reason
+            if fault.detail:
+                if msg:
+                    msg += ' '
+                msg = msg + 'Fault detail is "%s".' % fault.detail
+        if response:
+            if response.code:
+                if msg:
+                    msg += ' '
+                msg = msg + 'HTTP response code is %s.' % response.code
+            if response.message:
+                if msg:
+                    msg += ' '
+                msg = msg + 'HTTP response message is "%s".' % response.message
+
+        if isinstance(detail, six.string_types):
+            if msg:
+                msg += ' '
+            msg = msg + detail + '.'
+
+        class_ = Error
+        if response is not None:
+            if response.code in [401, 403]:
+                class_ = AuthError
+            elif response.code == 404:
+                class_ = NotFoundError
+
+        error = class_(msg)
+        error.code = response.code if response else None
+        error.fault = fault
+>       raise error
+E       Error: Fault reason is "Operation Failed". Fault detail is "[Cannot add network mig-net to network interface eth1. Network interface has an unmanaged network attached.]". HTTP response code is 400.
+
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:118: Error
+
+FAILED:  network-suite-4.3.tests.ovs.test_ovn_physnet.test_connect_vm_to_external_physnet
+
+Error Message:
+test setup failure
+
+Stack Trace:
+system = <ovirtlib.system.SDKSystemRoot object at 0x7f72fd4bc210>
+ovs_cluster = <ovirtlib.clusterlib.Cluster object at 0x7f72e90f41d0>
+default_cluster = <ovirtlib.clusterlib.Cluster object at 0x7f72fdb12dd0>
+default_data_center = <ovirtlib.datacenterlib.DataCenter object at 0x7f72fc04a490>
+
+    @pytest.fixture(scope='session')
+    def host_in_ovs_cluster(
+            system, ovs_cluster, default_cluster, default_data_center):
+        host_id = default_cluster.host_ids()[0]
+        host = hostlib.Host(system)
+        host.import_by_id(host_id)
+        host.wait_for_up_status(timeout=hostlib.HOST_TIMEOUT_LONG)
+        with hostlib.change_cluster(host, ovs_cluster):
+>           host.sync_all_networks()
+
+network-suite-4.3/fixtures/host.py:64:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+network-suite-4.3/ovirtlib/hostlib.py:218: in sync_all_networks
+    self.service.sync_all_networks()
+/usr/lib64/python2.7/site-packages/ovirtsdk4/services.py:39762: in sync_all_networks
+    return self._internal_action(action, 'syncallnetworks', None, headers, query, wait)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:299: in _internal_action
+    return future.wait() if wait else future
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:55: in wait
+    return self._code(response)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:296: in callback
+    self._check_fault(response)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:134: in _check_fault
+    self._raise_error(response, body.fault)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+response = <ovirtsdk4.http.Response object at 0x7f72e90f48d0>
+detail = <ovirtsdk4.types.Fault object at 0x7f72e90f4710>
+
+    @staticmethod
+    def _raise_error(response, detail=None):
+        """
+            Creates and raises an error containing the details of the given HTTP
+            response and fault.
+
+            This method is intended for internal use by other components of the
+            SDK. Refrain from using it directly, as backwards compatibility isn't
+            guaranteed.
+            """
+        fault = detail if isinstance(detail, types.Fault) else None
+
+        msg = ''
+        if fault:
+            if fault.reason:
+                if msg:
+                    msg += ' '
+                msg = msg + 'Fault reason is "%s".' % fault.reason
+            if fault.detail:
+                if msg:
+                    msg += ' '
+                msg = msg + 'Fault detail is "%s".' % fault.detail
+        if response:
+            if response.code:
+                if msg:
+                    msg += ' '
+                msg = msg + 'HTTP response code is %s.' % response.code
+            if response.message:
+                if msg:
+                    msg += ' '
+                msg = msg + 'HTTP response message is "%s".' % response.message
+
+        if isinstance(detail, six.string_types):
+            if msg:
+                msg += ' '
+            msg = msg + detail + '.'
+
+        class_ = Error
+        if response is not None:
+            if response.code in [401, 403]:
+                class_ = AuthError
+            elif response.code == 404:
+                class_ = NotFoundError
+
+        error = class_(msg)
+        error.code = response.code if response else None
+        error.fault = fault
+>       raise error
+E       Error: Fault reason is "Operation Failed". Fault detail is "[Illegal Network parameters]". HTTP response code is 400.
+
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:118: Error
+
+FAILED:  network-suite-4.3.tests.ovs.test_ovn_physnet.test_max_mtu_size
+
+Error Message:
+test setup failure
+
+Stack Trace:
+system = <ovirtlib.system.SDKSystemRoot object at 0x7f72fd4bc210>
+ovs_cluster = <ovirtlib.clusterlib.Cluster object at 0x7f72e90f41d0>
+default_cluster = <ovirtlib.clusterlib.Cluster object at 0x7f72fdb12dd0>
+default_data_center = <ovirtlib.datacenterlib.DataCenter object at 0x7f72fc04a490>
+
+    @pytest.fixture(scope='session')
+    def host_in_ovs_cluster(
+            system, ovs_cluster, default_cluster, default_data_center):
+        host_id = default_cluster.host_ids()[0]
+        host = hostlib.Host(system)
+        host.import_by_id(host_id)
+        host.wait_for_up_status(timeout=hostlib.HOST_TIMEOUT_LONG)
+        with hostlib.change_cluster(host, ovs_cluster):
+>           host.sync_all_networks()
+
+network-suite-4.3/fixtures/host.py:64:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+network-suite-4.3/ovirtlib/hostlib.py:218: in sync_all_networks
+    self.service.sync_all_networks()
+/usr/lib64/python2.7/site-packages/ovirtsdk4/services.py:39762: in sync_all_networks
+    return self._internal_action(action, 'syncallnetworks', None, headers, query, wait)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:299: in _internal_action
+    return future.wait() if wait else future
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:55: in wait
+    return self._code(response)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:296: in callback
+    self._check_fault(response)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:134: in _check_fault
+    self._raise_error(response, body.fault)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+response = <ovirtsdk4.http.Response object at 0x7f72e90f48d0>
+detail = <ovirtsdk4.types.Fault object at 0x7f72e90f4710>
+
+    @staticmethod
+    def _raise_error(response, detail=None):
+        """
+            Creates and raises an error containing the details of the given HTTP
+            response and fault.
+
+            This method is intended for internal use by other components of the
+            SDK. Refrain from using it directly, as backwards compatibility isn't
+            guaranteed.
+            """
+        fault = detail if isinstance(detail, types.Fault) else None
+
+        msg = ''
+        if fault:
+            if fault.reason:
+                if msg:
+                    msg += ' '
+                msg = msg + 'Fault reason is "%s".' % fault.reason
+            if fault.detail:
+                if msg:
+                    msg += ' '
+                msg = msg + 'Fault detail is "%s".' % fault.detail
+        if response:
+            if response.code:
+                if msg:
+                    msg += ' '
+                msg = msg + 'HTTP response code is %s.' % response.code
+            if response.message:
+                if msg:
+                    msg += ' '
+                msg = msg + 'HTTP response message is "%s".' % response.message
+
+        if isinstance(detail, six.string_types):
+            if msg:
+                msg += ' '
+            msg = msg + detail + '.'
+
+        class_ = Error
+        if response is not None:
+            if response.code in [401, 403]:
+                class_ = AuthError
+            elif response.code == 404:
+                class_ = NotFoundError
+
+        error = class_(msg)
+        error.code = response.code if response else None
+        error.fault = fault
+>       raise error
+E       Error: Fault reason is "Operation Failed". Fault detail is "[Illegal Network parameters]". HTTP response code is 400.
+
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:118: Error
+
+FAILED:  network-suite-4.3.tests.ovs.test_ovn_physnet.test_security_groups_allow_icmp
+
+Error Message:
+test setup failure
+
+Stack Trace:
+system = <ovirtlib.system.SDKSystemRoot object at 0x7f72fd4bc210>
+ovs_cluster = <ovirtlib.clusterlib.Cluster object at 0x7f72e90f41d0>
+default_cluster = <ovirtlib.clusterlib.Cluster object at 0x7f72fdb12dd0>
+default_data_center = <ovirtlib.datacenterlib.DataCenter object at 0x7f72fc04a490>
+
+    @pytest.fixture(scope='session')
+    def host_in_ovs_cluster(
+            system, ovs_cluster, default_cluster, default_data_center):
+        host_id = default_cluster.host_ids()[0]
+        host = hostlib.Host(system)
+        host.import_by_id(host_id)
+        host.wait_for_up_status(timeout=hostlib.HOST_TIMEOUT_LONG)
+        with hostlib.change_cluster(host, ovs_cluster):
+>           host.sync_all_networks()
+
+network-suite-4.3/fixtures/host.py:64:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+network-suite-4.3/ovirtlib/hostlib.py:218: in sync_all_networks
+    self.service.sync_all_networks()
+/usr/lib64/python2.7/site-packages/ovirtsdk4/services.py:39762: in sync_all_networks
+    return self._internal_action(action, 'syncallnetworks', None, headers, query, wait)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:299: in _internal_action
+    return future.wait() if wait else future
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:55: in wait
+    return self._code(response)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:296: in callback
+    self._check_fault(response)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:134: in _check_fault
+    self._raise_error(response, body.fault)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+response = <ovirtsdk4.http.Response object at 0x7f72e90f48d0>
+detail = <ovirtsdk4.types.Fault object at 0x7f72e90f4710>
+
+    @staticmethod
+    def _raise_error(response, detail=None):
+        """
+            Creates and raises an error containing the details of the given HTTP
+            response and fault.
+
+            This method is intended for internal use by other components of the
+            SDK. Refrain from using it directly, as backwards compatibility isn't
+            guaranteed.
+            """
+        fault = detail if isinstance(detail, types.Fault) else None
+
+        msg = ''
+        if fault:
+            if fault.reason:
+                if msg:
+                    msg += ' '
+                msg = msg + 'Fault reason is "%s".' % fault.reason
+            if fault.detail:
+                if msg:
+                    msg += ' '
+                msg = msg + 'Fault detail is "%s".' % fault.detail
+        if response:
+            if response.code:
+                if msg:
+                    msg += ' '
+                msg = msg + 'HTTP response code is %s.' % response.code
+            if response.message:
+                if msg:
+                    msg += ' '
+                msg = msg + 'HTTP response message is "%s".' % response.message
+
+        if isinstance(detail, six.string_types):
+            if msg:
+                msg += ' '
+            msg = msg + detail + '.'
+
+        class_ = Error
+        if response is not None:
+            if response.code in [401, 403]:
+                class_ = AuthError
+            elif response.code == 404:
+                class_ = NotFoundError
+
+        error = class_(msg)
+        error.code = response.code if response else None
+        error.fault = fault
+>       raise error
+E       Error: Fault reason is "Operation Failed". Fault detail is "[Illegal Network parameters]". HTTP response code is 400.
+
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:118: Error
+
+</pre>

--- a/source/develop/release-management/features/network/spikes/cannot_edit_interface.html.md
+++ b/source/develop/release-management/features/network/spikes/cannot_edit_interface.html.md
@@ -1,0 +1,12 @@
+## Error of first failed test
+
+
+## Analysis
+
+
+## Logs
+
+### engine.log
+
+
+## Stacktrace

--- a/source/develop/release-management/features/network/spikes/colliding-setup-and-commit-network.html.md
+++ b/source/develop/release-management/features/network/spikes/colliding-setup-and-commit-network.html.md
@@ -1,0 +1,181 @@
+---
+title: Colliding 'setup networks' and 'commit network changes'
+category: investigation
+authors: erav
+---
+
+# Colliding 'setup networks' and 'commit network changes' operations
+
+## Problem description
+
+Vdsm does not allow <code>Host.setupNetworks</code> and <code>Host.setSafeNetworkConfig</code> to run in parallel but 
+engine does not enforce this constraint. Engine executes a persistent-setup-networks operation 
+(<code>PersistentHostSetupNetworksCommand</code>) in two phases:
+* executes setup-networks (<code>HostSetupNeworkCommand</code>) and then get-caps (<code>RefreshHostCapabilitiesCommand</code>)
+  as a sinlge atomic operation
+* once the first phase completes successfully it runs commit-network-changes (<code>CommitNetworkChangesCommand</code>)
+  non-atomically.
+
+The sequential synced execution guarantees no collision will occur on vdsm between the two phases of a single invocation,
+but it does not guarantee collision avoidance with another similar action in the following cases:
+
+* another similar action is instantiated from a different client for the same host.
+* another similar action is instantiated from the same client for the same host, before the first action has terminated.
+  So a first invocation might still be busy with a <code>Host.setSafeNetworkConfig</code> when a second invocation invokes
+  <code>Host.setupNetworks</code>. The latter <code>Host.setupNetworks</code> would then be revoked by vdsm. 
+  This behaviour is documented in [1] where the collision occurred during sync host networks with the following scenario:
+
+	01. request A: client issues setup networks
+	02. request A: restapi accepts request, forwards it to bll and returns response to client
+	03. request A: bll acquires setup networks lock
+	04. request A: bll issues setup networks request to vdsm
+	05. request A: vdsm acquires semaphore, executes setup networks, releases semaphore and returns response to engine
+	06. request A: bll releases setup networks lock
+	07. request B: same as step 01
+	08. request B: same as step 02
+	09. request B: same as step 03
+	10. request A: bll issues commit-network-changes request to vdsm
+	11. request A: vdsm acquires semaphore and executes commit-network-changes
+	12. request B: same as step 04
+	13. request B: ==> vdsm revokes the setup networks request because the semaphore is busy (step 11)
+  
+  Sync-host-networks invokes a single setup-networks and a single commit-network-changes wrapped by a single persistent-
+  setup-networks operation. This means that the only way the collision could have happened is if another rest-api call was
+  executing at the same time.
+  This is possible because of the asynchronous logic invoked in the restapi code [2]: a REST API request
+  which involves persistent-setup-networks is returned to the caller without waiting for bll commands to execute. 
+  This is true even if the rest-api call specifies the action should be performed <code>async=false </code> because the
+  internal bll commands do not carry any vdsm tasks and are run async themselves.
+
+  [1] https://bugzilla.redhat.com/show_bug.cgi?id=1723804
+  [2] https://github.com/oVirt/ovirt-engine/blob/master/.../AbstractBackendActionableResource.java#L84
+
+
+## Requirements for solutions
+
+Any proposed solution must guarantee the following requirements:
+  1. a happens-before relation between a setup and its related commit: a commit can only happen after its related setup
+     completed
+  2. a happens-before relation between a setup+commit and any other setup+commit
+  3. no collision on vdsm between a setup and a commit (guaranteed because of the above two requirements)
+  4. no collision on vdsm between two setups (already guaranteed by engine-side setup-networks locking)
+  5. no collision on vdsm between two commits
+  6. execution of setup+commit requests in the same order that they were requested by a single client
+  7. execution of setup+commit requests in the same order that they were requested by a different clients
+
+
+## Selected solution - mute commit-network-config invocations for cluster level >=4.4
+
+* Benefits:
+  * satisfies all the requirements 1-7
+  * low risk
+  * easy to implement
+* Drawbacks:
+  * will not affect cluster-level < 4.4
+
+### Planned behaviour 
+
+* Do not invoke commit-network-changes phase of persistent-setup-networks for cluster level >=4.4
+* Set commit-on-success to true inside engine for add\update\install host flows (see below)
+  * need to check that the setup-networks is done after cluster-level has been verified.
+* https://bugzilla.redhat.com/show_bug.cgi?id=1657647 must be fixed in same version?
+
+### Analysis
+
+* current commit-network-changes usages:
+
+  01. add\update\install host
+  02. directly from save-network functionality (web-admin button or rest-api call)
+  03. all persistent-setup-networks flows (these flows invoke setup-networks and get-caps under the same lock, 
+      and then commit-network-changes):
+      * change host cluster
+      * update\remove host network QoS
+      * add\update\remove host network
+      * sync all host networks
+      * attach\detach network to cluster
+      * manage logical networks
+      
+* commit-on-success usage (when supported):
+  * set to true in all persistent-setup-networks flows - so net-config-dirty returns false and commit-network-changes is
+    redundant
+  * cannot be relied on for initial vds install because vdsm version is not yet known. 
+  * is ignored when not supported (no error)
+  
+* Flow analysis for all persistent-setup-networks flows:
+
+   * Flow identified in the bug [1]:
+     01. persistent-setup-networks is triggered
+     02. first phase of setup-networks + get-caps runs and completes. on version >=4.3 the net-config-dirty flag is now
+         false because engine requested commit-on-success
+     03. another similar request from same or other client triggers (on a separate thread in engine)
+	     another persistent-setup-networks
+	 04. the first persistent-setup-networks triggers its second phase of commit-network-changes at the same time the
+	     second one triggers its first phase setup-networks on vdsm and they collide.
+	      
+   * Another possible flow:
+     01. persistent-setup-networks is triggered
+     02. first phase of setup-networks + get-caps runs and completes. on version >=4.3 the net-config-dirty flag is now
+         false because engine requested commit-on-success
+     03. another network config change happens on the host
+     04. an internal periodic get-caps or get-stats is triggered in engine, identifies the above change and sets net-config
+         -dirty to true
+     05. commit-network-changes is triggered by initial persistent-setup-networks because net-config-dirty is now true
+     If the last step is removed, the state of the host will remain unpersisted on both the host and engine DB.
+    
+* Regression analysis and conclusion: 
+  * it is safe to assume that each commit-network-change should commit the changes of its related operation and not the
+    changes of other operations. 
+  * when commit-on-success is set to true, it is possible to forgo the commit-network-changes phase in all flows without
+    any anticipated regression.
+  * in versions where commit-on-success is not supported, the flow will remain as is, so no anticipated regression.
+  * if the internal periodic get-caps\get-stats finds an unpersisted config state on vdsm for some state, this will be
+    reflected in the 'save-network-config' becoming available so this situation can be remedied manually.
+    
+    
+## Other possible solutions that have been suggested but not pursued
+
+01. Make <code>HostSetupNeworkCommand</code> pass its lock to <code>CommitNetworkChangesCommand</code> once it completes.
+  * Benefits:
+    * Satisfies requirements: 1-5
+    * Operations remain independent and don't require a single atomic wrapper
+    * The 'save network changes' action from UI\REST can continue to exist as a separate action
+  * Drawbacks:
+    * Does not satisfy requirements 6, 7
+    * Requires adding a 'pass lock' functionality to the network commands, <code>CommandBase</code> and the locking infra-
+      structure
+    * The 'pass lock' functionality needs to be available both to the setup lock and the monitoring lock.
+
+
+02. Wrap <code>HostSetupNeworkCommand</code> and <code>CommitNetworkChangesCommand</code> inside a single lock acquisition,
+    making their execution a single atomic operation. This is similar conceptually to (1) but differs in the implementation
+    details.
+  * Benefits:
+    * Satisfies requirements: 1-5
+  * Drawbacks:
+    * Does not satisfy requirements 6, 7
+    * This change involves deep modification of the code in the setup-networks and refresh-caps flows and in 
+      <code>CommandBase</code> because acquiring the setup networks lock and the monitor lock would have to be moved from
+      individual commands to their parent commands so that multiple commands can be executed under the same lock.
+  
+  
+03. Make the REST API calls behave synchronously and wait on the actual completion of all sub tasks on the server before 
+   returning to the caller.
+  * Benefits:
+    * Satisfies requirements: 1-6
+    * Satisfies requirement 7 for same-client invocation
+    * REST API calls specify async=false by default but actually do behave async in above flows. This would rectify this
+      misleading contradiction which is actually a bug.
+    * If solution is implemented just in <code>PersistentHostSetupNetworksCommand</code> flows, it does not affect other
+      engine flows.
+  * Drawbacks:
+    * Does not satisfy requirement 7 for multi-client invocations
+    * If solution is implemented in the REST API infra code it influences all engine flows which is a risk and might break
+      existing usages. According to engine Infra team, there was once an RFE to accomplish this but it was not implemented
+      because of a technical issue. An email thread is under way now to find out about it.
+    * If solution is implemented just in <code>PersistentHostSetupNetworksCommand</code> flows, its scope and effort is
+      currently not known (need to register and report VDS tasks). 
+
+## Preferred Solution
+
+The selected solution of muting commit-network-changes is the easiest and least risky to implement. From the others only
+the last satisfies the most amount of requirements for OST usage so it is the next best favorite.

--- a/source/develop/release-management/features/network/spikes/fault_details_is_[].html.md
+++ b/source/develop/release-management/features/network/spikes/fault_details_is_[].html.md
@@ -1,0 +1,221 @@
+## Error of first failed test
+
+Fault detail is "[]".
+
+
+## Analysis and suggested solution
+
+The test invokes setup-networks and immediately afterwards refresh-caps but this refresh caps hits the internal refresh-
+caps invoked by engine's VdsEventListener service. This is the only test that invokes refresh_caps so this issue only 
+manifests in this test.
+
+Currently:
+* for an internal invocation of refresh-caps acquire lock is tried with wait-forever
+* for an external invocation of refresh-caps acquire lock is tried with no wait
+
+A patch for moving both to a timed-wait was posted in the past but not merged (https://gerrit.ovirt.org/#/c/98257/)
+
+
+## Logs
+
+Alternating according to timestamp:
+
+### engine.log 
+
+VdsEventListener invokes internal refresh_caps ("Before acquiring and wait lock" -> with wait forever, see RefreshHostCommand#L20)
+
+<pre>
+2019-08-04 22:14:26,300-04 DEBUG [org.ovirt.engine.core.bll.RefreshHostCapabilitiesCommand] (ForkJoinPool-1-worker-7) [4039c3cd] Permission check skipped for internal action RefreshHostCapabilities.
+2019-08-04 22:14:26,300-04 INFO  [org.ovirt.engine.core.bll.RefreshHostCapabilitiesCommand] (ForkJoinPool-1-worker-7) [4039c3cd] Before acquiring and wait lock 'EngineLock:{exclusiveLocks='[HOST_NETWORKba68128a-31b9-4305-bb3d-2dd6b96b227f=HOST_NETWORK, ba68128a-31b9-4305-bb3d-2dd6b96b227f=VDS]', sharedLocks=''}'
+2019-08-04 22:14:26,300-04 DEBUG [org.ovirt.engine.core.bll.lock.InMemoryLockManager] (ForkJoinPool-1-worker-7) [4039c3cd] Before acquiring and wait lock 'EngineLock:{exclusiveLocks='[HOST_NETWORKba68128a-31b9-4305-bb3d-2dd6b96b227f=HOST_NETWORK, ba68128a-31b9-4305-bb3d-2dd6b96b227f=VDS]', sharedLocks=''}'
+2019-08-04 22:14:26,300-04 DEBUG [org.ovirt.engine.core.bll.lock.InMemoryLockManager] (ForkJoinPool-1-worker-7) [4039c3cd] Success acquiring lock 'EngineLock:{exclusiveLocks='[HOST_NETWORKba68128a-31b9-4305-bb3d-2dd6b96b227f=HOST_NETWORK, ba68128a-31b9-4305-bb3d-2dd6b96b227f=VDS]', sharedLocks=''}'
+2019-08-04 22:14:26,300-04 INFO  [org.ovirt.engine.core.bll.RefreshHostCapabilitiesCommand] (ForkJoinPool-1-worker-7) [4039c3cd] Lock-wait acquired to object 'EngineLock:{exclusiveLocks='[HOST_NETWORKba68128a-31b9-4305-bb3d-2dd6b96b227f=HOST_NETWORK, ba68128a-31b9-4305-bb3d-2dd6b96b227f=VDS]', sharedLocks=''}'
+2019-08-04 22:14:26,308-04 DEBUG [org.ovirt.engine.core.common.di.interceptor.DebugLoggingInterceptor] (ForkJoinPool-1-worker-7) [4039c3cd] method: get, params: [ba68128a-31b9-4305-bb3d-2dd6b96b227f], timeElapsed: 7ms
+2019-08-04 22:14:26,310-04 INFO  [org.ovirt.engine.core.bll.RefreshHostCapabilitiesCommand] (ForkJoinPool-1-worker-7) [4039c3cd] Running command: RefreshHostCapabilitiesCommand(RunSilent = false, VdsId = ba68128a-31b9-4305-bb3d-2dd6b96b227f) internal: true. Entities affected :  ID: ba68128a-31b9-4305-bb3d-2dd6b96b227f Type: VDSAction group MANIPULATE_HOST with role type ADMIN
+2019-08-04 22:14:26,310-04 INFO  [org.ovirt.engine.core.bll.RefreshHostCapabilitiesCommand] (ForkJoinPool-1-worker-7) [4039c3cd] Before acquiring lock in order to prevent monitoring for host 'lago-network-suite-master-host-1' from data-center 'Default'
+2019-08-04 22:14:26,310-04 DEBUG [org.ovirt.engine.core.bll.lock.InMemoryLockManager] (ForkJoinPool-1-worker-7) [4039c3cd] Before acquiring and wait lock 'HostEngineLock:{exclusiveLocks='[ba68128a-31b9-4305-bb3d-2dd6b96b227f=VDS_INIT]', sharedLocks=''}'
+2019-08-04 22:14:26,310-04 DEBUG [org.ovirt.engine.core.bll.lock.InMemoryLockManager] (ForkJoinPool-1-worker-7) [4039c3cd] Success acquiring lock 'HostEngineLock:{exclusiveLocks='[ba68128a-31b9-4305-bb3d-2dd6b96b227f=VDS_INIT]', sharedLocks=''}'
+2019-08-04 22:14:26,311-04 INFO  [org.ovirt.engine.core.bll.RefreshHostCapabilitiesCommand] (ForkJoinPool-1-worker-7) [4039c3cd] Lock acquired, from now a monitoring of host will be skipped for host 'lago-network-suite-master-host-1' from data-center 'Default'
+2019-08-04 22:14:26,311-04 DEBUG [org.ovirt.engine.core.common.di.interceptor.DebugLoggingInterceptor] (ForkJoinPool-1-worker-7) [4039c3cd] method: getVdsManager, params: [ba68128a-31b9-4305-bb3d-2dd6b96b227f], timeElapsed: 0ms
+2019-08-04 22:14:26,313-04 DEBUG [org.ovirt.engine.core.vdsbroker.vdsbroker.GetCapabilitiesVDSCommand] (ForkJoinPool-1-worker-7) [4039c3cd] START, GetCapabilitiesVDSCommand(HostName = lago-network-suite-master-host-1, VdsIdAndVdsVDSCommandParametersBase:{hostId='ba68128a-31b9-4305-bb3d-2dd6b96b227f', vds='Host[lago-network-suite-master-host-1,ba68128a-31b9-4305-bb3d-2dd6b96b227f]'}), log id: 1d417421
+</pre>
+
+### vdsm.log
+
+Internal refresh-caps starts on vdsm
+
+<pre>
+2019-08-04 22:14:26,313-0400 INFO  (jsonrpc/7) [api.host] START getCapabilities() from=::ffff:192.168.201.2,47182, flow_id=4039c3cd (api:48)
+</pre>
+
+### engine.log
+
+Test invokes external refresh-caps ("Before acquiring lock" -> with no wait, see RefreshHostCommand#L20) but fails because lock is taken
+
+<pre>
+2019-08-04 22:14:26,897-04 DEBUG [org.ovirt.engine.core.bll.lock.InMemoryLockManager] (default task-2) [5b93a451] Before acquiring lock 'EngineLock:{exclusiveLocks='[HOST_NETWORKba68128a-31b9-4305-bb3d-2dd6b96b227f=HOST_NETWORK, ba68128a-31b9-4305-bb3d-2dd6b96b227f=VDS]', sharedLocks=''}'
+2019-08-04 22:14:26,897-04 DEBUG [org.ovirt.engine.core.bll.lock.InMemoryLockManager] (default task-2) [5b93a451] Failed to acquire lock. Exclusive lock is taken for key 'HOST_NETWORKba68128a-31b9-4305-bb3d-2dd6b96b227f', value 'HOST_NETWORK'
+2019-08-04 22:14:26,898-04 INFO  [org.ovirt.engine.core.bll.RefreshHostCapabilitiesCommand] (default task-2) [5b93a451] Failed to Acquire Lock to object 'EngineLock:{exclusiveLocks='[HOST_NETWORKba68128a-31b9-4305-bb3d-2dd6b96b227f=HOST_NETWORK, ba68128a-31b9-4305-bb3d-2dd6b96b227f=VDS]', sharedLocks=''}'
+2019-08-04 22:14:26,898-04 WARN  [org.ovirt.engine.core.bll.RefreshHostCapabilitiesCommand] (default task-2) [5b93a451] Validation of action 'RefreshHostCapabilities' failed for user admin@internal-authz. Reasons: VAR__ACTION__REFRESH,VAR__TYPE__HOST_CAPABILITIES,ACTION_TYPE_FAILED_SETUP_NETWORKS_OR_REFRESH_IN_PROGRESS
+2019-08-04 22:14:26,910-04 DEBUG [org.ovirt.engine.core.bll.CommandCompensator] (default task-2) [5b93a451] Command [id=9ae3b04c-e6bc-4641-ba6b-93ae64393fba]: No compensation data.
+2019-08-04 22:14:26,957-04 ERROR [org.ovirt.engine.core.bll.network.host.RefreshHostCommand] (default task-2) [5b93a451] Transaction rolled-back for command 'org.ovirt.engine.core.bll.network.host.RefreshHostCommand'.
+2019-08-04 22:14:26,960-04 DEBUG [org.ovirt.engine.core.common.di.interceptor.DebugLoggingInterceptor] (default task-2) [5b93a451] method: runAction, params: [RefreshHost, VdsActionParameters:{commandId='9ae3b04c-e6bc-4641-ba6b-93ae64393fba', user='null', commandType='Unknown'}], timeElapsed: 89ms
+2019-08-04 22:14:26,961-04 ERROR [org.ovirt.engine.api.restapi.resource.AbstractBackendResource] (default task-2) [] Operation Failed: []
+</pre>
+
+### vdsm.log
+
+Internal refresh-caps terminates on vdsm
+
+<pre>
+2019-08-04 22:14:28,852-0400 INFO  (jsonrpc/7) [api.host] FINISH getCapabilities return={'status': {'message': 'Done', 'code': 0}, 'info': {u'HBAInventory': {u'iSCSI': 
+2019-08-04 22:14:28,861-0400 INFO  (jsonrpc/7) [jsonrpc.JsonRpcServer] RPC call Host.getCapabilities succeeded in 2.55 seconds (__init__:312)
+
+2019-08-04 22:14:28,889-0400 INFO  (jsonrpc/3) [api.host] START getHardwareInfo() from=::ffff:192.168.201.2,47182, flow_id=4039c3cd (api:48)
+2019-08-04 22:14:28,890-0400 INFO  (jsonrpc/3) [api.host] FINISH getHardwareInfo return={'status': {'message': 'Done', 'code': 0}, 'info': {'systemProductName': u'KVM', 'systemUUID': u'FF9718A0-5B56-4705-8C2A-62B6D95BA1DE', 'systemFamily': u'Red Hat Enterprise Linux', 'systemVersion': u'RHEL 7.6.0 PC (i440FX + PIIX, 1996)', 'systemManufacturer': u'Red Hat'}} from=::ffff:192.168.201.2,47182, flow_id=4039c3cd (api:54)
+2019-08-04 22:14:28,890-0400 INFO  (jsonrpc/3) [jsonrpc.JsonRpcServer] RPC call Host.getHardwareInfo succeeded in 0.00 seconds (__init__:312)
+
+2019-08-04 22:14:29,167-0400 INFO  (jsonrpc/4) [api.network] START setupNetworks(networks={u'sync-net': {u'remove': u'true'}}, bondings={}, options={u'connectivityCheck': u'true', 
+2019-08-04 22:14:34,390-0400 INFO  (jsonrpc/4) [api.network] FINISH setupNetworks return={'status': {'message': 'Done', 'code': 0}} from=::ffff:192.168.201.2,47182, flow_id=3427f12b (api:54)
+2019-08-04 22:14:34,391-0400 INFO  (jsonrpc/4) [jsonrpc.JsonRpcServer] RPC call Host.setupNetworks succeeded in 5.23 seconds (__init__:312)
+</pre>
+
+
+ 
+## Test code: network-suite/test_sync_all_hosts.test_sync_across_cluster
+
+<pre>
+
+def test_sync_across_cluster(...):
+
+    cluster_hosts_up = (host_0_up, host_1_up)
+    with netlib.new_network('sync-net', default_data_center) as sync_net:
+        with clusterlib.network_assignment(default_cluster, sync_net):
+            with contextlib2.ExitStack() as stack:
+                for i, host in enumerate(cluster_hosts_up):
+                    att_datum = create_attachment(sync_net, i)
+                    stack.enter_context(
+                        hostlib.setup_networks(host, (att_datum,))
+                    )
+                    stack.enter_context(unsynced_host_network(host))
+                default_cluster.sync_all_networks()
+                for host in cluster_hosts_up:
+                    host.wait_for_networks_in_sync()
+       
+def unsynced_host_network(host_up):
+    ...
+    host_up.refresh_capabilities()
+
+</pre>
+
+
+## Stack trace
+
+<pre>
+
+-----------------
+Failed Tests:
+-----------------
+1 tests failed.
+FAILED:  network-suite-master.tests.test_sync_all_hosts.test_sync_across_cluster
+
+Error Message:
+Error: Fault reason is "Operation Failed". Fault detail is "[]". HTTP response code is 400.
+
+Stack Trace:
+default_data_center = <ovirtlib.datacenterlib.DataCenter object at 0x7fa5eab6b3d0>
+default_cluster = <ovirtlib.clusterlib.Cluster object at 0x7fa5ec632d50>
+host_0_up = <ovirtlib.hostlib.Host object at 0x7fa5e8aa3690>
+host_1_up = <ovirtlib.hostlib.Host object at 0x7fa5ea0fc0d0>
+
+    def test_sync_across_cluster(default_data_center, default_cluster,
+                                 host_0_up, host_1_up):
+
+        cluster_hosts_up = (host_0_up, host_1_up)
+        with netlib.new_network('sync-net', default_data_center) as sync_net:
+            with clusterlib.network_assignment(default_cluster, sync_net):
+                with contextlib2.ExitStack() as stack:
+                    for i, host in enumerate(cluster_hosts_up):
+                        att_datum = create_attachment(sync_net, i)
+                        stack.enter_context(
+                            hostlib.setup_networks(host, (att_datum,))
+                        )
+>                       stack.enter_context(unsynced_host_network(host))
+
+network-suite-master/tests/test_sync_all_hosts.py:45:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+/usr/lib/python2.7/site-packages/contextlib2.py:380: in enter_context
+    result = _cm_type.__enter__(cm)
+/usr/lib64/python2.7/contextlib.py:17: in __enter__
+    return self.gen.next()
+network-suite-master/tests/test_sync_all_hosts.py:64: in unsynced_host_network
+    host_up.refresh_capabilities()
+network-suite-master/ovirtlib/hostlib.py:321: in refresh_capabilities
+    self.service.refresh()
+/usr/lib64/python2.7/site-packages/ovirtsdk4/services.py:39403: in refresh
+    return self._internal_action(action, 'refresh', None, headers, query, wait)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:299: in _internal_action
+    return future.wait() if wait else future
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:55: in wait
+    return self._code(response)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:296: in callback
+    self._check_fault(response)
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:134: in _check_fault
+    self._raise_error(response, body.fault)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+response = <ovirtsdk4.http.Response object at 0x7fa5e2dc3290>
+detail = <ovirtsdk4.types.Fault object at 0x7fa5e2dc3050>
+
+    @staticmethod
+    def _raise_error(response, detail=None):
+        """
+            Creates and raises an error containing the details of the given HTTP
+            response and fault.
+
+            This method is intended for internal use by other components of the
+            SDK. Refrain from using it directly, as backwards compatibility isn't
+            guaranteed.
+            """
+        fault = detail if isinstance(detail, types.Fault) else None
+
+        msg = ''
+        if fault:
+            if fault.reason:
+                if msg:
+                    msg += ' '
+                msg = msg + 'Fault reason is "%s".' % fault.reason
+            if fault.detail:
+                if msg:
+                    msg += ' '
+                msg = msg + 'Fault detail is "%s".' % fault.detail
+        if response:
+            if response.code:
+                if msg:
+                    msg += ' '
+                msg = msg + 'HTTP response code is %s.' % response.code
+            if response.message:
+                if msg:
+                    msg += ' '
+                msg = msg + 'HTTP response message is "%s".' % response.message
+
+        if isinstance(detail, six.string_types):
+            if msg:
+                msg += ' '
+            msg = msg + detail + '.'
+
+        class_ = Error
+        if response is not None:
+            if response.code in [401, 403]:
+                class_ = AuthError
+            elif response.code == 404:
+                class_ = NotFoundError
+
+        error = class_(msg)
+        error.code = response.code if response else None
+        error.fault = fault
+>       raise error
+E       Error: Fault reason is "Operation Failed". Fault detail is "[]". HTTP response code is 400.
+
+/usr/lib64/python2.7/site-packages/ovirtsdk4/service.py:118: Error
+</pre>

--- a/source/develop/release-management/features/network/spikes/ost_net_failures_2019.html.md
+++ b/source/develop/release-management/features/network/spikes/ost_net_failures_2019.html.md
@@ -1,0 +1,94 @@
+# Inconsistent but repeated failures are happening on OST 4.3 and master
+
+
+### Discussion
+
+Until now the policy for handling network requests in engine was:
+1. REST API requests are handled async unless the underlying commands report their Vdsm Tasks.
+2. <code>PersistentHostSetupNetworksCommand</code> flows are run async internally in the server.
+3. an external network action is revoked if the server is busy (lock taken)
+4. an internal refresh host action waits for a lock forever
+
+Policy (3) guarantees execution of requests in the order that they were issued - whether from a single client or from
+multiple clients. It also did not fail the 'human admin' usage model where a person can retry the request and check for
+its successful completion.
+However it does not perform well in a testing environment where revocations of requests due to 'busy server' fail the
+suite frequently.
+
+
+An alternate server policy for test suites must fulfill the following requirements:
+1. execution of requests in the same order that they were requested by a single client
+2. the server cannot be respond as 'busy' - it must queue external requests if it cannot serve them
+
+To fulfill requirement (1) it is necessary to make the REST API requests return synchronously with the completion of their
+operations.
+
+To fulfill requirement (2) a timed-wait for setup-networks was introduced to master. It helped reduce the failures on master
+considerably.
+The current failures on master all are around a similar situation with an external refresh-caps being revoked on 'server
+busy'. This situation might be resolved with a timed-wait for refresh-caps (https://gerrit.ovirt.org/#/c/98257).
+
+
+### OST Failures on branch 4.3
+
+  * 145 Fault detail is "[]"
+  * 162 Fault detail is "[]"
+  * 150 another setup in progress
+  * 151
+    * Cannot add network רשת עם שם ארוך מאוד to network interface eth1. Network interface has an unmanaged network attached.
+    * Cannot add network mig-net to network interface eth1. Network interface has an unmanaged network attached.
+    * Illegal Network parameters
+    * Illegal Network parameters
+    * Illegal Network parameters
+  * 152 another setup in progress
+  * 159 another setup in progress
+  * 161 another setup in progress
+  * 154 cannot activate host. related op in progress
+  * 157
+    * Cannot edit Interface. Updating some of the properties is not supported while the interface is plugged into a running
+      virtual machine.
+    * another setup in progress
+  * 169, 172
+    * setup networks in progress 
+    * 3 tests (ovn) failed with Illegal Network parameters
+  * 173
+    * test teardown failure (change_cluster)
+    * test setup failure (setup_networks)
+    * general command validation failure (setup_networks)
+
+
+### OST Failures on branch master
+
+  * 1067 Fault detail is "[]"
+  * 1071 Fault detail is "[]"
+  * 1080 Fault detail is "[]"
+  * 1092 cannot activate host. related op in progress
+  * 1095 
+  
+
+### QE test suite failures
+
+ * colliding setup-networks with commit-network-changes on vdsm
+ 
+
+### Explained Failures
+
+ * another setup in progress
+   * reason: timed wait for setup networks not backported to 4.3
+ * test_sync_across_cluster: Fault detail is "[]"
+   * reason: refresh host failed because refresh caps could not get lock
+ * test_required_network: cannot activate host. related op in progress
+   * reason: refresh caps in progress
+ * colliding setup-networks with commit-network-changes on vdsm
+   * reason: different lock policy in engine and in vdsm for these actions
+
+
+### Unexplained Failures (TODO)
+
+ * test_unrestricted_display_network_name: cannot add network. Network interface has an unmanaged network attached
+   * reason: a remove network attachment was not executed on one of the hosts
+ * test_move_mac_to_new_vm: test teardown failure.
+   * reason: change_cluster failed during teardown
+   
+   
+


### PR DESCRIPTION
Analysis of failures in OST test runs and QE test suite run.

For example:
* Colliding setup-networks with commit-networks-changes
* Colliding refresh-caps invocations



Changes proposed in this pull request:
* create spikes folder under release-management/network
* add detailed analyses for spikes that have been carried out. one page per spike
-

-

-

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @mention yourself to sign)
@erav 

This pull request needs review by: (please @mention the reviewer if relevant) 
@dominikholler 
