### PR TITLE
virtual_machine_management_guide: fix title levels

### DIFF
--- a/source/documentation/virtual_machine_management_guide/assembly-Installing_Red_Hat_Enterprise_Linux_Virtual_Machines.adoc
+++ b/source/documentation/virtual_machine_management_guide/assembly-Installing_Red_Hat_Enterprise_Linux_Virtual_Machines.adoc
@@ -31,9 +31,9 @@ include::../common/install/proc-Creating_a_virtual_machine.adoc[leveloffset=+1]
 [[Starting_the_Virtual_Machine]]
 == Starting the Virtual Machine
 
-include::topics/Powering_on_a_virtual_machine.adoc[]
+include::topics/Powering_on_a_virtual_machine.adoc[leveloffset=+2]
 
-include::topics/Opening_a_console_to_a_virtual_machine.adoc[]
+include::topics/Opening_a_console_to_a_virtual_machine.adoc[leveloffset=+2]
 
 include::topics/Opening_a_Serial_Console_to_a_Virtual_Machine.adoc[]
 

--- a/source/documentation/virtual_machine_management_guide/chap-Additional_Configuration.adoc
+++ b/source/documentation/virtual_machine_management_guide/chap-Additional_Configuration.adoc
@@ -1,7 +1,7 @@
 [[chap-Additional_Configuration]]
 = Additional Configuration
 
-include::topics/Configuring_operating_systems_with_osinfo.adoc[]
+include::topics/Configuring_operating_systems_with_osinfo.adoc[leveloffset=+1]
 
 [[sect-Configuring_Single_Sign-On_for_Virtual_Machines]]
 === Configuring Single Sign-On for Virtual Machines

--- a/source/documentation/virtual_machine_management_guide/chap-Installing_Windows_Virtual_Machines.adoc
+++ b/source/documentation/virtual_machine_management_guide/chap-Installing_Windows_Virtual_Machines.adoc
@@ -20,9 +20,9 @@ include::../common/install/proc-Creating_a_virtual_machine.adoc[leveloffset=+1]
 [[sect-Starting_the_Virtual_Machine_Using_the_Run_Once_Option]]
 == Starting the virtual machine using Run Once
 
-include::topics/Installing_Windows_on_Virtio_Optimized_Hardware.adoc[]
+include::topics/Installing_Windows_on_Virtio_Optimized_Hardware.adoc[leveloffset=+2]
 
-include::topics/Opening_a_Console_to_a_Virtual_Machine.adoc[]
+include::topics/Opening_a_Console_to_a_Virtual_Machine.adoc[leveloffset=+2]
 
 [[Installing_Guest_Agents_and_Drivers_Windows]]
 == Installing guest agents and drivers

--- a/source/documentation/virtual_machine_management_guide/topics/Configuring_operating_systems_with_osinfo.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Configuring_operating_systems_with_osinfo.adoc
@@ -1,5 +1,5 @@
 [[Configuring_operating_systems_with_osinfo]]
-== Configuring Operating Systems with osinfo
+= Configuring Operating Systems with osinfo
 
 {virt-product-fullname} stores operating system configurations for virtual machines in */etc/ovirt-engine/osinfo.conf.d/00-defaults.properties*. This file contains default values such as `os.other.devices.display.protocols.value = spice/qxl,vnc/vga,vnc/qxl`.
 

--- a/source/documentation/virtual_machine_management_guide/topics/Configuring_operating_systems_with_osinfo.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Configuring_operating_systems_with_osinfo.adoc
@@ -1,5 +1,5 @@
 [[Configuring_operating_systems_with_osinfo]]
-=== Configuring Operating Systems with osinfo
+== Configuring Operating Systems with osinfo
 
 {virt-product-fullname} stores operating system configurations for virtual machines in */etc/ovirt-engine/osinfo.conf.d/00-defaults.properties*. This file contains default values such as `os.other.devices.display.protocols.value = spice/qxl,vnc/vga,vnc/qxl`.
 

--- a/source/documentation/virtual_machine_management_guide/topics/Installing_Windows_on_Virtio_Optimized_Hardware.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Installing_Windows_on_Virtio_Optimized_Hardware.adoc
@@ -1,5 +1,5 @@
 [[Installing_Windows_on_Virtio_Optimized_Hardware]]
-=== Installing Windows on VirtIO-optimized hardware
+= Installing Windows on VirtIO-optimized hardware
 
 Install VirtIO-optimized disk and network device drivers during your Windows installation by attaching the `virtio-win___version__.iso` file to your virtual machine. These drivers provide a performance improvement over emulated device drivers.
 

--- a/source/documentation/virtual_machine_management_guide/topics/Installing_Windows_on_Virtio_Optimized_Hardware.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Installing_Windows_on_Virtio_Optimized_Hardware.adoc
@@ -1,5 +1,5 @@
 [[Installing_Windows_on_Virtio_Optimized_Hardware]]
-==== Installing Windows on VirtIO-optimized hardware
+=== Installing Windows on VirtIO-optimized hardware
 
 Install VirtIO-optimized disk and network device drivers during your Windows installation by attaching the `virtio-win___version__.iso` file to your virtual machine. These drivers provide a performance improvement over emulated device drivers.
 

--- a/source/documentation/virtual_machine_management_guide/topics/Opening_a_Console_to_a_Virtual_Machine.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Opening_a_Console_to_a_Virtual_Machine.adoc
@@ -1,5 +1,5 @@
 [[Opening_a_Console_to_a_Virtual_Machine]]
-=== Opening a console to a virtual machine
+= Opening a console to a virtual machine
 
 Use Remote Viewer to connect to a virtual machine.
 

--- a/source/documentation/virtual_machine_management_guide/topics/Opening_a_Console_to_a_Virtual_Machine.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Opening_a_Console_to_a_Virtual_Machine.adoc
@@ -1,5 +1,5 @@
 [[Opening_a_Console_to_a_Virtual_Machine]]
-==== Opening a console to a virtual machine
+=== Opening a console to a virtual machine
 
 Use Remote Viewer to connect to a virtual machine.
 

--- a/source/documentation/virtual_machine_management_guide/topics/Opening_a_console_to_a_virtual_machine.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Opening_a_console_to_a_virtual_machine.adoc
@@ -1,5 +1,5 @@
 [[Logging_in_to_a_virtual_machine_using_SPICE]]
-==== Opening a Console to a Virtual Machine
+=== Opening a Console to a Virtual Machine
 
 Use Remote Viewer to connect to a virtual machine.
 

--- a/source/documentation/virtual_machine_management_guide/topics/Opening_a_console_to_a_virtual_machine.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Opening_a_console_to_a_virtual_machine.adoc
@@ -1,5 +1,5 @@
 [[Logging_in_to_a_virtual_machine_using_SPICE]]
-=== Opening a Console to a Virtual Machine
+= Opening a Console to a Virtual Machine
 
 Use Remote Viewer to connect to a virtual machine.
 

--- a/source/documentation/virtual_machine_management_guide/topics/Powering_on_a_virtual_machine.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Powering_on_a_virtual_machine.adoc
@@ -1,5 +1,5 @@
 [[Powering_on_a_virtual_machine]]
-=== Starting a Virtual Machine
+= Starting a Virtual Machine
 
 *Starting Virtual Machines*
 

--- a/source/documentation/virtual_machine_management_guide/topics/Powering_on_a_virtual_machine.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Powering_on_a_virtual_machine.adoc
@@ -1,5 +1,5 @@
 [[Powering_on_a_virtual_machine]]
-==== Starting a Virtual Machine
+=== Starting a Virtual Machine
 
 *Starting Virtual Machines*
 


### PR DESCRIPTION
Changes proposed in this pull request:

 - Fixes:
```
asciidoctor: WARNING: topics/Powering_on_a_virtual_machine.adoc: line 2: section title out of sequence: expected level 3, got level 4
asciidoctor: WARNING: topics/Opening_a_console_to_a_virtual_machine.adoc: line 2: section title out of sequence: expected level 3, got level 4
asciidoctor: WARNING: topics/Opening_a_Serial_Console_to_a_Virtual_Machine.adoc: line 2: section title out of sequence: expected level 3, got level 4
asciidoctor: WARNING: topics/Automatically_connecting_to_a_Virtual_Machine.adoc: line 2: section title out of sequence: expected level 3, got level 4
asciidoctor: WARNING: topics/Installing_Windows_on_Virtio_Optimized_Hardware.adoc: line 2: section title out of sequence: expected level 3, got level 4
asciidoctor: WARNING: topics/Opening_a_Console_to_a_Virtual_Machine.adoc: line 2: section title out of sequence: expected level 3, got level 4
asciidoctor: WARNING: topics/Configuring_operating_systems_with_osinfo.adoc: line 2: section title out of sequence: expected level 2, got level 3
asciidoctor: WARNING: chap-Additional_Configuration.adoc: line 7: section title out of sequence: expected level 2, got level 3
asciidoctor: WARNING: chap-Additional_Configuration.adoc: line 30: section title out of sequence: expected level 2, got level 3
asciidoctor: WARNING: chap-Additional_Configuration.adoc: line 53: section title out of sequence: expected level 2, got level 3
asciidoctor: WARNING: chap-Additional_Configuration.adoc: line 60: section title out of sequence: expected level 2, got level 3
asciidoctor: WARNING: chap-Additional_Configuration.adoc: line 101: section title out of sequence: expected level 2, got level 3
asciidoctor: WARNING: topics/Configuring_virtual_NUMA.adoc: line 2: section title out of sequence: expected level 2, got level 3
asciidoctor: WARNING: topics/Configuring_Satellite_Errata.adoc: line 2: section title out of sequence: expected level 2, got level 3
asciidoctor: WARNING: topics/Configuring_Headless_Machines.adoc: line 2: section title out of sequence: expected level 2, got level 3
asciidoctor: WARNING: topics/Configuring_high_performance_virtual_machines.adoc: line 2: section title out of sequence: expected level 2, got level 3
```

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @stoobie 
