### PR TITLE
Move repository-mirrors to the Community section

### DIFF
--- a/source/community/get-involved/repository-mirrors.md
+++ b/source/community/get-involved/repository-mirrors.md
@@ -1,7 +1,7 @@
 ---
 title: Repository mirrors
 category: infra
-authors: amarchuk, bproffitt, dcaroest, ngoldin
+authors: amarchuk, bproffitt, dcaroest, ngoldin, ederevea
 ---
 
 # Repository mirrors
@@ -10,7 +10,7 @@ authors: amarchuk, bproffitt, dcaroest, ngoldin
 
 Do you want to become a mirror? Do you have some bandwidth to spare?
 
-Drop us a line at [infa](mailto:infra@ovirt.org) and tell us about yourself! You just need to pass us a public ssh key, and once set up you'll be able to rsync from our site with the following command:
+Drop us a line at [infa](mailto:infra-support@ovirt.org) and tell us about yourself! You just need to pass us a public ssh key, and once set up you'll be able to rsync from our site with the following command:
 
        rsync -rltHvvP mirror@resources.ovirt.org:/var/www/html destination/dir
 
@@ -21,10 +21,11 @@ After some validation we will add your site to this page and to the mirrorlist!
 ## For admins
 
 We have a simple setup to allow mirroring of the oVirt repositories. Right now the mirroring is done through ssh with rsync. You'll find in **resources.ovirt.org** a user named **mirror**, that's the user that the mirrors should use, you'll see that it has a lot of entries under *~/.ssh/authorized_keys*, there each entry is restricted to run only a specific command that allows them to rsync the repo directory.
+Please refer to the [read the docs page](https://ovirt-infra-docs.readthedocs.io/en/latest/General/Mirror/index.html) for more info on adding mirrors.
 
 ### Adding a mirror
 
-To add a mirror you just need to add it's public ssh key in *~mirror/.ssh/authorized_keys*, with the command restriction as the other entries. Then when the mirror is confirmed you can add it to the mirrorlist (*resources.ovirt.org:/var/www/html/pub/yum-repo/mirrorlist*) and to this wiki.
+Then when the mirror is in sync you can add it to the mirrorlist (*resources.ovirt.org:/var/www/html/pub/yum-repo/mirrorlist*) and to this wiki.
 
 ## Current mirrors
 

--- a/source/community/index.md
+++ b/source/community/index.md
@@ -46,7 +46,7 @@ Reporting bugs is one of the most valuable ways you can contribute! Ideas for ne
 
 ## Participate in the oVirt infrastructure
 
-Our project infrastructure can always benefit from extra people, hardware and network bandwidth. First of all, consider [becoming a public mirror](/develop/infra/repository-mirrors.html) of oVirt repositories. You can also [become an infra team member](/develop/infra/becoming-an-infrastructure-team-member.html) or [donate hardware](/community/get-involved/donate-hardware.html) to the project to improve our capacity and redundancy.
+Our project infrastructure can always benefit from extra people, hardware and network bandwidth. First of all, consider [becoming a public mirror](/community/get-involved/repository-mirrors.html) of oVirt repositories. You can also [become an infra team member](/develop/infra/becoming-an-infrastructure-team-member.html) or [donate hardware](/community/get-involved/donate-hardware.html) to the project to improve our capacity and redundancy.
 
 ## Supporters, Sponsors, and Providers
 


### PR DESCRIPTION
Signed-off-by: Evgheni Dereveanchin <ederevea@redhat.com>

Fixes OVIRT-2916

Changes proposed in this pull request:

- move repository-mirrors to the Community section from the deprecated Documentation section

- update email to automatically create JIRA tickets

- link to RTD page for admins on setting up mirrors

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @jekader 

This pull request needs review by: @marchukov 
