### PR TITLE
Update alpha download page

### DIFF
--- a/source/download/alpha.md
+++ b/source/download/alpha.md
@@ -35,9 +35,9 @@ Engine:
 - Scientific Linux 7.7 or later but < 8
 
 Hosts:
-- Red Hat Enterprise Linux 8.0 or later
-- CentOS Linux 8.0 or later
-- oVirt Node (based on CentOS Linux 8.0)
+- Red Hat Enterprise Linux 8.1 or later
+- CentOS Linux 8.1 or later
+- oVirt Node (based on CentOS Linux 8.1)
 
 See the [Release Notes for oVirt 4.4.0](/release/4.4.0/).
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Update Alpha download page pointing to CentOS 8.1

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 
