### PR TITLE
Update the value of `:vernum_rhv:` from `4.4-beta` to `4.4`

### DIFF
--- a/source/documentation/common/collateral_files/ovirt-attributes.adoc
+++ b/source/documentation/common/collateral_files/ovirt-attributes.adoc
@@ -1,7 +1,7 @@
 // Warning: Changing these attribute definitions is very likely to
 // break links throughout our doc set.
 // Carefully analyze, test, and peer review all changes to this file!
-:vernum_rhv: 4.4-beta
+:vernum_rhv: 4.4
 :vernum_rhv_legacy: 4.3
 :vernum_satellite: 6.5
 :vernum_rhel: 8.0


### PR DESCRIPTION
Fixes issue #2332

Changes proposed in this pull request:

- update documentation for displaying 4.4 instead of 4.4-beta. Adapted from downstream documentation patch 8ca2d191ac757d4019d34038b27b656e10c07a0e by @rolfedh 

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @rolfedh 
