### PR TITLE
admin guide: fix broken links to RHEL docs

### DIFF
--- a/source/documentation/administration_guide/topics/Red_Hat_Virtualization_Hosts.adoc
+++ b/source/documentation/administration_guide/topics/Red_Hat_Virtualization_Hosts.adoc
@@ -11,7 +11,7 @@ Access the Cockpit web interface at https://_HostFQDNorIP_:9090 in your web brow
 
 [NOTE]
 ====
-Custom boot kernel arguments can be added to {hypervisor-fullname} using the `grubby` tool. The `grubby` tool makes persistent changes to the *grub.cfg* file. Navigate to the *Terminal* sub-tab in the host's Cockpit web interface to use `grubby` commands. See the link:{URL_rhel_docs_legacy}html/System_Administrators_Guide/sec-Making_Persistent_Changes_to_a_GRUB_2_Menu_Using_the_grubby_Tool.html[_{enterprise-linux} System Administrator's Guide_] for more information.
+Custom boot kernel arguments can be added to {hypervisor-fullname} using the `grubby` tool. The `grubby` tool makes persistent changes to the *grub.cfg* file. Navigate to the *Terminal* sub-tab in the host's Cockpit web interface to use `grubby` commands. See the link:{URL_rhel_docs_legacy}html/system_administrators_guide/ch-Working_with_the_GRUB_2_Boot_Loader#sec-Making_Persistent_Changes_to_a_GRUB_2_Menu_Using_the_grubby_Tool[_{enterprise-linux} System Administrator's Guide_] for more information.
 ====
 
 [WARNING]

--- a/source/documentation/common/she/proc-Booting_a_self-hosted_engine_in_rescue_mode.adoc
+++ b/source/documentation/common/she/proc-Booting_a_self-hosted_engine_in_rescue_mode.adoc
@@ -1,7 +1,7 @@
 [id='Booting_a_Self-Hosted_Engine_in_Rescue_Mode_{context}']
 = Booting the {engine-name} Virtual Machine in Rescue Mode
 
-This topic describes how to boot the {engine-name} virtual machine into rescue mode when it does not start. For more information, see link:{URL_rhel_docs_legacy}html/system_administrators_guide/sec-terminal_menu_editing_during_boot[Booting to Rescue Mode] in the __{enterprise-linux} System Administrator's Guide__.
+This topic describes how to boot the {engine-name} virtual machine into rescue mode when it does not start. For more information, see link:{URL_rhel_docs_legacy}html/system_administrators_guide/ch-working_with_the_grub_2_boot_loader#sec-Terminal_Menu_Editing_During_Boot[Booting to Rescue Mode] in the __{enterprise-linux} System Administrator's Guide__.
 
 . Connect to one of the hosted-engine nodes:
 +


### PR DESCRIPTION
Changes proposed in this pull request:

- admin guide: fix broken links to RHEL docs


I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 
