### PR TITLE
Update oVirt Node Master links

### DIFF
--- a/source/download/node.md
+++ b/source/download/node.md
@@ -35,9 +35,9 @@ This is the oVirt Node 4.3 image including the latest oVirt 4.3 packages. This i
 
 This is the oVirt Node image build based on oVirt packages from the master branches.
 
-* [oVirt Node master experimental ISO (based on el7)](http://jenkins.ovirt.org/job/ovirt-node-ng-image_master_build-artifacts-el7-x86_64/lastSuccessfulBuild/artifact/exported-artifacts/latest-installation-iso.html)
+* [oVirt Node master experimental ISO (based on el8)](http://jenkins.ovirt.org/job/ovirt-node-ng-image_master_build-artifacts-el8-x86_64/lastSuccessfulBuild/artifact/exported-artifacts/latest-installation-iso.html)
 
-* Jenkins job (el7): <http://jenkins.ovirt.org/job/ovirt-node-ng-image_master_build-artifacts-el7-x86_64/>
+* Jenkins job (el8): <http://jenkins.ovirt.org/job/ovirt-node-ng-image_master_build-artifacts-el8-x86_64/>
 
 # Old releases
 


### PR DESCRIPTION
Fixes issue #2099

Changes proposed in this pull request:

- Update download links for oVirt Node master, pointing to EL8 builds since we are not providing EL7 node anymore on master / 4.4.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola
