### PR TITLE
docs: use relative urls

### DIFF
--- a/source/documentation/common/collateral_files/ovirt-attributes.adoc
+++ b/source/documentation/common/collateral_files/ovirt-attributes.adoc
@@ -39,7 +39,7 @@
 :URL_format: 
 // Here are the composite URL attributes.
 // Where possible, use these instead of the atomic URL attributes.
-:URL_virt_product_docs: https://ovirt.org/documentation
+:URL_virt_product_docs: /documentation/
 :URL_downstream_virt_product_docs: {URL_customer-portal}{URL_docs}{URL_lang-locale}{URL_product_rhv}{URL_vernum_rhv}html-single
 :URL_rhel_docs_legacy: {URL_customer-portal}{URL_docs}{URL_lang-locale}{URL_product_rhel}{URL_vernum_rhel_legacy}
 :URL_rhel_docs_latest: {URL_customer-portal}{URL_docs}{URL_lang-locale}{URL_product_rhel}{URL_vernum_rhel_latest}


### PR DESCRIPTION
ovirt-attributes contained:
URL_virt_product_docs: https://ovirt.org/documentation

which caused the generation of broken links like:
https://ovirt.org/documentationvmm-guide/Virtual_Machine_Management_Guide.html#Importing_a_Virtual_Machine_from_Xen
in /documentation/administration_guide/index.html

changing it to:
:URL_virt_product_docs: /documentation/
so the broken url should become:
/documentation/vmm-guide/Virtual_Machine_Management_Guide.html#Importing_a_Virtual_Machine_from_Xen
and be also available when running the site locally.


I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @stoobie , @rolfedh , @pmkovar 
