### PR TITLE
engine hw reqs: explicit x86_64 arch

### DIFF
--- a/source/documentation/common/prereqs/ref-Manager_Hardware_Requirements.adoc
+++ b/source/documentation/common/prereqs/ref-Manager_Hardware_Requirements.adoc
@@ -18,7 +18,7 @@ endif::[]
 [options="header"]
 |===
 |Resource |Minimum |Recommended
-|CPU |A dual core CPU. |A quad core CPU or multiple dual core CPUs.
+|CPU |A dual core x86_64 CPU. |A quad core x86_64 CPU or multiple dual core x86_64 CPUs.
 |Memory |4 GB of available system RAM if Data Warehouse is not installed and if memory is not being consumed by existing processes. |16 GB of system RAM.
 |Hard Disk |25 GB of locally accessible, writable disk space. |50 GB of locally accessible, writable disk space.
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Make engine hardwdare requirements explicit about needing x86_64 architecture.
  Bug-Url: https://bugzilla.redhat.com/1910847

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @stoobie @emarcusRH 
