### PR TITLE
docs: DWH Guide: fix title sequence

### DIFF
--- a/source/documentation/data_warehouse_guide/chap-Installing_and_Configuring_Data_Warehouse.adoc
+++ b/source/documentation/data_warehouse_guide/chap-Installing_and_Configuring_Data_Warehouse.adoc
@@ -3,7 +3,7 @@
 
 :context: DWH_admin
 
-include::topics/Overview_of_Configuring_Data_Warehouse.adoc[]
+include::topics/Overview_of_Configuring_Data_Warehouse.adoc[leveloffset=+1]
 
 include::../common/database/proc-Installing_and_Configuring_Data_Warehouse_on_a_Separate_Machine.adoc[leveloffset=+1]
 

--- a/source/documentation/data_warehouse_guide/topics/Overview_of_Configuring_Data_Warehouse.adoc
+++ b/source/documentation/data_warehouse_guide/topics/Overview_of_Configuring_Data_Warehouse.adoc
@@ -1,5 +1,5 @@
 [[Overview_of_Configuring_Data_Warehouse]]
-=== Overview of Configuring Data Warehouse
+== Overview of Configuring Data Warehouse
 
 You can install and configure Data Warehouse on the same machine as the {engine-name}, or on a separate machine with access to the {engine-name}:
 

--- a/source/documentation/data_warehouse_guide/topics/Overview_of_Configuring_Data_Warehouse.adoc
+++ b/source/documentation/data_warehouse_guide/topics/Overview_of_Configuring_Data_Warehouse.adoc
@@ -1,5 +1,5 @@
 [[Overview_of_Configuring_Data_Warehouse]]
-== Overview of Configuring Data Warehouse
+= Overview of Configuring Data Warehouse
 
 You can install and configure Data Warehouse on the same machine as the {engine-name}, or on a separate machine with access to the {engine-name}:
 


### PR DESCRIPTION
Changes proposed in this pull request:

- fixes:
 `asciidoctor: WARNING: topics/Overview_of_Configuring_Data_Warehouse.adoc: line 2: section title out of sequence: expected level 2, got level 3`

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @stoobie 
