### PR TITLE
Docs: Use root user for hosted engine deployment via cockpit

### DIFF
--- a/source/documentation/common/install/proc-Deploying_the_Self-Hosted_Engine_Using_Cockpit.adoc
+++ b/source/documentation/common/install/proc-Deploying_the_Self-Hosted_Engine_Using_Cockpit.adoc
@@ -10,7 +10,7 @@ Deploy a self-hosted engine, using Cockpit to collect the details of your enviro
 
 .Procedure
 
-. Log in to Cockpit at `https://__HostIPorFQDN__:9090` and click menu:Virtualization[Hosted Engine].
+. Log in to Cockpit at `https://__HostIPorFQDN__:9090` using the root user and click menu:Virtualization[Hosted Engine].
 . Click btn:[Start] under the *Hosted Engine* option.
 . Enter the details for the {engine-name} virtual machine:
 .. Enter the *Engine VM FQDN*. This is the FQDN for the {engine-name} virtual machine, not the base host.


### PR DESCRIPTION
Minor change to the docs, I've been trying to setup the hosted engine with a user I created during ovirt-node install. That does not work and provides an error message that is not really helpful "Deployment failed" with an error about permission denied in /var/lib/ovirt-hosted-engine-setup/cockpit/

I was not the only one not getting that root needs to be used: https://lists.ovirt.org/archives/list/users@ovirt.org/message/G452P2BN7Z7SBIGX3V6PB2RKDZJ72KKI/

So here is an explicit mention that the root user is to be used for cockpit.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @Klaas- 

