### PR TITLE
automation: enable external site url check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,20 @@ language: ruby
 rvm:
   - "2.5"
 sudo: false
-cache: bundler
+cache:
+  bundler: true
+  directories:
+    - $TRAVIS_BUILD_DIR/tmp/.htmlproofer  # https://github.com/gjtorikian/html-proofer/issues/381
+
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true  # speeds up installation of html-proofer
+
+addons:
+  apt:
+    packages:
+      - libcurl4-openssl-dev  # required to avoid SSL errors
+
 script:
   - |
     if grep -rEi "^wiki_[^ ]+: " source/; then

--- a/test.rb
+++ b/test.rb
@@ -10,9 +10,9 @@ options = {
   check_opengraph: true,
   only_4xx: true,
   http_status_ignore: [429],
-  file_ignore: [ "/events/" ],
   url_ignore: [ "https://github.com/oVirt/.*/edit/.*" ],
-  parallel: { in_processes: 8 }
+  parallel: { in_processes: 8 },
+  cache: { timeframe: '6w' },
 }
 
 HTMLProofer.check_directory("./_site", options).run


### PR DESCRIPTION
Fixes: #1228

Changes proposed in this pull request:

- Enable external site url check with 6 weeks caching.
  Example from: https://github.com/gjtorikian/html-proofer/wiki/Using-HTMLProofer-From-Ruby-and-Travis
  This completes all url testing within the website.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @duck-rh 
