### PR TITLE
Adjust z-indexes

### DIFF
--- a/source/_sass/lib/events.sass
+++ b/source/_sass/lib/events.sass
@@ -112,7 +112,7 @@
       position: absolute
       bottom: -2em
       left: 0
-      z-index: 500
+      z-index: 99
 
 @media screen and (min-width: 641px)
   #all-events .talk
@@ -137,7 +137,7 @@
       position: absolute
       bottom: 0
       left: 0
-      z-index: 500
+      z-index: 99
 
   abbr
     cursor: default

--- a/source/_sass/lib/site.sass
+++ b/source/_sass/lib/site.sass
@@ -181,7 +181,7 @@ header.masthead .navbar-collapse.in
     //background: white
     position: fixed
     top: 0
-    z-index: 100
+    z-index: 110
 
   .page
     margin-top: 12ex


### PR DESCRIPTION
Fixes issue #2077

Changes proposed in this pull request:

-  Reduced events z-indexes from 500 to 99 so they'll go under the top bar when scrolling (fixes #2077)

- Raised z-index of the top header to 110 since other elements have z-index 100 and we don't want them to overlap the header bar

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @duck-rh 
