### PR TITLE
cleanup: drop refs to quickstart-guide

### DIFF
--- a/source/develop/release-management/features/gluster/gluster-dr.md
+++ b/source/develop/release-management/features/gluster/gluster-dr.md
@@ -72,7 +72,7 @@ Such a script is already available at [ovirt-georep-backup](https://github.com/s
 
 In the event of a disaster, the storage domain can be attached to a running instance of oVirt. 
 
-1. A new instance of oVirt is setup with a master storage domain.(see [Quick_Start_Guide#Install_oVirt](/documentation/quickstart/quickstart-guide/#install-ovirt)). A master storage domain needs to be active in oVirt to initialize the Data Center and perform further operations
+1. A new instance of oVirt is setup with a master storage domain. A master storage domain needs to be active in oVirt to initialize the Data Center and perform further operations
 2. Use the [Import Storage Domain](/develop/release-management/features/storage/importstoragedomain/) feature to import the gluster volume from secondary site (the one setup as slave gluster volume in previous setup)
     - In case the storage domain contains the VMs and all its disks, the VMs can be imported to the new oVirt instance
     - In case the storage domain contains only floating disks (i.e not attached to any VMs or where the storage domain does not contain the VM's OS disks), the disks can be registered via GUI (see [Bug 1138139](https://bugzilla.redhat.com/show_bug.cgi?id=1138139))

--- a/source/develop/release-management/features/integration/allinone.md
+++ b/source/develop/release-management/features/integration/allinone.md
@@ -11,8 +11,6 @@ feature_status: Released
 
 ## Notes
 
-For general instructions on how to install and setup oVirt, please refer to the [Quick Start Guide](/documentation/quickstart/quickstart-guide/).
-
 This feature is deprecated in 3.6 and it will be dropped in the next release, 4.0.
 
 An alternative, supported since 3.4 and the only one to be in 4.0, is to use a [Self Hosted Engine](/develop/release-management/features/engine/self-hosted-engine/). See also its [Howto](/documentation/how-to/hosted-engine/) page.

--- a/source/develop/release-management/features/storage/importstoragedomain.md
+++ b/source/develop/release-management/features/storage/importstoragedomain.md
@@ -99,7 +99,7 @@ As long as the setup contains 3.5v Data Centers, the Import Storage Domain featu
 
 This is an example of how to recover a setup if it encountered a disaster.
 
-1. Create a new engine setup with new Data Base (see [Quick_Start_Guide#Install_oVirt](/documentation/quickstart/quickstart-guide/#install-ovirt))
+1. Create a new engine setup with new Data Base
 2. Create a new Data Center version 3.5 with cluster and add a Host to this cluster. (Recommended to reboot the Host)
 3. Once the Host is UP and running, add and activate a new empty Storage Domain to initialize the Data Center.
 4. If there were VMs/Templates which ran in the old setup on different compatible versions, or different CPU types, then those type of clusters should be created on the new Data Center.

--- a/source/develop/release-management/releases/3.3.1/index.md
+++ b/source/develop/release-management/releases/3.3.1/index.md
@@ -17,7 +17,6 @@ To find out more about features which were added in previous oVirt releases, che
 
 ### Fedora / CentOS / RHEL
 
-If you're installing oVirt 3.3.1 on a clean host you should read our [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
 
 If you're upgrading from oVirt 3.3 you should just execute:
 

--- a/source/develop/release-management/releases/3.3.2/index.md
+++ b/source/develop/release-management/releases/3.3.2/index.md
@@ -17,7 +17,6 @@ To find out more about features which were added in previous oVirt releases, che
 
 ### Fedora / CentOS / RHEL
 
-If you're installing oVirt 3.3.2 on a clean host you should read our [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
 
 **IMPORTANT NOTE:** If you're upgrading from a previous version please update ovirt-release to latest version (10) and ensure you've **ovirt-3.3.2** and **ovirt-stable** repository enabled.
 

--- a/source/develop/release-management/releases/3.3.3/index.md
+++ b/source/develop/release-management/releases/3.3.3/index.md
@@ -19,7 +19,6 @@ For a general overview of oVirt, read [the oVirt 3.0 feature guide](/develop/rel
 
 ### Fedora / CentOS / RHEL
 
-If you're installing oVirt 3.3.3 on a clean host you should read our [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
 
 **IMPORTANT NOTE:** If you're upgrading from a previous version please update ovirt-release to latest version (10) and ensure you've **ovirt-3.3.3** and **ovirt-stable** repository enabled.
 

--- a/source/develop/release-management/releases/3.3.4/index.md
+++ b/source/develop/release-management/releases/3.3.4/index.md
@@ -17,7 +17,6 @@ To find out more about features which were added in previous oVirt releases, che
 
 ### Fedora / CentOS / RHEL
 
-If you're installing oVirt 3.3.4 on a clean host you should read our [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
 
 If you're upgrading from oVirt 3.3 you should just execute:
 

--- a/source/develop/release-management/releases/3.3.5/index.md
+++ b/source/develop/release-management/releases/3.3.5/index.md
@@ -28,8 +28,6 @@ Since oVirt 3.4.0 has been released, in order to install 3.3.5 instead of 3.4.0 
 
 ### Fedora / CentOS / RHEL
 
-If you're installing oVirt 3.3.5 on a clean host you should read our [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-
 If you're upgrading from oVirt 3.3 you should just execute:
 
       # yum update ovirt-engine-setup

--- a/source/develop/release-management/releases/3.4.1/index.md
+++ b/source/develop/release-management/releases/3.4.1/index.md
@@ -21,7 +21,6 @@ In order to install it on a clean system, you need to install
 
 `# yum localinstall `[`http://resources.ovirt.org/pub/yum-repo/ovirt-release34.rpm`](http://resources.ovirt.org/pub/yum-repo/ovirt-release34.rpm)
 
-You should read then our [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
 
 If you're upgrading from a previous version you should have ovirt-release package already installed on your system.
 

--- a/source/develop/release-management/releases/3.4.2/index.md
+++ b/source/develop/release-management/releases/3.4.2/index.md
@@ -21,7 +21,6 @@ In order to install it on a clean system, you need to install
 
 `# yum localinstall `[`http://resources.ovirt.org/pub/yum-repo/ovirt-release34.rpm`](http://resources.ovirt.org/pub/yum-repo/ovirt-release34.rpm)
 
-You should read then our [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
 
 If you're upgrading from a previous version you should have ovirt-release package already installed on your system.
 

--- a/source/develop/release-management/releases/3.4.3/index.md
+++ b/source/develop/release-management/releases/3.4.3/index.md
@@ -21,7 +21,6 @@ In order to install it on a clean system, you need to install
 
 `# yum localinstall `[`http://resources.ovirt.org/pub/yum-repo/ovirt-release34.rpm`](http://resources.ovirt.org/pub/yum-repo/ovirt-release34.rpm)
 
-You should read then our [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
 
 If you're upgrading from a previous version you should have ovirt-release package already installed on your system.
 

--- a/source/develop/release-management/releases/3.4.4/index.md
+++ b/source/develop/release-management/releases/3.4.4/index.md
@@ -21,8 +21,6 @@ In order to install it on a clean system, you need to install
 
 `# yum localinstall `[`http://resources.ovirt.org/pub/yum-repo/ovirt-release34.rpm`](http://resources.ovirt.org/pub/yum-repo/ovirt-release34.rpm)
 
-You should read then our [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-
 If you're upgrading from a previous version you should have ovirt-release package already installed on your system.
 
 You can then install ovirt-release34.rpm as in a clean install side-by-side.

--- a/source/develop/release-management/releases/3.4/index.md
+++ b/source/develop/release-management/releases/3.4/index.md
@@ -140,8 +140,6 @@ If you're updating from a pre release version and you want to have rollback supp
 
 ## Fedora / CentOS / RHEL
 
-If you're installing oVirt 3.4 on a clean host, you should read our [Quick Start Guide](/documentation/quickstart/quickstart-guide/).
-
 If you're using pre-release repo you'll need to run:
 
           # yum update "ovirt-engine-setup*"

--- a/source/develop/release-management/releases/3.5.1/index.md
+++ b/source/develop/release-management/releases/3.5.1/index.md
@@ -11,7 +11,7 @@ The oVirt Project is pleased to announce the availability of oVirt 3.5.1 release
 
 oVirt is an open source alternative to VMware vSphere, and provides an awesome KVM management interface for multi-node virtualization. This release is available now for Fedora 20, Red Hat Enterprise Linux 6.6, CentOS 6.6, (or similar) and Red Hat Enterprise Linux 7, CentOS 7 (or similar).
 
-To find out more about features which were added in previous oVirt releases, check out the [previous versions release notes](/develop/release-management/releases/). For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/) and the [about oVirt](/community/about.html) page.
+To find out more about features which were added in previous oVirt releases, check out the [previous versions release notes](/develop/release-management/releases/). 
 
 ## Install / Upgrade from previous versions
 
@@ -24,8 +24,6 @@ In order to install it on a clean system, you need to install
 If you are upgrading from a previous version, you may have the ovirt-release34 package already installed on your system. You can then install ovirt-release35.rpm as in a clean install side-by-side.
 
 Once ovirt-release35 package is installed, you will have the ovirt-3.5-stable repository and any other repository needed for satisfying dependencies enabled by default.
-
-If you're installing oVirt 3.5.1 on a clean host, you should read our [Quick Start Guide](/documentation/quickstart/quickstart-guide/).
 
 If you are upgrading from oVirt < 3.4.1, you must first upgrade to oVirt 3.4.1 or later. Please see [oVirt 3.4.1 release notes](/develop/release-management/releases/3.4.1/) for upgrade instructions.
 

--- a/source/develop/release-management/releases/3.5.2/index.md
+++ b/source/develop/release-management/releases/3.5.2/index.md
@@ -11,7 +11,7 @@ The oVirt Project is pleased to announce the availability of oVirt 3.5.2 release
 
 oVirt is an open source alternative to VMware vSphere, and provides an awesome KVM management interface for multi-node virtualization. This release is available now for Fedora 20, Red Hat Enterprise Linux 6.6, CentOS 6.6, (or similar) and Red Hat Enterprise Linux 7.1, CentOS 7.1 (or similar).
 
-To find out more about features which were added in previous oVirt releases, check out the [previous versions release notes](/develop/release-management/releases/). For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/) and the [about oVirt](/community/about.html) page.
+To find out more about features which were added in previous oVirt releases, check out the [previous versions release notes](/develop/release-management/releases/). 
 
 ## Install / Upgrade from previous versions
 
@@ -26,8 +26,6 @@ In order to install it on a clean system, you need to install
 If you are upgrading from a previous version, you may have the ovirt-release34 package already installed on your system. You can then install ovirt-release35.rpm as in a clean install side-by-side.
 
 Once ovirt-release35 package is installed, you will have the ovirt-3.5-stable repository and any other repository needed for satisfying dependencies enabled by default.
-
-If you're installing oVirt 3.5.2 on a clean host, you should read our [Quick Start Guide](/documentation/quickstart/quickstart-guide/).
 
 If you are upgrading from oVirt < 3.4.1, you must first upgrade to oVirt 3.4.1 or later. Please see [oVirt 3.4.1 release notes](/develop/release-management/releases/3.4.1/) for upgrade instructions.
 

--- a/source/develop/release-management/releases/3.5.3/index.md
+++ b/source/develop/release-management/releases/3.5.3/index.md
@@ -11,7 +11,7 @@ The oVirt Project is pleased to announce the availability of oVirt 3.5.3 release
 
 oVirt is an open source alternative to VMware vSphere, and provides an awesome KVM management interface for multi-node virtualization. This release is available now for Fedora 20, Red Hat Enterprise Linux 6.6, CentOS Linux 6.6, (or similar) and Red Hat Enterprise Linux 7.1, CentOS Linux 7.1 (or similar).
 
-To find out more about features which were added in previous oVirt releases, check out the [previous versions release notes](/develop/release-management/releases/). For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/) and the [about oVirt](/community/about.html) page.
+To find out more about features which were added in previous oVirt releases, check out the [previous versions release notes](/develop/release-management/releases/). 
 
 ## Install / Upgrade from previous versions
 
@@ -24,8 +24,6 @@ In order to install it on a clean system, you need to install
 If you are upgrading from a previous version, you may have the ovirt-release34 package already installed on your system. You can then install ovirt-release35.rpm as in a clean install side-by-side.
 
 Once ovirt-release35 package is installed, you will have the ovirt-3.5-stable repository and any other repository needed for satisfying dependencies enabled by default.
-
-If you're installing oVirt 3.5.3 on a clean host, you should read our [Quick Start Guide](/documentation/quickstart/quickstart-guide/).
 
 If you are upgrading from oVirt < 3.4.1, you must first upgrade to oVirt 3.4.1 or later. Please see [oVirt 3.4.1 release notes](/develop/release-management/releases/3.4.1/) for upgrade instructions.
 

--- a/source/develop/release-management/releases/3.5.4/index.md
+++ b/source/develop/release-management/releases/3.5.4/index.md
@@ -11,7 +11,7 @@ The oVirt Project is pleased to announce the availability of oVirt 3.5.4 release
 
 oVirt is an open source alternative to VMware vSphere, and provides an awesome KVM management interface for multi-node virtualization. This release is available now for Fedora 20, Red Hat Enterprise Linux 6.7, CentOS Linux 6.7, (or similar) and Red Hat Enterprise Linux 7.1, CentOS Linux 7.1 (or similar).
 
-To find out more about features which were added in previous oVirt releases, check out the [previous versions release notes](/develop/release-management/releases/). For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/) and the [about oVirt](/community/about.html) page.
+To find out more about features which were added in previous oVirt releases, check out the [previous versions release notes](/develop/release-management/releases/). 
 
 ## Install / Upgrade from previous versions
 
@@ -22,8 +22,6 @@ In order to install it on a clean system, you need to install
 If you are upgrading from a previous version, you may have the ovirt-release34 package already installed on your system. You can then install ovirt-release35.rpm as in a clean install side-by-side.
 
 Once ovirt-release35 package is installed, you will have the ovirt-3.5-stable repository and any other repository needed for satisfying dependencies enabled by default.
-
-If you're installing oVirt 3.5.4 on a clean host, you should read our [Quick Start Guide](/documentation/quickstart/quickstart-guide/).
 
 If you are upgrading from oVirt < 3.4.1, you must first upgrade to oVirt 3.4.1 or later. Please see [oVirt 3.4.1 release notes](/develop/release-management/releases/3.4.1/) for upgrade instructions.
 

--- a/source/develop/release-management/releases/3.5.5/index.md
+++ b/source/develop/release-management/releases/3.5.5/index.md
@@ -11,7 +11,7 @@ The oVirt Project is pleased to announce the availability of oVirt 3.5.5 release
 
 oVirt is an open source alternative to VMware vSphere, and provides an awesome KVM management interface for multi-node virtualization. This release is available now for Red Hat Enterprise Linux 6.7, CentOS Linux 6.7 (or similar) and Red Hat Enterprise Linux 7.1, CentOS Linux 7.1 (or similar).
 
-To find out more about features which were added in previous oVirt releases, check out the [previous versions release notes](/develop/release-management/releases/). For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/) and the [about oVirt](/community/about.html) page.
+To find out more about features which were added in previous oVirt releases, check out the [previous versions release notes](/develop/release-management/releases/). 
 
 ## Install / Upgrade from previous versions
 
@@ -24,8 +24,6 @@ In order to install oVirt 3.5.5 Release on a clean system, you need to install
 If you are upgrading from a previous version, you may have the ovirt-release34 package already installed on your system. You can then install ovirt-release35.rpm as in a clean install side-by-side.
 
 Once ovirt-release35 package is installed, you will have the ovirt-3.5-stable repository and any other repository needed for satisfying dependencies enabled by default.
-
-If you're installing oVirt 3.5.5 on a clean host, you should read our [Quick Start Guide](/documentation/quickstart/quickstart-guide/).
 
 If you are upgrading from oVirt < 3.4.1, you must first upgrade to oVirt 3.4.1 or later. Please see [oVirt 3.4.1 release notes](/develop/release-management/releases/3.4.1/) for upgrade instructions.
 

--- a/source/develop/release-management/releases/3.5.6/index.md
+++ b/source/develop/release-management/releases/3.5.6/index.md
@@ -11,7 +11,7 @@ The oVirt Project is pleased to announce the availability of oVirt 3.5.6 release
 
 oVirt is an open source alternative to VMware vSphere, and provides an awesome KVM management interface for multi-node virtualization. This release is available now for Red Hat Enterprise Linux 6.7, CentOS Linux 6.7 (or similar) and Red Hat Enterprise Linux 7.1, CentOS Linux 7.1 (or similar).
 
-To find out more about features which were added in previous oVirt releases, check out the [previous versions release notes](/develop/release-management/releases/). For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/) and the [about oVirt](/community/about.html) page.
+To find out more about features which were added in previous oVirt releases, check out the [previous versions release notes](/develop/release-management/releases/). 
 
 ## Install / Upgrade from previous versions
 
@@ -24,8 +24,6 @@ In order to install it on a clean system, you need to install
 If you are upgrading from a previous version, you may have the ovirt-release34 package already installed on your system. You can then install ovirt-release35.rpm as in a clean install side-by-side.
 
 Once ovirt-release35 package is installed, you will have the ovirt-3.5-stable repository and any other repository needed for satisfying dependencies enabled by default.
-
-If you're installing oVirt 3.5.6 on a clean host, you should read our [Quick Start Guide](/documentation/quickstart/quickstart-guide/).
 
 If you are upgrading from oVirt < 3.4.1, you must first upgrade to oVirt 3.4.1 or later. Please see [oVirt 3.4.1 release notes](/develop/release-management/releases/3.4.1/) for upgrade instructions.
 

--- a/source/develop/release-management/releases/3.5/index.md
+++ b/source/develop/release-management/releases/3.5/index.md
@@ -71,8 +71,6 @@ If you are upgrading from oVirt < 3.4.1, you must first upgrade to oVirt 3.4.1 o
 
 Once ovirt-release35 package is installed, you will have the ovirt-3.5-stable repository and any other repository needed for satisfying dependencies enabled by default.
 
-If you're installing oVirt 3.5 on a clean host, you should read our [Quick Start Guide](/documentation/quickstart/quickstart-guide/).
-
 If you're using pre-release repo you'll need to re-enable pre release repository:
 
       [ovirt-3.5-pre]

--- a/source/develop/release-management/releases/3.6/index.md
+++ b/source/develop/release-management/releases/3.6/index.md
@@ -12,7 +12,7 @@ The oVirt Project is pleased to announce the availability of oVirt 3.6.0 Release
 
 oVirt is an open source alternative to VMware vSphere, and provides an awesome KVM management interface for multi-node virtualization. This release is available now for Fedora 22, Red Hat Enterprise Linux 6.7, CentOS Linux 6.7, (or similar) and Red Hat Enterprise Linux 7.1, CentOS Linux 7.1 (or similar).
 
-To find out more about features which were added in previous oVirt releases, check out the [previous versions release notes](/develop/release-management/releases/). For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/) and the [about oVirt](/community/about.html) page.
+To find out more about features which were added in previous oVirt releases, check out the [previous versions release notes](/develop/release-management/releases/). 
 
 ## Experimental Docker Integration
 
@@ -126,8 +126,6 @@ In order to install it on a clean system, you need to run (see also [Known Issue
 If you are upgrading from a previous version, you may have the ovirt-release35 package already installed on your system. You can then install ovirt-release36.rpm as in a clean install side-by-side.
 
 Once ovirt-release36 package is installed, you will have the ovirt-3.6 repository and any other repository needed for satisfying dependencies enabled by default.
-
-If you're installing this release on a clean host, you should read our [Quick Start Guide](/documentation/quickstart/quickstart-guide/).
 
 If you are upgrading from oVirt < 3.5.0, you must first upgrade to oVirt 3.5.0 or later. Please see [oVirt 3.5.5 Release Notes](/develop/release-management/releases/3.5.5/) for upgrade instructions.
 

--- a/source/release/3.6.1/index.md
+++ b/source/release/3.6.1/index.md
@@ -11,7 +11,7 @@ The oVirt Project is pleased to announce the availability of oVirt 3.6.1 release
 
 oVirt is an open source alternative to VMware vSphere, and provides an awesome KVM management interface for multi-node virtualization. This release is available now for Red Hat Enterprise Linux 6.7, CentOS Linux 6.7 (or similar) and Red Hat Enterprise Linux 7.2, CentOS Linux 7.2 (or similar).
 
-To find out more about features which were added in previous oVirt releases, check out the [previous versions release notes](/develop/release-management/releases/). For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/) and the [about oVirt](/community/about.html) page.
+To find out more about features which were added in previous oVirt releases, check out the [previous versions release notes](/develop/release-management/releases/). 
 
 ## Install / Upgrade from previous versions
 
@@ -24,8 +24,6 @@ In order to install it on a clean system, you need to install
 If you are upgrading from a previous version, you may have the ovirt-release35 package already installed on your system. You can then install ovirt-release36.rpm as in a clean install side-by-side.
 
 Once ovirt-release36 package is installed, you will have the ovirt-3.6 stable repository and any other repository needed for satisfying dependencies enabled by default.
-
-If you're installing oVirt 3.6.1 on a clean host, you should read our [Quick Start Guide](/documentation/quickstart/quickstart-guide/).
 
 If you are upgrading from oVirt < 3.5.0, you must first upgrade to oVirt 3.5.0 or later. Please see [oVirt 3.5.6 Release Notes](/develop/release-management/releases/3.5.6/) for upgrade instructions.
 

--- a/source/release/3.6.2/index.md
+++ b/source/release/3.6.2/index.md
@@ -11,7 +11,7 @@ The oVirt Project is pleased to announce the availability of oVirt 3.6.2 release
 
 oVirt is an open source alternative to VMware vSphere, and provides an awesome KVM management interface for multi-node virtualization. This release is available now for Red Hat Enterprise Linux 6.7, CentOS Linux 6.7 (or similar) and Red Hat Enterprise Linux 7.2, CentOS Linux 7.2 (or similar).
 
-To find out more about features which were added in previous oVirt releases, check out the [previous versions release notes](/develop/release-management/releases/). For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/) and the [about oVirt](/community/about.html) page.
+To find out more about features which were added in previous oVirt releases, check out the [previous versions release notes](/develop/release-management/releases/).
 
 ## Install / Upgrade from previous versions
 
@@ -24,8 +24,6 @@ In order to install it on a clean system, you need to install
 If you are upgrading from a previous version, you may have the ovirt-release35 package already installed on your system. You can then install ovirt-release36.rpm as in a clean install side-by-side.
 
 Once ovirt-release36 package is installed, you will have the ovirt-3.6-stable repository and any other repository needed for satisfying dependencies enabled by default.
-
-If you're installing oVirt 3.6.2 on a clean host, you should read our [Quick Start Guide](/documentation/quickstart/quickstart-guide/).
 
 If you are upgrading from oVirt < 3.5.0, you must first upgrade to oVirt 3.5.0 or later. Please see [oVirt 3.5.6 Release Notes](/develop/release-management/releases/3.5.6/) for upgrade instructions.
 

--- a/source/release/3.6.3/index.md
+++ b/source/release/3.6.3/index.md
@@ -14,8 +14,6 @@ oVirt is an open source alternative to VMware vSphere, and provides an awesome K
 
 To find out more about features which were added in previous oVirt releases,
 check out the [previous versions release notes](/develop/release-management/releases/).
-For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and the [about oVirt](/community/about.html) page.
 
 ## Install / Upgrade from previous versions
 
@@ -28,9 +26,6 @@ In order to install it on a clean system, you need to install
 If you are upgrading from a previous version, you may have the ovirt-release35 package already installed on your system. You can then install ovirt-release36.rpm as in a clean install side-by-side.
 
 Once ovirt-release36 package is installed, you will have the ovirt-3.6-stable repository and any other repository needed for satisfying dependencies enabled by default.
-
-If you're installing oVirt 3.6.3 on a clean host, you should read our
-[Quick Start Guide](/documentation/quickstart/quickstart-guide/).
 
 If you are upgrading from oVirt < 3.5.0, you must first upgrade to oVirt 3.5.0 or later. Please see [oVirt 3.5.6 Release Notes](/develop/release-management/releases/3.5.6/) for upgrade instructions.
 

--- a/source/release/3.6.4/index.md
+++ b/source/release/3.6.4/index.md
@@ -13,8 +13,6 @@ oVirt is an open source alternative to VMware vSphere, and provides an awesome K
 
 To find out more about features which were added in previous oVirt releases,
 check out the [previous versions release notes](/develop/release-management/releases/).
-For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and the [about oVirt](/community/about.html) page.
 
 ## Install / Upgrade from previous versions
 
@@ -27,9 +25,6 @@ In order to install it on a clean system, you need to install
 If you are upgrading from a previous version, you may have the ovirt-release35 package already installed on your system. You can then install ovirt-release36.rpm as in a clean install side-by-side.
 
 Once ovirt-release36 package is installed, you will have the ovirt-3.6 stable repository and any other repository needed for satisfying dependencies enabled by default.
-
-If you're installing oVirt 3.6.4 on a clean host, you should read our
-[Quick Start Guide](/documentation/quickstart/quickstart-guide/).
 
 If you are upgrading from oVirt < 3.5.0, you must first upgrade to oVirt 3.5.6. Please see [oVirt 3.5.6 Release Notes](/develop/release-management/releases/3.5.6/) for upgrade instructions.
 

--- a/source/release/3.6.5/index.md
+++ b/source/release/3.6.5/index.md
@@ -13,8 +13,6 @@ oVirt is an open source alternative to VMware vSphere, and provides an awesome K
 
 To find out more about features which were added in previous oVirt releases,
 check out the [previous versions release notes](/develop/release-management/releases/).
-For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and the [about oVirt](/community/about.html) page.
 
 ## Install / Upgrade from previous versions
 
@@ -27,9 +25,6 @@ In order to install it on a clean system, you need to install
 If you are upgrading from a previous version, you may have the ovirt-release35 package already installed on your system. You can then install ovirt-release36.rpm as in a clean install side-by-side.
 
 Once ovirt-release36 package is installed, you will have the ovirt-3.6-stable repository and any other repository needed for satisfying dependencies enabled by default.
-
-If you're installing oVirt 3.6.5 on a clean host, you should read our
-[Quick Start Guide](/documentation/quickstart/quickstart-guide/).
 
 If you are upgrading from oVirt < 3.5.0, you must first upgrade to oVirt 3.5.0 or later. Please see [oVirt 3.5.6 Release Notes](/develop/release-management/releases/3.5.6/) for upgrade instructions.
 

--- a/source/release/3.6.6/index.md
+++ b/source/release/3.6.6/index.md
@@ -13,8 +13,6 @@ oVirt is an open source alternative to VMware vSphere, and provides an awesome K
 
 To find out more about features which were added in previous oVirt releases,
 check out the [previous versions release notes](/develop/release-management/releases/).
-For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and the [about oVirt](/community/about.html) page.
 
 ## Install / Upgrade from previous versions
 
@@ -27,9 +25,6 @@ In order to install it on a clean system, you need to install
 If you are upgrading from a previous version, you may have the ovirt-release35 package already installed on your system. You can then install ovirt-release36.rpm as in a clean install side-by-side.
 
 Once ovirt-release36 package is installed, you will have the ovirt-3.6-stable repository and any other repository needed for satisfying dependencies enabled by default.
-
-If you're installing oVirt 3.6.6 on a clean host, you should read our
-[Quick Start Guide](/documentation/quickstart/quickstart-guide/).
 
 If you are upgrading from oVirt < 3.5.0, you must first upgrade to oVirt 3.5.0 or later. Please see [oVirt 3.5.6 Release Notes](/develop/release-management/releases/3.5.6/) for upgrade instructions.
 

--- a/source/release/3.6.7/index.md
+++ b/source/release/3.6.7/index.md
@@ -14,8 +14,6 @@ This release supports Hypervisor Hosts running Red Hat Enterprise Linux 7.2, Cen
 
 To find out more about features which were added in previous oVirt releases,
 check out the [previous versions release notes](/develop/release-management/releases/).
-For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and the [about oVirt](/community/about.html) page.
 
 ## Install / Upgrade from previous versions
 
@@ -28,8 +26,6 @@ In order to install it on a clean system, you need to install
 If you are upgrading from a previous version, you may have the ovirt-release35 package already installed on your system. You can then install ovirt-release36.rpm as in a clean install side-by-side.
 
 Once ovirt-release36 package is installed, you will have the ovirt-3.6-stable repository and any other repository needed for satisfying dependencies enabled by default.
-
-If you're installing oVirt 3.6.7 on a clean host, you should read our [Quick Start Guide](/documentation/quickstart/quickstart-guide/).
 
 If you are upgrading from oVirt < 3.5.0, you must first upgrade to oVirt 3.5.0 or later. Please see [oVirt 3.5.6 Release Notes](/develop/release-management/releases/3.5.6/) for upgrade instructions.
 

--- a/source/release/4.0.0/index.md
+++ b/source/release/4.0.0/index.md
@@ -13,8 +13,6 @@ oVirt is an open source alternative to VMware™ vSphere™, and provides an awe
 
 To find out more about features which were added in previous oVirt releases,
 check out the [previous versions release notes](/develop/release-management/releases/).
-For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and the [about oVirt](/community/about.html) page.
 
 ## Install / Upgrade from previous versions
 
@@ -23,8 +21,6 @@ and the [about oVirt](/community/about.html) page.
 In order to install it on a clean system, you need to install
 
 `# yum install `[`http://resources.ovirt.org/pub/yum-repo/ovirt-release40.rpm`](http://resources.ovirt.org/pub/yum-repo/ovirt-release40.rpm)
-
-and then follow our [Quick Start Guide](/documentation/quickstart/quickstart-guide/).
 
 If you're upgrading from a previous release on Enterprise Linux 7 you just need to execute:
 

--- a/source/release/4.0.1/index.md
+++ b/source/release/4.0.1/index.md
@@ -13,8 +13,6 @@ oVirt is an open source alternative to VMware™ vSphere™, and provides an awe
 
 To find out more about features which were added in previous oVirt releases,
 check out the [previous versions release notes](/develop/release-management/releases/).
-For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and the [about oVirt](/community/about.html) page.
 
 ## Install / Upgrade from previous versions
 
@@ -23,8 +21,6 @@ and the [about oVirt](/community/about.html) page.
 In order to install it on a clean system, you need to install
 
 `# yum install `[`http://resources.ovirt.org/pub/yum-repo/ovirt-release40.rpm`](http://resources.ovirt.org/pub/yum-repo/ovirt-release40.rpm)
-
-and then follow our [Quick Start Guide](/documentation/quickstart/quickstart-guide/).
 
 If you're upgrading from a previous release on Enterprise Linux 7 you just need to execute:
 

--- a/source/release/4.0.2/index.md
+++ b/source/release/4.0.2/index.md
@@ -14,8 +14,6 @@ oVirt is an open source alternative to VMware™ vSphere™, and provides an awe
 
 To find out more about features which were added in previous oVirt releases,
 check out the [previous versions release notes](/develop/release-management/releases/).
-For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and the [about oVirt](/community/about.html) page.
 
 ## Install / Upgrade from previous versions
 
@@ -24,8 +22,6 @@ and the [about oVirt](/community/about.html) page.
 In order to install it on a clean system, you need to install
 
 `# yum install `[`http://resources.ovirt.org/pub/yum-repo/ovirt-release40.rpm`](http://resources.ovirt.org/pub/yum-repo/ovirt-release40.rpm)
-
-and then follow our [Quick Start Guide](/documentation/quickstart/quickstart-guide/).
 
 If you're upgrading from a previous release on Enterprise Linux 7 you just need to execute:
 

--- a/source/release/4.0.3/index.md
+++ b/source/release/4.0.3/index.md
@@ -16,8 +16,6 @@ This release is available now for Red Hat Enterprise Linux 7.2, CentOS Linux 7.2
 
 To find out more about features which were added in previous oVirt releases,
 check out the [previous versions release notes](/develop/release-management/releases/).
-For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and the [about oVirt](/community/about.html) page.
 
 An updated documentation has been provided by our downstream 
 [Red Hat Virtualization](https://access.redhat.com/documentation/en/red-hat-virtualization?version=4.0/)
@@ -61,8 +59,7 @@ In order to install it on a clean system, you need to install
 
 `# yum install `[`http://resources.ovirt.org/pub/yum-repo/ovirt-release40.rpm`](http://resources.ovirt.org/pub/yum-repo/ovirt-release40.rpm)
 
-and then follow our [Quick Start Guide](/documentation/quickstart/quickstart-guide/) or
-a more updated documentation from our downstream
+and then follow documentation from our downstream
 [Red Hat Virtualization](https://access.redhat.com/documentation/en/red-hat-virtualization/4.0/)
 
 If you're upgrading from a previous release on Enterprise Linux 7 you just need to execute:

--- a/source/release/4.0.4/index.md
+++ b/source/release/4.0.4/index.md
@@ -16,8 +16,6 @@ This release is available now for Red Hat Enterprise Linux 7.2, CentOS Linux 7.2
 
 To find out more about features which were added in previous oVirt releases,
 check out the [previous versions release notes](/develop/release-management/releases/).
-For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and the [about oVirt](/community/about.html) page.
 
 An updated documentation has been provided by our downstream 
 [Red Hat Virtualization](https://access.redhat.com/documentation/en/red-hat-virtualization?version=4.0/)
@@ -61,8 +59,7 @@ In order to install it on a clean system, you need to install
 
 `# yum install `[`http://resources.ovirt.org/pub/yum-repo/ovirt-release40.rpm`](http://resources.ovirt.org/pub/yum-repo/ovirt-release40.rpm)
 
-and then follow our [Quick Start Guide](/documentation/quickstart/quickstart-guide/) or
-a more updated documentation from our downstream
+and then follow documentation from our downstream
 [Red Hat Virtualization](https://access.redhat.com/documentation/en/red-hat-virtualization/4.0/)
 
 If you're upgrading from a previous release on Enterprise Linux 7 you just need to execute:

--- a/source/release/4.0.5/index.md
+++ b/source/release/4.0.5/index.md
@@ -16,8 +16,6 @@ This release is available now for Red Hat Enterprise Linux 7.2, CentOS Linux 7.2
 
 To find out more about features which were added in previous oVirt releases,
 check out the [previous versions release notes](/develop/release-management/releases/).
-For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and the [about oVirt](/community/about.html) page.
 
 An updated documentation has been provided by our downstream 
 [Red Hat Virtualization](https://access.redhat.com/documentation/en/red-hat-virtualization?version=4.0/)
@@ -61,8 +59,7 @@ In order to install it on a clean system, you need to install
 
 `# yum install `[`http://resources.ovirt.org/pub/yum-repo/ovirt-release40.rpm`](http://resources.ovirt.org/pub/yum-repo/ovirt-release40.rpm)
 
-and then follow our [Quick Start Guide](/documentation/quickstart/quickstart-guide/) or
-a more updated documentation from our downstream
+and then follow documentation from our downstream
 [Red Hat Virtualization](https://access.redhat.com/documentation/en/red-hat-virtualization/4.0/)
 
 If you're upgrading from a previous release on Enterprise Linux 7 you just need to execute:

--- a/source/release/4.0.6/index.md
+++ b/source/release/4.0.6/index.md
@@ -20,8 +20,6 @@ This release is available now for Red Hat Enterprise Linux 7.2, CentOS Linux 7.2
 
 To find out more about features which were added in previous oVirt releases,
 check out the [previous versions release notes](/develop/release-management/releases/).
-For a general overview of oVirt, read [the Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and the [about oVirt](/community/about.html) page.
 
 An updated documentation has been provided by our downstream
 [Red Hat Virtualization](https://access.redhat.com/documentation/en/red-hat-virtualization?version=4.0/)
@@ -68,9 +66,7 @@ In order to install it on a clean system, you need to install
 `# yum install `[`http://resources.ovirt.org/pub/yum-repo/ovirt-release40.rpm`](http://resources.ovirt.org/pub/yum-repo/ovirt-release40.rpm)
 
 
-and then follow our
-[Quick Start Guide](/documentation/quickstart/quickstart-guide/) or a more updated documentation
-from our downstream
+and then follow documentation from our downstream
 [Red Hat Virtualization](https://access.redhat.com/documentation/en/red-hat-virtualization/4.0/)
 
 

--- a/source/release/4.1.1/index.md
+++ b/source/release/4.1.1/index.md
@@ -15,9 +15,6 @@ awesome KVM management interface for multi-node virtualization.
 This release is available now for Red Hat Enterprise Linux 7.3,
 CentOS Linux 7.3 (or similar).
 
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.1.1, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.1.2/index.md
+++ b/source/release/4.1.2/index.md
@@ -15,8 +15,6 @@ awesome KVM management interface for multi-node virtualization.
 This release is available now for Red Hat Enterprise Linux 7.3,
 CentOS Linux 7.3 (or similar).
 
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
 
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 

--- a/source/release/4.1.3/index.md
+++ b/source/release/4.1.3/index.md
@@ -18,9 +18,6 @@ Packages for Fedora 24 are also available as a Tech Preview.
 
 
 
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.1.3, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.1.4/index.md
+++ b/source/release/4.1.4/index.md
@@ -18,9 +18,6 @@ Packages for Fedora 24 are also available as a Tech Preview.
 
 
 
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.1.4, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.1.5/index.md
+++ b/source/release/4.1.5/index.md
@@ -16,10 +16,6 @@ CentOS Linux 7.3 (or similar).
 Packages for Fedora 24 are also available as a Tech Preview.
 
 
-
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.1.5, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.1.6/index.md
+++ b/source/release/4.1.6/index.md
@@ -17,9 +17,6 @@ CentOS Linux 7.4 (or similar).
 
 
 
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.1.6, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.1.7/index.md
+++ b/source/release/4.1.7/index.md
@@ -16,9 +16,6 @@ CentOS Linux 7.4 (or similar).
 
 
 
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.1.7, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.1.8/index.md
+++ b/source/release/4.1.8/index.md
@@ -16,9 +16,6 @@ CentOS Linux 7.4 (or similar).
 
 
 
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.1.8, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.1.9/index.md
+++ b/source/release/4.1.9/index.md
@@ -15,10 +15,6 @@ This release is available now for Red Hat Enterprise Linux 7.4,
 CentOS Linux 7.4 (or similar).
 
 
-
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.1.9, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.2.0/index.md
+++ b/source/release/4.2.0/index.md
@@ -17,9 +17,6 @@ CentOS Linux 7.4 (or similar).
 
 
 
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 ## What's New in 4.2.0?

--- a/source/release/4.2.1/index.md
+++ b/source/release/4.2.1/index.md
@@ -16,9 +16,6 @@ CentOS Linux 7.4 (or similar).
 
 
 
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.2.1, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.2.2/index.md
+++ b/source/release/4.2.2/index.md
@@ -15,9 +15,6 @@ CentOS Linux 7.4 (or similar).
 
 
 
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.2.2, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.2.3/index.md
+++ b/source/release/4.2.3/index.md
@@ -15,10 +15,6 @@ CentOS Linux 7.5 (or similar).
 
 
 
-
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.2.3, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.2.4/index.md
+++ b/source/release/4.2.4/index.md
@@ -14,10 +14,6 @@ This release is available now for Red Hat Enterprise Linux 7.5,
 CentOS Linux 7.5 (or similar).
 
 
-
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.2.4, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.2.5/index.md
+++ b/source/release/4.2.5/index.md
@@ -16,10 +16,6 @@ This release is available now for Red Hat Enterprise Linux 7.5,
 CentOS Linux 7.5 (or similar).
 
 
-
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.2.5, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.2.6/index.md
+++ b/source/release/4.2.6/index.md
@@ -19,9 +19,6 @@ CentOS Linux 7.5 (or similar).
 
 
 
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.2.6, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.2.7/index.md
+++ b/source/release/4.2.7/index.md
@@ -17,9 +17,6 @@ CentOS Linux 7.5 (or similar).
 
 
 
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.2.7, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.2.8/index.md
+++ b/source/release/4.2.8/index.md
@@ -17,9 +17,6 @@ CentOS Linux 7.6 (or similar).
 
 
 
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.2.8, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.3.0/index.md
+++ b/source/release/4.3.0/index.md
@@ -16,9 +16,6 @@ CentOS Linux 7.6 (or similar).
 
 
 
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.3.0, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.3.1/index.md
+++ b/source/release/4.3.1/index.md
@@ -15,10 +15,6 @@ This release is available now for Red Hat Enterprise Linux 7.6,
 CentOS Linux 7.6 (or similar).
 
 
-
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/community/about.html) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.3.1, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.3.2/index.md
+++ b/source/release/4.3.2/index.md
@@ -15,10 +15,6 @@ This release is available now for Red Hat Enterprise Linux 7.6,
 CentOS Linux 7.6 (or similar).
 
 
-
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/documentation/introduction/about-ovirt/) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.3.2, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.3.3/index.md
+++ b/source/release/4.3.3/index.md
@@ -16,9 +16,6 @@ CentOS Linux 7.6 (or similar).
 
 
 
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/documentation/introduction/about-ovirt/) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.3.3, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.3.4/index.md
+++ b/source/release/4.3.4/index.md
@@ -15,10 +15,6 @@ This release is available now for Red Hat Enterprise Linux 7.6,
 CentOS Linux 7.6 (or similar).
 
 
-
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/documentation/introduction/about-ovirt/) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.3.4, see the [release notes for previous versions](/documentation/#previous-release-notes).

--- a/source/release/4.3.5/index.md
+++ b/source/release/4.3.5/index.md
@@ -14,11 +14,6 @@ awesome KVM management interface for multi-node virtualization.
 This release is available now for Red Hat Enterprise Linux 7.6,
 CentOS Linux 7.6 (or similar).
 
-
-
-For a general overview of oVirt, read the [Quick Start Guide](/documentation/quickstart/quickstart-guide/)
-and visit the [About oVirt](/documentation/introduction/about-ovirt/) page.
-
 For detailed installation instructions, read the [Installation Guide](/documentation/install-guide/Installation_Guide/).
 
 To learn about features introduced before 4.3.5, see the [release notes for previous versions](/documentation/#previous-release-notes).


### PR DESCRIPTION
Changes proposed in this pull request:

- The quickstart-guide doesn't exist anymore. Dropped all references to that guide.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @lveyde
