### PR TITLE
schema - adding metrics schema files to upstream

### DIFF
--- a/source/documentation/administration_guide/chap-monitoring_and_observability.adoc
+++ b/source/documentation/administration_guide/chap-monitoring_and_observability.adoc
@@ -19,6 +19,13 @@ include::topics/Configure_grafana.adoc[]
 
 include::topics/Sending_metrics_to_ELK.adoc[]
 
+ifdef::ovirt-doc[]
+
+=== Metrics schema
+
+include::topics/Metrics_Schema.adoc[]
+endif::[]
+
 ifdef::rhv-doc[]
 === Deploying Insights in Red Hat Virtualization Manager
 

--- a/source/documentation/administration_guide/chap-monitoring_and_observability.adoc
+++ b/source/documentation/administration_guide/chap-monitoring_and_observability.adoc
@@ -18,9 +18,10 @@ include::topics/Configure_grafana.adoc[]
 === Sending metrics to a remote instance of Elasticsearch
 
 include::topics/Sending_metrics_to_ELK.adoc[]
-//to be included in upstream only
-ifdef::ovirt-doc[]
 
+//to be included in upstream only
+
+ifdef::ovirt-doc[]
 === Metrics schema
 
 include::topics/Metrics_Schema.adoc[]

--- a/source/documentation/administration_guide/chap-monitoring_and_observability.adoc
+++ b/source/documentation/administration_guide/chap-monitoring_and_observability.adoc
@@ -18,7 +18,7 @@ include::topics/Configure_grafana.adoc[]
 === Sending metrics to a remote instance of Elasticsearch
 
 include::topics/Sending_metrics_to_ELK.adoc[]
-
+//to be included in upstream only
 ifdef::ovirt-doc[]
 
 === Metrics schema

--- a/source/documentation/administration_guide/topics/Aggregation.adoc
+++ b/source/documentation/administration_guide/topics/Aggregation.adoc
@@ -1,0 +1,33 @@
+[[Aggregation]]
+=== Aggregation Metrics
+
+The Aggregation metric aggregates several values into one using aggregation functions such as sum, average, min, and max. It is used to provide a combined value for average and total CPU statistics.
+
+The following table describes the aggregation metrics reported by the *Aggregation* plugin.
+
+[options="header"]
+|====
+|Metric Name |collectd.type_instance |Description
+|collectd.aggregation.percent a|* interrupt
+* user
+* wait
+* nice
+* softirq
+* system
+* idle
+* steal |The average and total CPU usage, as an aggregated percentage, for each of the _collectd.type_instance_ states.
+|====
+
+*Additional Values*
+
+** *collectd.plugin:* Aggregation
+** *collectd.type_instance:* cpu-average / cpu-sum
+** *collectd.plugin_instance:*
+** *collectd.type:* percent
+** *ovirt.entity:* host
+** *ovirt.cluster.name.raw:* _The cluster's name_
+** *ovirt.engine_fqdn.raw:* _The {engine-name}'s FQDN_
+** *hostname:* _The host's FQDN_
+** *ipaddr4:* _IP address_
+** *interval:* 10
+** *collectd.dstypes:* xref:Gauge[Gauge]

--- a/source/documentation/administration_guide/topics/CPU.adoc
+++ b/source/documentation/administration_guide/topics/CPU.adoc
@@ -1,0 +1,34 @@
+[[CPU]]
+=== CPU Metrics
+
+CPU metrics display the amount of time spent by the hosts' CPUs, as a percentage.
+
+The following table describes CPU metrics as reported by the *CPU* plugin.
+
+.CPU Metrics
+[options="header"]
+
+|====
+|Metric Name |collectd.type_instance |Description
+|collectd.cpu.percent a|* interrupt
+* user
+* wait
+* nice
+* softirq
+* system
+* idle
+* steal |The percentage of time spent, per CPU, in the _collectd.type_instance_ states.
+|====
+
+*Additional Values*
+
+** *collectd.plugin:* CPU
+** *collectd.plugin_instance:* _The CPU's number_
+** *collectd.type:* percent
+** *ovirt.entity:* host
+** *ovirt.cluster.name.raw:* _The cluster's name_
+** *ovirt.engine_fqdn.raw:* _The {engine-name}'s FQDN_
+** *hostname:* _The host's FQDN_
+** *ipaddr4:* _IP address_
+** *interval:* 10
+** *collectd.dstypes:* xref:Gauge[Gauge]

--- a/source/documentation/administration_guide/topics/DF.adoc
+++ b/source/documentation/administration_guide/topics/DF.adoc
@@ -1,0 +1,26 @@
+[[DF]]
+=== Disk Consumption Metrics
+
+Disk consumption (DF) metrics enable you to monitor metrics about disk consumption, such as the used, reserved, and free space for each mounted file system.
+
+The following table describes the disk consumption metrics reported by the *DF* plugin.
+
+[options="header"]
+|====
+|Metric Name |Description
+|collectd.df.df_complex |The amount of free, used, and reserved disk space, in bytes, on this file system.
+|collectd.df.percent_bytes |The amount of free, used, and reserved disk space, as a percentage of total disk space, on this file system.
+|====
+
+*Additional Values*
+
+** *collectd.plugin:* DF
+** *collectd.type_instance:* free, used, reserved
+** *collectd.plugin_instance:* _A mounted partition_
+** *ovirt.entity:* host
+** *ovirt.cluster.name.raw:* _The cluster's name_
+** *ovirt.engine_fqdn.raw:* _The {engine-name}'s FQDN_
+** *hostname:* _The host's FQDN_
+** *ipaddr4:* _IP address_
+** *interval:* 10
+** *collectd.dstypes:* xref:Gauge[Gauge]

--- a/source/documentation/administration_guide/topics/Disks.adoc
+++ b/source/documentation/administration_guide/topics/Disks.adoc
@@ -1,0 +1,43 @@
+[[Disks]]
+=== Disk Operation Metrics
+
+Disk operation metrics are reported per physical disk on the host, and per partition.
+
+The following table describes the disk operation metrics reported by the *Disk* plugin.
+
+.Disk Operation Metrics
+[options="header"]
+
+|====
+|Metric Name |Description |collectd.dstypes
+
+|collectd.disk.disk_ops.read |The number of disk read operations. |xref:Derive[Derive]
+
+|collectd.disk.disk_ops.write |The number of disk write operations. |xref:Derive[Derive]
+
+|collectd.disk.disk_merged.read |The number of disk reads that have been merged into single physical disk access operations. In other words, this metric measures the number of instances in which one physical disk access served multiple disk reads. The higher the number, the better. |xref:Derive[Derive]
+
+|collectd.disk.disk_merged.write |The number of disk writes that were merged into single physical disk access operations. In other words, this metric measures the number of instances in which one physical disk access served multiple write operations. The higher the number, the better. |xref:Derive[Derive]
+
+|collectd.disk.disk_time.read |The average amount of time it took to do a read operation, in milliseconds. |xref:Derive[Derive]
+
+|collectd.disk.disk_time.write |The average amount of time it took to do a write operation, in milliseconds. |xref:Derive[Derive]
+
+|collectd.disk.pending_operations |The queue size of pending I/O operations. |xref:Gauge[Gauge]
+
+|collectd.disk.disk_io_time.io_time | The time spent doing I/Os in milliseconds. This can be used as a device load percentage, where a value of 1 second of time spent represents a 100% load.  |xref:Derive[Derive]
+
+|collectd.disk.disk_io_time.weighted_io_time |A measure of both I/O completion time and the backlog that may be accumulating.  |xref:Derive[Derive]
+|====
+
+*Additional Values*
+
+** *collectd.plugin:* Disk
+** *collectd.type_instance:* None
+** *collectd.plugin_instance:* _The disk's name_
+** *ovirt.entity:* host
+** *ovirt.cluster.name.raw:* _The cluster's name_
+** *ovirt.engine_fqdn.raw:* _The {engine-name}'s FQDN_
+** *hostname:* _The host's FQDN_
+** *ipaddr4:* _IP address_
+** *interval:* 10

--- a/source/documentation/administration_guide/topics/Entropy.adoc
+++ b/source/documentation/administration_guide/topics/Entropy.adoc
@@ -1,0 +1,27 @@
+[[Entropy]]
+=== Entropy Metrics
+
+Entropy metrics display the available entropy pool size on the host. Entropy is important for generating random numbers, which are used for encryption, authorization, and similar tasks.
+
+The following table describes the entropy metrics reported by the *Entropy* plugin.
+
+.Entropy Metrics
+[options="header"]
+
+|====
+|Metric Name |Description
+|collectd.entropy.entropy |The entropy pool size, in bits, on the host.
+|====
+
+*Additional Values*
+
+** *collectd.plugin:* Entropy
+** *collectd.type_instance:* None
+** *collectd.plugin_instance:* None
+** *ovirt.entity:* host
+** *ovirt.cluster.name.raw:* _The cluster's name_
+** *ovirt.engine_fqdn.raw:* _The {engine-name}'s FQDN_
+** *hostname:* _The host's FQDN_
+** *ipaddr4:* _IP address_
+** *interval:* 10
+** *collectd.dstypes:* xref:Gauge[Gauge]

--- a/source/documentation/administration_guide/topics/Gauge.adoc
+++ b/source/documentation/administration_guide/topics/Gauge.adoc
@@ -1,0 +1,16 @@
+[[Gauge_and_Derive]]
+=== Gauge and Derive Data Source Types
+
+Each metric includes a _collectd.dstypes_ value that defines the data source's type:
+
+[[Gauge]]
+*  *Gauge*: A gauge value is simply stored as-is and is used for values that may increase or decrease, such as the amount of memory used.
+
+[[Derive]]
+* *Derive*:
+    These data sources assume that the change of the value is interesting, i.e., the derivative. Such data sources are very common for events that can be counted, for example the number of disk read operations. The total number of disk read operations is not interesting, but rather the change since the value was last read. The value is therefore converted to a rate using the following formula:
+
+        rate = value(new)-value(old)\
+                time(new)-time(old)
+[NOTE]
+If value(new) is less than value (old), the resulting rate will be negative. If the minimum value to zero, such data points will be discarded.

--- a/source/documentation/administration_guide/topics/Interface.adoc
+++ b/source/documentation/administration_guide/topics/Interface.adoc
@@ -1,0 +1,88 @@
+[[Interface]]
+=== Network Interface Metrics
+
+The following types of metrics are reported from physical and virtual network interfaces on the host:
+
+* Bytes (octets) transmitted and received (total, or per second)
+* Packets transmitted and received (total, or per second)
+* Interface errors (total, or per second)
+
+The following table describes the network interface metrics reported by the *Interface* plugin.
+
+.Network Interface Metrics
+[options="header"]
+
+|====
+|collectd.type |Metric Name |Description
+
+|if_octets |collectd.interface.if_octets.rx |A count of the bytes received by the interface. You can view this metric as a Rate/sec or a cumulative count (Max):
+
+* Rate/sec: Provides the current traffic level on the interface in bytes/sec.
+
+* Max: Provides the cumulative count of bytes received. Note that since this metric is a cumulative counter, its value will periodically restart from zero when the maximum possible value of the counter is exceeded.
+|if_octets |collectd.interface.if_octets.tx |A count of the bytes transmitted by the interface. You can view this metric as a Rate/sec or a cumulative count (Max):
+
+* Rate/sec: Provides the current traffic level on the interface in bytes/sec.
+
+* Max: Provides the cumulative count of bytes transmitted. Note that since this metric is a cumulative counter, its value will periodically restart from zero when the maximum possible value of the counter is exceeded.
+
+|if_packets |collectd.interface.if_packets.rx | A count of the packets received by the interface.
+
+You can view this metric as a Rate/sec or a cumulative count (Max):
+
+* Rate/sec: Provides the current traffic level on the interface in bytes/sec.
+
+* Max: Provides the cumulative count of packets received. Note that since this metric is a cumulative counter, its value will periodically restart from zero when the maximum possible value of the counter is exceeded.
+
+|if_packets |collectd.interface.if_packets.tx | A count of the packets transmitted by the interface.
+
+You can view this metric as a Rate/sec or a cumulative count (Max):
+
+* Rate/sec: Provides the current traffic level on the interface in packets/sec.
+
+* Max: Provides the cumulative count of packets transmitted. Note that since this metric is a cumulative counter, its value will periodically restart from zero when the maximum possible value of the counter is exceeded.
+
+|if_errors |collectd.interface.if_errors.rx | A count of errors received on the interface.
+
+You can view this metric as a Rate/sec or a cumulative count (Max).
+
+* Rate/sec rollup provides the current rate of errors received on the interface in errors/sec.
+
+* Max rollup provides the total number of errors received since the beginning. Note that since this is a cumulative counter, its value will periodically restart from zero when the maximum possible value of the counter is exceeded.
+
+|if_errors |collectd.interface.if_errors.tx | A count of errors transmitted on the interface.
+
+You can view this metric as a Rate/sec or a cumulative count (Max).
+
+* Rate/sec rollup provides the current rate of errors transmitted on the interface in errors/sec.
+
+* Max rollup provides the total number of errors transmitted since the beginning. Note that since this is a cumulative counter, its value will periodically restart from zero when the maximum possible value of the counter is exceeded.
+
+|if_dropped |collectd.interface.if_dropped.rx | A count of dropped packets received on the interface.
+
+You can view this metric as a Rate/sec or a cumulative count (Max).
+
+* Rate/sec rollup provides the current rate of dropped packets received on the interface in packets/sec.
+
+* Max rollup provides the total number of dropped packets received since the beginning. Note that since this is a cumulative counter, its value will periodically restart from zero when the maximum possible value of the counter is exceeded.
+|if_dropped |collectd.interface.if_dropped.tx | A count of dropped packets transmitted on the interface.
+
+You can view this metric as a Rate/sec or a cumulative count (Max).
+
+* Rate/sec rollup provides the current rate of dropped packets transmitted on the interface in packets/sec.
+
+* Max rollup provides the total number of dropped packets transmitted since the beginning. Note that since this is a cumulative counter, its value will periodically restart from zero when the maximum possible value of the counter is exceeded.
+|====
+
+*Additional Values*
+
+** *collectd.plugin:* Interface
+** *collectd.type_instance:* None
+** *collectd.plugin_instance:* _The network's name_
+** *ovirt.entity:* host
+** *ovirt.cluster.name.raw:* _The cluster's name_
+** *ovirt.engine_fqdn.raw:* _The {engine-name}'s FQDN_
+** *hostname:* _The host's FQDN_
+** *ipaddr4:* _IP address_
+** *interval:* 10
+** *collectd.dstypes:* xref:Derive[Derive]

--- a/source/documentation/administration_guide/topics/Load.adoc
+++ b/source/documentation/administration_guide/topics/Load.adoc
@@ -1,0 +1,36 @@
+[[Load]]
+=== CPU Load Average Metrics
+
+CPU load represents CPU contention, that is, the average number of schedulable processes at any given time. This is reported as an average value for all CPU cores on the host. Each CPU core can only execute one process at a time. Therefore, a CPU load average above 1.0 indicates that the CPUs have more work than they can perform, and the system is overloaded.
+
+CPU load is reported over short term (last one minute), medium term (last five minutes) and long term (last fifteen minutes). While it is normal for a host's short term load average to exceed 1.0 (for a single CPU), sustained load average above 1.0 on a host may indicate a problem.
+
+On multi-processor systems, the load is relative to the number of processor cores available. The "100% utilization" mark is 1.00 on a single-core, 2.00 on a dual-core, 4.00 on a quad-core system.
+
+{org-fullname} recommends looking at CPU load in conjunction with xref:CPU[CPU Metrics].
+
+The following table describes the CPU load metrics reported by the  *Load* plugin.
+
+.CPU Load Average Metrics
+[options="header"]
+
+|====
+|Metric Name |Description
+|collectd.load.load.longterm |Average number of schedulable processes per CPU core over the last 15 minutes. A value above 1.0 indicates the system was overloaded during the last 15 minutes.
+|collectd.load.load.midterm |Average number of schedulable processes per CPU core over the last five minutes. A value above 1.0 indicates the system was overloaded during the last 5 minutes.
+|collectd.load.load.shortterm |Average number of schedulable processes per CPU core over the last one minute. A value above 1.0 indicates the system was overloaded during the last minute.
+|====
+
+*Additional Values*
+
+** *collectd.plugin:* Load
+** *collectd.type:* load
+** *collectd.type_instance:* None
+** *collectd.plugin_instance:* None
+** *ovirt.entity:* host
+** *ovirt.cluster.name.raw:* _The cluster's name_
+** *ovirt.engine_fqdn.raw:* _The {engine-name}'s FQDN_
+** *hostname:* _The host's FQDN_
+** *ipaddr4:* _IP address_
+** *interval:* 10
+** *collectd.dstypes:* xref:Gauge[Gauge]

--- a/source/documentation/administration_guide/topics/Memory.adoc
+++ b/source/documentation/administration_guide/topics/Memory.adoc
@@ -1,0 +1,28 @@
+[[Memory]]
+=== Memory Metrics
+Metrics collected about memory usage.
+
+The following table describes the memory usage metrics reported by the *Memory* plugin.
+
+.Memory Metrics
+[options="header"]
+
+|====
+|Metric Name |collectd.type |collectd.type_instance |Description
+.6+|collectd.memory.memory .6+|memory |used |The total amount of memory used. |free |The total amount of unused memory. |cached
+|The amount of memory used for caching disk data for reads, memory-mapped files, or tmpfs data. |buffered |The amount of memory used for buffering, mostly for I/O operations. |slab_recl |The amount of reclaimable memory used for slab kernel allocations. |slab_unrecl|Amount of unreclaimable memory used for slab kernel allocations.
+
+.6+|collectd.memory.percent .6+|percent |used |The total amount of memory used, as a percentage. |free |The total amount of unused memory, as a percentage. |cached
+|The amount of memory used for caching disk data for reads, memory-mapped files, or tmpfs data, as a percentage. |buffered |The amount of memory used for buffering I/O operations, as a percentage. |slab_recl |The amount of reclaimable memory used for slab kernel allocations, as a percentage. |slab_unrecl |The amount of unreclaimable memory used for slab kernel allocations, as a percentage.
+|====
+*Additional Values*
+
+** *collectd.plugin:* Memory
+** *collectd.plugin_instance:* None
+** *ovirt.entity:* Host
+** *ovirt.cluster.name.raw:* _The cluster's name_
+** *ovirt.engine_fqdn.raw:* _The {engine-name}'s FQDN_
+** *hostname:* _The host's FQDN_
+** *ipaddr4:* _IP address_
+** *interval:* 10
+** *collectd.dstypes:* xref:Gauge[Gauge]

--- a/source/documentation/administration_guide/topics/Metrics_Schema.adoc
+++ b/source/documentation/administration_guide/topics/Metrics_Schema.adoc
@@ -1,0 +1,39 @@
+[[Metrics_Schema]]
+== Metrics Schema
+
+The following sections describe the metrics that are available from the *Field* menu when creating visualizations.
+
+[NOTE]
+====
+All metric values are collected at 10 second intervals.
+====
+
+include::Aggregation.adoc[Aggregation]
+
+include::CPU.adoc[CPU]
+
+include::Load.adoc[CPU Load Average]
+
+include::DF.adoc[Disk Consumption]
+
+include::Disks.adoc[Disk Operations]
+
+include::Entropy.adoc[Entropy]
+
+include::Interface.adoc[Network Interface]
+
+include::Memory.adoc[Memory]
+
+include::NFS.adoc[NFS]
+
+include::postgresql.adoc[Postgresql]
+
+include::Processes.adoc[Processes]
+
+include::StatsD.adoc[StatSd]
+
+include::Swap.adoc[Swap]
+
+include::Virt.adoc[Virt]
+
+include::Gauge.adoc[]

--- a/source/documentation/administration_guide/topics/NFS.adoc
+++ b/source/documentation/administration_guide/topics/NFS.adoc
@@ -1,0 +1,31 @@
+[[NFS]]
+=== NFS Metrics
+
+NFS metrics enable you to analyze the use of NFS procedures.
+
+The following table describes the NFS metrics reported by the *NFS* plugin.
+
+[options="header"]
+|====
+|Metric Name 3+|collectd.type_instance |Description
+|collectd.nfs.nfs_procedure
+|null / getattr / lookup / access / readlink / read / write / create / mkdir / symlink / mknod / rename / readdir / remove / link / fsstat / fsinfo / readdirplus / pathconf / rmdir / commit / compound / reserved / access / close / delegpurge / putfh / putpubfh putrootfh / renew / restorefh / savefh / secinfo
+
+| / setattr / setclientid / setcltid_confirm / verify / open / openattr / open_confirm / exchange_id / create_session / destroy_session / bind_conn_to_session / delegreturn / getattr / getfh / lock / lockt / locku / lookupp /  open_downgrade / nverify
+
+| / release_lockowner / backchannel_ctl / free_stateid / get_dir_delegation / getdeviceinfo / getdevicelist / layoutcommit / layoutget / layoutreturn / secinfo_no_name / sequence / set_ssv / test_stateid / want_delegation / destroy_clientid / reclaim_complete
+|The number of processes per _collectd.type_instance_ state.
+|====
+
+*Additional Values*
+
+** *collectd.plugin:* NFS
+** *collectd.plugin_instance:* _File system + server or client (for example: v3client)_
+** *collectd.type:* nfs_procedure
+** *ovirt.entity:* host
+** *ovirt.cluster.name.raw:* _The cluster's name_
+** *ovirt.engine_fqdn.raw:* _The {engine-name}'s FQDN_
+** *hostname:* _The host's FQDN_
+** *ipaddr4:* _IP address_
+** *interval:* 10
+** *collectd.dstypes:* xref:Derive[Derive]

--- a/source/documentation/administration_guide/topics/Processes.adoc
+++ b/source/documentation/administration_guide/topics/Processes.adoc
@@ -1,0 +1,40 @@
+[[Processes]]
+=== Process Metrics
+
+The following table describes the process metrics reported by the *Processes* plugin.
+
+[options="header"]
+|====
+|Metric Name |collectd.type|Description |collectd.dstypes
+|collectd.processes.ps_state |ps_state|The number of processes in each state. |xref:Gauge[Gauge]
+|collectd.processes.ps_disk_ops.read |ps_disk_ops|The process's I/O read operations. |xref:Derive[Derive]
+|collectd.processes.ps_disk_ops.write |ps_disk_ops|The process's I/O write operations. |xref:Derive[Derive]
+|collectd.processes.ps_vm |ps_vm|The total amount of memory including swap. |xref:Gauge[Gauge]
+|collectd.processes.ps_rss|ps_rss|The amount of physical memory assigned to the process.|xref:Gauge[Gauge]
+|collectd.processes.ps_data|ps_data||xref:Gauge[Gauge]
+|collectd.processes.ps_code|ps_code||xref:Gauge[Gauge]
+
+|collectd.processes.ps_stacksize|ps_stacksize||xref:Gauge[Gauge]
+|collectd.processes.ps_cputime.syst|ps_cputime|The amount of time spent by the matching processes in kernel mode. The values are scaled to microseconds per second to match collectd's numbers.|xref:Derive[Derive]
+|collectd.processes.ps_cputime.user|ps_cputime|The amount of time spent by the matching processes in user mode. The values are scaled to microseconds per second.|xref:Derive[Derive]
+|collectd.processes.ps_count.processes|ps_count|The number of processes for the defined process.|xref:Gauge[Gauge]
+|collectd.processes.ps_count.threads|ps_count|The number of threads for the defined process. |xref:Gauge[Gauge]
+|collectd.processes.ps_pagefaults.majfltadd |ps_pagefaults|The number of major page faults caused by the process. |xref:Derive[Derive]
+|collectd.processes.ps_pagefaults.minflt |ps_pagefaults|The number of major page faults caused by the process.|xref:Derive[Derive]
+|collectd.processes.ps_disk_octets.write |ps_disk_octets|The process's I/O write operations in transferred bytes. |xref:Derive[Derive]
+|collectd.processes.ps_disk_octets.read|ps_disk_octets|The process's I/O read operations in transferred bytes. |xref:Derive[Derive]
+
+|collectd.processes.fork_rate |fork_rate|The system's fork rate. |xref:Derive[Derive]
+
+|====
+
+*Additional Values*
+
+** *collectd.plugin:* Processes
+** *collectd.type_instance:* N/A (except for collectd.processes.ps_state=running/ zombies/ stopped/ paging/ blocked/ sleeping)
+** *ovirt.entity:* host
+** *ovirt.cluster.name.raw:* _The cluster's name_
+** *ovirt.engine_fqdn.raw:* _The {engine-name}'s FQDN_
+** *hostname:* _The host's FQDN_
+** *ipaddr4:* _IP address_
+** *interval:* 10

--- a/source/documentation/administration_guide/topics/StatsD.adoc
+++ b/source/documentation/administration_guide/topics/StatsD.adoc
@@ -1,0 +1,53 @@
+[[StatsD]]
+=== StatsD Metrics
+
+The following table describes the StatsD metrics reported by the *StatsD* plugin.
+
+[options="header"]
+|====
+|Metric Name |collectd.type |collectd.type_instance |Description
+|collectd.statsd.host_storage |host_storage |storage uuid |The latency for writing to the storage domain.
+|collectd.statsd.vm_balloon_cur |vm_balloon_cur |N/A |The current amount of memory available to the guest virtual machine (in KB).
+|collectd.statsd.vm_balloon_max |vm_balloon_max |N/A |The maximum amount of memory available to the guest virtual machine (in KB).
+|collectd.statsd.vm_balloon_min |vm_balloon_min |N/A |The minimum amount of memory guaranteed to the guest virtual machine (in KB).
+|collectd.statsd.vm_balloon_target |vm_balloon_target |N/A |The amount of memory requested (in KB).
+|collectd.statsd.vm_cpu_sys |vm_cpu_sys |N/A |Ratio of non-guest virtual machine CPU time to total CPU time spent by QEMU.
+|collectd.statsd.vm_cpu_usage |vm_cpu_usage |N/A |Total CPU usage since VM start in (ns).
+|collectd.statsd.vm_cpu_user |vm_cpu_user |N/A |Ratio of guest virtual machine CPU time to total CPU time spent by QEMU.
+
+|collectd.statsd.vm_disk_apparent_size |vm_disk_apparent_size |disk name |The size of the disk (in bytes).
+
+|collectd.statsd.vm_disk_flush_latency |vm_disk_flush_latency |disk name |The virtual disk's flush latency (in seconds).
+
+|collectd.statsd.vm_disk_read_bytes |vm_disk_read_bytes |disk name |The read rate from disk (in bytes per second).
+
+|collectd.statsd.vm_disk_read_latency |vm_disk_read_latency |disk name |The virtual disk's read latency (in seconds).
+
+|collectd.statsd.vm_disk_read_ops |vm_disk_read_ops |disk name |The number of read operations since the virtual machine was started.
+
+|collectd.statsd.vm_disk_read_rate |vm_disk_read_rate |disk name |The virtual machine's read activity rate (in bytes per second).
+|collectd.statsd.vm_disk_true_size |vm_disk_true_size |disk name |The amount of underlying storage allocated (in bytes).
+
+|collectd.statsd.vm_disk_write_latency |vm_disk_write_latency |disk name |The virtual disk's write latency (in seconds).
+|collectd.statsd.vm_disk_write_ops |vm_disk_write_ops |disk name |The number of write operations since the virtual machine was started.
+|collectd.statsd.vm_disk_write_rate |vm_disk_write_rate |disk name |The virtual machine's write activity rate (in bytes per second).
+
+|collectd.statsd.vm_nic_rx_bytes |vm_nic_rx_bytes |network name |The total number of incoming bytes.
+|collectd.statsd.vm_nic_rx_dropped |vm_nic_rx_dropped |network name |The number of incoming packets that have been dropped.
+|collectd.statsd.vm_nic_rx_errors|vm_nic_rx_errors |network name |The number of incoming packets that contained errors.
+|collectd.statsd.vm_nic_speed|vm_nic_speed |network name |The interface speed (in Mbps).
+|collectd.statsd.vm_nic_tx_bytes|vm_nic_tx_bytes |network name |The total number of outgoing bytes.
+|collectd.statsd.vm_nic_tx_dropped |vm_nic_tx_dropped |network name |The number of outgoing packets that were dropped.
+|collectd.statsd.vm_nic_tx_errors |vm_nic_tx_errors |network name |The number of outgoing packets that contained errors.
+|====
+*Additional Values*
+
+** *collectd.plugin:* StatsD
+** *collectd.plugin_instance:* The virtual machine's name (except for collectd.statsd.host_storage=N/A)
+** *ovirt.entity:* vm (except for collectd.statsd.host_storage=host)
+** *ovirt.cluster.name.raw:* _The cluster's name_
+** *ovirt.engine_fqdn.raw:* _The {engine-name}'s FQDN_
+** *hostname:* _The host's FQDN_
+** *ipaddr4:* _IP address_
+** *interval:* 10
+** *collectd.dstypes:* xref:Gauge[Gauge]

--- a/source/documentation/administration_guide/topics/Swap.adoc
+++ b/source/documentation/administration_guide/topics/Swap.adoc
@@ -1,0 +1,27 @@
+[[Swap]]
+=== Swap Metrics
+
+Swap metrics enable you to view the amount of memory currently written onto the hard disk, in bytes, according to available, used, and cached swap space.
+
+The following table describes the Swap metrics reported by the *Swap* plugin.
+
+.Swap Metrics
+[options="header"]
+
+|====
+|Metric Name |collectd.type |collectd.type_instance|collectd.dstypes |Description
+|collectd.swap.swap |swap |used / free /  cached|xref:Gauge[Gauge]|The used, available, and cached swap space (in bytes).
+|collectd.swap.swap_io|swap_io |in / out |xref:Derive[Derive] |The number of swap pages written and read per second.
+|collectd.swap.percent|percent |used / free / cached |xref:Gauge[Gauge] |The percentage of used, available, and cached swap space.
+|====
+
+*Additional Fields*
+
+** *collectd.plugin:* Swap
+** *collectd.plugin_instance:* None
+** *ovirt.entity:* host or {engine-name}
+** *ovirt.cluster.name.raw:* _The cluster's name_
+** *ovirt.engine_fqdn.raw:* _The {engine-name}'s FQDN_
+** *hostname:* _The host's FQDN_
+** *ipaddr4:* _IP address_
+** *interval:* 10

--- a/source/documentation/administration_guide/topics/Virt.adoc
+++ b/source/documentation/administration_guide/topics/Virt.adoc
@@ -1,0 +1,49 @@
+[[Virt]]
+=== Virtual Machine Metrics
+
+The following table describes the virtual machine metrics reported by the *Virt* plugin.
+
+[options="header"]
+|====
+|Metric Name |collectd.type |collectd.type_instance |collectd.dstypes
+
+|collectd.virt.ps_cputime.syst |ps_cputime.syst |N/A |xref:Derive[Derive]
+|collectd.virt.percent |percent |virt_cpu_total |xref:Gauge[Gauge]
+|collectd.virt.ps_cputime.user |ps_cputime.user |N/A |xref:Derive[Derive]
+|collectd.virt.virt_cpu_total |virt_cpu_total |CPU number |xref:Derive[Derive]
+|collectd.virt.virt_vcpu |virt_vcpu |CPU number |xref:Derive[Derive]
+
+|collectd.virt.disk_octets.read |disk_octets.read |disk name |xref:Gauge[Gauge]
+
+|collectd.virt.disk_ops.read |disk_ops.read |disk name |xref:Gauge[Gauge]
+|collectd.virt.disk_octets.write |disk_octets.write |disk name |xref:Gauge[Gauge]
+
+|collectd.virt.disk_ops.write |disk_ops.write |disk name |xref:Gauge[Gauge]
+
+|collectd.virt.if_octets.rx |if_octets.rx |network name |xref:Derive[Derive]
+|collectd.virt.if_dropped.rx |if_dropped.rx |network name |xref:Derive[Derive]
+|collectd.virt.if_errors.rx|if_errors.rx |network name |xref:Derive[Derive]
+
+|collectd.virt.if_octets.tx|if_octets.tx |network name |xref:Derive[Derive]
+|collectd.virt.if_dropped.tx |if_dropped.tx |network name |xref:Derive[Derive]
+|collectd.virt.if_errors.tx |if_errors.tx |network name |xref:Derive[Derive]
+|collectd.virt.if_packets.rx |if_packets.rx |network name |xref:Derive[Derive]
+|collectd.virt.if_packets.tx |if_packets.tx |network name |xref:Derive[Derive]
+
+|collectd.virt.memory|memory |rss / total /actual_balloon / available / unused / usable / last_update / major_fault / minor_fault / swap_in / swap_out |xref:Gauge[Gauge]
+
+|collectd.virt.total_requests |total_requests |flush-DISK |xref:Derive[Derive]
+|collectd.virt.total_time_in_ms |total_time_in_ms |flush-DISK |xref:Derive[Derive]
+|collectd.virt.total_time_in_ms |total_time_in_ms |flush-DISK |xref:Derive[Derive]
+|====
+
+*Additional Values*
+
+** *collectd.plugin:* virt
+** *collectd.plugin_instance:* The virtual machine's name
+** *ovirt.entity:* vm
+** *ovirt.cluster.name.raw:* _The cluster's name_
+** *ovirt.engine_fqdn.raw:* _The {engine-name}'s FQDN_
+** *hostname:* _The host's FQDN_
+** *ipaddr4:* _IP address_
+** *interval:* 10

--- a/source/documentation/administration_guide/topics/postgresql.adoc
+++ b/source/documentation/administration_guide/topics/postgresql.adoc
@@ -1,0 +1,44 @@
+[[Postgresql]]
+=== PostgreSQL Metrics
+
+PostgreSQL data collected by executing SQL statements on a PostgreSQL database.
+
+The following table describes the PostgreSQL metrics reported by the *PostgreSQL* plugin.
+
+.PostgreSQL Metrics
+[options="header"]
+
+|====
+|Metric Name |collectd.type_instance |Description
+|collectd.postgresql.pg_numbackends |N/A |How many server processes this database is using.
+
+.2+|collectd.postgresql.pg_n_tup_g |live |The number of live rows in the database.
+|dead |The number of dead rows in the database. Rows that are deleted or obsoleted by an update are not physically removed from their table; they remain present as dead rows until a VACUUM is performed.
+.4+|collectd.postgresql.pg_n_tup_c |del |The number of delete operations.
+|upd  |The number of update operations.
+ |hot_upd  |The number of update operations that have been performed without requiring an index update.
+|ins  |The number of insert operations.
+|collectd.postgresql.pg_xact |num_deadlocks |The number of deadlocks that have been detected by the database. Deadlocks are caused by two or more competing actions that are unable to finish because each is waiting for the other's resources to be unlocked.
+
+|collectd.postgresql.pg_db_size |N/A |The size of the database on disk, in bytes.
+
+.7+|collectd.postgresql.pg_blks a|heap_read | How many disk blocks have been read.
+|heap_hit |How many read operations were served from the buffer in memory, so that a disk read was not necessary. This only includes hits in the PostgreSQL buffer cache, not the operating system's file system cache.
+|idx_read |How many disk blocks have been read by index access operations.
+|idx_hit |How many index access operations have been served from the buffer in memory.
+|toast_read |How many disk blocks have been read on TOAST tables.
+|toast_hit |How many TOAST table reads have been served from buffer in memory.
+|tidx_read |How many disk blocks have been read by index access operations on TOAST tables.
+|====
+
+*Additional Values*
+
+** *collectd.plugin:* Postgresql
+** *collectd.plugin_instance:* _Database's Name_
+** *ovirt.entity:* engine
+** *ovirt.cluster.name.raw:* _The cluster's name_
+** *ovirt.engine_fqdn.raw:* _The {engine-name}'s FQDN_
+** *hostname:* _The host's FQDN_
+** *ipaddr4:* _IP address_
+** *interval:* 10
+** *collectd.dstypes:* xref:Gauge[Gauge]


### PR DESCRIPTION
Changes proposed in this pull request:

- adding metrics schema files to upstream library in order to include in the Administration_guide/chap-monitoring_and_observability chapter


I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @emarcusRH

This pull request needs review by: @sradco / @sandrobonazzola 
