### PR TITLE
Update chap-Deploying_Hyperconverged.md

### DIFF
--- a/source/documentation/gluster-hyperconverged/chap-Deploying_Hyperconverged.md
+++ b/source/documentation/gluster-hyperconverged/chap-Deploying_Hyperconverged.md
@@ -112,7 +112,7 @@ Brick configuration allows for per-host definition of bricks. This is useful in 
 
 ![Brick setup sub-tab](/images/gluster-hyperconverged/7-Bricks.png)
 
-**Prev:** [Chapter: Introduction](../chap-Introduction) <br>
-**Next:** [Chapter: Additional Steps](../chap-Additional_Steps)
+**Prev:** [Chapter: Introduction](chap-Introduction) <br>
+**Next:** [Chapter: Additional Steps](chap-Additional_Steps)
 
 


### PR DESCRIPTION
Updating links at the bottom of the page. They were pointing to the wrong directory because of the use of `../` before the page name

Fixes issue #2325
Changes proposed in this pull request:

- Point `Prev` link to correct location by removing `../`
- Point `Next` link to correct location by removing `../`

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @GhostViz

This pull request needs review by: @sandrobonazzola 
