### PR TITLE
Fix link to security advisories

### DIFF
--- a/source/develop/security/security.md
+++ b/source/develop/security/security.md
@@ -29,5 +29,5 @@ You will be invited to subscribe to this list if you are subscribed to security 
 
 ## Security advisories
 
-The [security advisories](/documentation/security/security-advisories/) page lists all security vulnerabilities fixed in oVirt.
+The [security advisories](security-advisories/) page lists all security vulnerabilities fixed in oVirt.
 


### PR DESCRIPTION
Fixes issue #2003

Changes proposed in this pull request:

- Fix broken link to security advisories page

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola
