### PR TITLE
Wrong software name

### DIFF
--- a/source/documentation/admin-guide/virt/console-client-resources.md
+++ b/source/documentation/admin-guide/virt/console-client-resources.md
@@ -12,7 +12,7 @@ oVirt provides several ways to connect to remote virtual machines. This page des
 *   Native Client
 
 This way make use of locally installed remote-viewer application.
-You can install the application using your package manager (yum/dnf install remote-viewer) or download it from <http://virt-manager.org/download/> for various platforms.
+You can install the application using your package manager (yum/dnf install virt-viewer) or download it from <http://virt-manager.org/download/> for various platforms.
 
 *   spice-html5
 


### PR DESCRIPTION
There is no software remote-viewer available. Given that the linked page only lists a "virt-viewer" I guess that this is the software the author wanted to link to.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @modir 
