### PR TITLE
fix outdated notice lack of spaces on strong

### DIFF
--- a/source/_includes/developer_outdated.haml
+++ b/source/_includes/developer_outdated.haml
@@ -1,15 +1,9 @@
 
 %div.alert.alert-warning
-  This developer documentation is
-  %strong
-    outdated
-  , but provides historical context.
+  This developer documentation is <strong>outdated</strong>, but provides historical context.
   %br
   %br
-  It is
-  %strong
-    not
-  user documentation and should not be treated as such.
+  It is <strong>not</strong> user documentation and should not be treated as such.
   %br
   %br
   %a(href="/documentation/")Documentation is available here.


### PR DESCRIPTION
Changes proposed in this pull request:

- strong element used in haml removed pre and post whitespaces. Converted that part to plain html in order to have proper spacing.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @duck-rh 
