### PR TITLE
features warning: add spaces around strong text

### DIFF
--- a/source/_includes/feature.haml
+++ b/source/_includes/feature.haml
@@ -3,16 +3,16 @@
   Feature pages are design documents that developers have created while collaborating on oVirt.
   %br
   %br
-  Most of them are 
+  Most of them are&nbsp;
   %strong
     outdated
   , but provide historical design context.
   %br
   %br
-  They are 
+  They are&nbsp;
   %strong
     not 
-  user documentation and should not be treated as such.
+  &nbsp;user documentation and should not be treated as such.
   %br
   %br
   %a(href="/documentation/")Documentation is available here.


### PR DESCRIPTION
Current spaces around strong text are ignored. Use &nbsp; to add space
around strong text in feature pages warning.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @vjuranek 

