### PR TITLE
nav: fix link to page-top

### DIFF
--- a/source/_includes/nav.haml
+++ b/source/_includes/nav.haml
@@ -38,7 +38,7 @@
 
                 <ul class="nav navbar-nav">
                     <li class="hidden active">
-                        <a href="#page-top"></a>
+                        <a href="#page-wrap"></a>
                     </li>
 
 :ruby


### PR DESCRIPTION
Changes proposed in this pull request:

- In generated pages page-top anchor doesn't exist. Using page-wrap instead.
  This fixes 1111 broken links.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @duck-rh 
