### PR TITLE
Add missing spaces in Feature Pages warning

### DIFF
--- a/source/_includes/feature.haml
+++ b/source/_includes/feature.haml
@@ -3,15 +3,15 @@
   Feature pages are design documents that developers have created while collaborating on oVirt.
   %br
   %br
-  Most of them are
+  Most of them are 
   %strong
     outdated
   , but provide historical design context.
   %br
   %br
-  They are
+  They are 
   %strong
-    not
+    not 
   user documentation and should not be treated as such.
   %br
   %br


### PR DESCRIPTION
Changes proposed in this pull request:

- Adding  missing spaces in Feature Pages warning

-

-

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @rollandf 

This pull request needs review by: @duck-rh @sandrobonazzola 
