### PR TITLE
Add solution to permission denied issue on Fedora

### DIFF
--- a/source/develop/dev-process/working-with-gerrit.md
+++ b/source/develop/dev-process/working-with-gerrit.md
@@ -47,6 +47,7 @@ To allow SSH to access Gerrit, update the SSH public key via Gerrit settings:
          HostName gerrit.ovirt.org
          Port 29418
          User <username>
+         PubkeyAcceptedKeyTypes=+rsa-sha2-512
        
 
 ### Changing File Permissions


### PR DESCRIPTION
On Fedora 33, there is a problem to reach Gerrit.
This has been confirmed by multiple Fedora 33 users.
The following error occurs:
"<your name>@code.engineering.redhat.com: Permission denied (publickey)"

Adding "PubkeyAcceptedKeyTypes=+rsa-sha2-512" to ~/.ssh/config
solves this issue.