### PR TITLE
Unify incremental-backup.md and incremental-backup-guide.md

### DIFF
--- a/source/documentation/incremental-backup-guide/incremental-backup-guide.md
+++ b/source/documentation/incremental-backup-guide/incremental-backup-guide.md
@@ -33,16 +33,16 @@ Backups are simpler, faster and more robust, and integration with backup applica
 
 ## Creating a Virtual Machine With Incremental Backup Enabled
 
-For a backup application to be able to include a disk during incremental backups, you must enable incremental backup for that disk. When adding a disk, you should enable incremental backup for every disk. You can back up disks that are not enabled for incremental backup in the same way you did previously.
+For a backup application to be able to include a disk during incremental backups, you must enable incremental backup for that disk. When adding a disk, you should enable incremental backup for every disk. You can back up disks that are not enabled for incremental backup using full backup or in the same way you did previously.
 
 Because incremental backup requires disks to be formatted in QCOW2, use QCOW2 format instead of RAW format. For more information, see [Disk Format](#disk-format).
 
 ## Enabling Incremental Backup on an Existing Virtual Machine
 
-Because incremental backup is not supported for disks in RAW format, a QCOW2 format layer must exist on top of any RAW format disks in order to use incremental backup. Creating a snapshot generates a QCOW2 layer, so creating a snapshot enables incremental backup on all disks that are included in the snapshot, from the point at which the snapshot is created.
+Because incremental backup is not supported for disks in RAW format, a QCOW2 format layer must exist on top of any RAW format disks in order to use incremental backup. Creating a snapshot generates a QCOW2 layer, so creating a snapshot will allow to enable incremental backup on all disks that are included in the snapshot, from the point at which the snapshot is created.
 
 **WARNING**
-If the base layer of a disk uses RAW format, deleting the last snapshot and merging the top QCOW2 layer into the base layer converts the disk to RAW format, thereby disabling incremental backup. To re-enable incremental backup, you can create a new snapshot, including this disk.
+If the base layer of a disk uses RAW format, deleting the last snapshot and merging the top QCOW2 layer into the base layer converts the disk to RAW format, thereby disabling incremental backup if it was set. To re-enable incremental backup, you can create a new snapshot, including this disk.
 
 ## Disk Format
 
@@ -64,26 +64,28 @@ The following table shows how enabling incremental backup affects disk format:
 ## The Incremental Backup Flow
 
 1. The backup application uses the REST API to find virtual machine disks that should be included in the backup. Only disks that are enabled for incremental backup, using QCOW2 format, are included.
-1. The backup application starts a backup using the [VmBackup API]: http://ovirt.github.io/ovirt-engine-api-model/4.3/#services/vm_backup "VmBackup API", specifying a virtual machine ID, an optional previous backup ID, and a list of disks to back up. If you don't specify a previous backup ID, all data in the specified disks is included in the backup, based on the state of each disk when the backup begins.
-1. The engine prepares the virtual machine for backup. The virtual machine can continue running during the backup.
-1. The backup application polls the engine for the backup status, until the engine reports that the backup is ready to begin.
-1. When the backup is ready to begin, the backup application creates an image transfer for every disk included in the backup. For more information, see the [ImageTransfer API]: http://ovirt.github.io/ovirt-engine-api-model/4.3/#services/image_transfer "ImageTransfer API".
-1. The backup application gets a list of changed blocks from ovirt-imageio for every image transfer. If a change list is not available, the backup application gets an error.
-1. The backup application downloads changed blocks in RAW format from ovirt-imageio and stores them in the backup media. If a list of changed blocks is not available, the backup application can fall back to copying the entire disk.
-1. The backup application finalizes all image transfers.
-1. The backup application finalizes the backup using the REST API.
+2. The backup application starts a backup using the [VmBackup API]: http://ovirt.github.io/ovirt-engine-api-model/4.3/#services/vm_backup "VmBackup API", specifying a virtual machine ID, an optional previous checkpoint ID, and a list of disks to back up. If you don't specify a previous checkpoint ID, all data in the specified disks is included in the backup, based on the state of each disk when the backup begins (full backup).
+3. The engine prepares the virtual machine for backup. The virtual machine can continue running during the backup.
+4. The backup application polls the engine for the backup status, until the engine reports that the backup is ready to begin.
+5. When the backup is ready to begin, the backup application creates an image transfer for every disk included in the backup. For more information, see the [ImageTransfer API]: http://ovirt.github.io/ovirt-engine-api-model/4.3/#services/image_transfer "ImageTransfer API".
+6. The backup application gets a list of changed blocks from ovirt-imageio for every image transfer. If a change list is not available, the backup application gets an error.
+7. The backup application downloads changed blocks in RAW format from ovirt-imageio and stores them in the backup media. If a list of changed blocks is not available, the backup application can fall back to copying the entire disk.
+8. The backup application finalizes all image transfers.
+9. The backup application finalizes the backup using the REST API.
 
 ## The Incremental Restore Flow
 
-1. The user selects a restore point based on available backups using the backup application.
-1. The backup application creates a new disk or a snapshot with an existing disk to hold the restored data.
-1. The backup application starts an upload image transfer for every disk, specifying `format=raw`. This enables format conversion when uploading RAW data to a QCOW2 disk.
-1. The backup application transfers the data included in this restore point to imageio using the API.
-1. The backup application finalizes the image transfers.
+1. The user selects a restore point based on available backups using the backup application (not part of oVirt).
+2. The backup application creates a new disk or a snapshot with an existing disk to hold the restored data.
+3. The backup application starts an upload image transfer for every disk, specifying `format=raw`. This enables format conversion when uploading RAW data to a QCOW2 disk.
+4. The backup application transfers the data included in this restore point to imageio using the API.
+5. The backup application finalizes the image transfers.
 
-## Handling an Unclean Shutdown or Storage Outage During Shutdown
+### Checkpoint deletion
 
-If a virtual machine shuts down abnormally, bitmaps on the disk might be left in an invalid state. Creating an incremental backup using such bitmaps leads to corrupt virtual machine data after a restore. To recover from an invalid bitmap, you need to delete the invalid bitmap and all previous bitmaps, and the next backup needs to include the entire disk contents.
+1. Backup application finds the oldest checkpoint of a VM.
+
+2. Backup application remove the checkpoint
 
 ### Restoring snapshots
 
@@ -97,7 +99,7 @@ If a virtual machine is shut down abnormally, bitmaps on the disk might be left 
 To detect bitmap in invalid state we can use the in-use bit in the
 bitmap, but this info is not exposed to the management layer.
 
-To recover from an invalid bitmap, you need to delete the invalid bitmap and all previous bitmaps, and the next backup needs to include the entire disk contents.
+To recover from an invalid bitmap, you need to delete the invalid bitmap and all previous bitmaps, and the next backup needs to include the entire disk contents (full backup).
 
 ## Backup REST API
 
@@ -107,7 +109,7 @@ _Enable incremental backup for a virtual machine’s disk._
 For example, to enable incremental backup for a new disk on a virtual machine with id `123`, send a request like this:
 
 ````
-POST /vms/123/diskattachments
+PUT /vms/123/diskattachments
 ````
 
 With a request body like this:
@@ -143,7 +145,7 @@ The response is:
 #### Finding disks enabled for incremental backup
 
 ## list GET
-_For the specified virtual machine, list the disks that are enabled for incremental backup, filtered according to the `backup` property._
+For the specified virtual machine, list the disks that are enabled for incremental backup, filtered according to the `backup` property.
 
 For example, for a virtual machine with the id `123`, this request:
 
@@ -171,7 +173,7 @@ Gets this response:
 `backup`| ? | out | Required. Possible values: `incremental`, `none` |
 
 ### Start a full backup POST
-_For the specified virtual machine, start a full backup of the specified disk. The response includes a backup id and <to_checkpoint_id>, which is created on the disks. You can use this id as the start point in the subsequent incremental backup._
+Start full backup. The response phase indicates that the backup is `“initializing”`. You need to poll the backup until the phase is `“ready”`. Once the backup is ready the response will include `<to_checkpoint_id>` which should be used as the `<from_checkpoint_id>` in the next incremental backup.
 
 For example, to start a full backup of a disk with id 456 on a virtual machine with id 123, send a request like this:
 
@@ -194,7 +196,6 @@ The response includes backup 789 with <to_checkpoint_id> 999:
 
 ````
 <backup id="789">
-    <to_checkpoint_id>999</to_checkpoint_id>
     <disks>
         <disk id="456" />
         ...
@@ -212,7 +213,7 @@ The response includes backup 789 with <to_checkpoint_id> 999:
 
 
 ### Start an incremental backup POST
-_Start an incremental backup at the checkpoint defined by the property `<from_checkpoint_id>`, which is the previous checkpoint id. The response includes the object `<to_checkpoint_id>`` with a new checkpoint id, which you should use for `<from_checkpoint_id>` in the next incremental backup._
+Start incremental backup since checkpoint id `<from_checkpoint_uuid>`. The response phase indicates that the backup is `“initializing”`. You need to poll the backup until the phase is `“ready”`. Once the backup is ready the response will include `<to_checkpoint_id>` which should be used as the `<from_checkpoint_id>` in the next incremental backup.
 
 For example, to start an incremental backup of disk `222` on virtual machine `111`, send a request like this:
 
@@ -237,7 +238,6 @@ The response includes backup `789` with `<from_checkpoint_id>` `999` and  `<to_c
 ````
 <backup id="777">
     <from_checkpoint_id>999</from_checkpoint_id>
-    <to_checkpoint_id>666</to_checkpoint_id>
     <disks>
         <disk id="222" />
         ...
@@ -260,7 +260,7 @@ Gets the following information about a specific backup:
 * the phase of the backup
 * the date the backup was created
 
-When the value of `<phase>` is `ready`, you can start downloading the disks to back up the virtual machine storage.
+When the value of `<phase>` is `ready`,  the response will include `<to_checkpoint_id>` which should be used as the `<from_checkpoint_id>` in the next incremental backup and you can start downloading the disks to back up the virtual machine storage.
 
 For example, to get info about a backup with id `456` of a virtual machine with id `123`, send a request like this:
 
@@ -281,17 +281,25 @@ The response includes the backup with id `456`, with `<from_checkpoint_id>` `999
         ...
     </disks>
     <phase>ready</phase>
-    <creation_date>...
+    <creation_date>
 </vm_backup>
 ````
 
-### finalize POST
-To finalize a backup, use the finalize method of the image_transfer service. For more information, see [ImageTransfer]: http://ovirt.github.io/ovirt-engine-api-model/4.3/#services/image_transfer "finalize API".
+### finalizing backup POST
+To finalize a backup, use the finalize backup service method.
+
+For example, to finalize backup with id `456` of a virtual machine with id `123`, send a request like this:
+
+```
+POST /vms/123/backups/456/finalize
+
+<action></action>
+```
 
 
-### Creating an image transfer object for incremental backup POST
-When the backup is ready to begin, an *imagetransfer* object should be created.
-To correlate the transfer with the backup, `<backup>` property should be specified with the relevant  backup id.
+### Creating an image transfer object for downloading an incremental backup POST
+When the backup is ready to download, an *imagetransfer* object should be created.
+To correlate the transfer with the backup, `<backup>` property should be specified with the relevant backup id.
 The transfer `<format>` property should be `raw` (this indicates that NBD is used as the ImageTransfer backend).
 For information on creating an *imagetransfer* object, see the [`add` method for `ImageTransfers`]:http://ovirt.github.io/ovirt-engine-api-model/4.3/#services/image_transfers/methods/add "add method" in the REST API Guide.
 
@@ -334,6 +342,59 @@ When uploading into a snapshot, replace `<disk id="123"/>` with `<snapshot id="4
 When the transfer format is RAW and the underlying disk format is QCOW2, uploaded data is converted on the fly to QCOW2 format when writing to storage.
 Uploading data from a QCOW2 disk to a RAW disk is not supported.
 
+### Checkpoints REST API
+
+#### Get all created checkpoints for a VM GET
+
+To get all the created checkpoints of a VM :
+
+For example, to get all the created checkpoints of a virtual machine with id `123` send a request like this:
+
+```
+GET /vms/123/checkpoints/
+```
+
+The response includes all the virtual machine checkpoints, each checkpoint contains the checkpoint's `disks`, `<parent_id>`, `<creation_date>` and the virtual machine it belongs to `<vm>`:
+
+```
+<checkpoints>
+   <checkpoint id="456">
+      <link href="/ovirt-engine/api/vms/vm-uuid/checkpoints/456/disks" rel="disks"/>
+      <parent_id>parent-checkpoint-uuid</parent_id>
+      <creation_date>xxx</creation_date>
+      <vm href="/ovirt-engine/api/vms/123" id="123"/>
+   </checkpoint>
+</checkpoints>
+```
+
+#### Get a specific VM checkpoint GET
+
+For example, to get a specific checkpoint with id `456` of a virtual machine with id `123` send a request like this:
+
+```
+GET /vms/123/checkpoints/456/
+```
+
+Response:
+
+```
+<checkpoint id="456">
+  <link href="/ovirt-engine/api/vms/v123/checkpoints/456/disks" rel="disks"/>
+  <parent_id>parent-checkpoint-uuid</parent_id>
+  <creation_date>xxx</creation_date>
+  <vm href="/ovirt-engine/api/vms/123" id="123"/>
+</checkpoint>
+```
+
+#### Remove the root checkpoint of a specific virtual machine DELETE
+
+To remove a checkpoint of a virtual machine, the removed checkpoint should be the oldest checkpoint of the VM (root checkpoint).
+
+For example, to remove the root checkpoint with id `456` of a virtual machine with id `123` send a request like this::
+
+```
+DELETE /vms/123/checkpoints/456/
+```
 
 ## imageio backup API
 


### PR DESCRIPTION
The incremental-backup-guide.md is not up to date, unify the documentation
according to incremental-backup.md.

Also, fix some documentation errors is incremental-backup.md.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md):@shenitzky

This pull request needs review by: @nirs 