### PR TITLE
upgrade-guide_he_4.4-beta Added Self-hosted engine section

### DIFF
--- a/source/documentation/upgrade_guide/index.adoc
+++ b/source/documentation/upgrade_guide/index.adoc
@@ -38,7 +38,7 @@ include::assembly-SHE_Upgrading_from_4-2_ff.adoc[leveloffset=+1]
 
 ////
 
-= Upgrading a Local Database Environment Manually
+= Upgrading a standalone {engine-name}, local database environment
 :local_database_upgrade:
 // include::assembly-Upgrading_from_4-0.adoc[leveloffset=+1]
 
@@ -54,12 +54,14 @@ include::assembly-Upgrading_from_4-3.adoc[leveloffset=+1]
 :remote_database_upgrade:
 include::assembly-Remote_Upgrading_from_4-2.adoc[leveloffset=+1]
 :remote_database_upgrade!:
-
+////
 = Upgrading a Self-hosted Engine Environment Manually
 :SHE_upgrade:
 include::assembly-SHE_Upgrading_from_4-2.adoc[leveloffset=+1]
+
+include::assembly-SHE_Upgrading_from_4-3.adoc[leveloffset=+1]
 :SHE_upgrade!:
-////
+
 
 :numbered!:
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Added section on upgrading self-hosted engine to ovirt 4.4 beta.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @stoobie 

This pull request needs review by: @sandrobonazzola 
