### PR TITLE
fix old screen mention

### DIFF
--- a/source/documentation/common/install/proc-Deploying_the_Self-Hosted_Engine_Using_the_CLI.adoc
+++ b/source/documentation/common/install/proc-Deploying_the_Self-Hosted_Engine_Using_the_CLI.adoc
@@ -39,7 +39,7 @@ Install and run `tmux`:
 +
 [NOTE]
 ====
-To escape the script at any time, use the kbd:[Ctrl+D] keyboard combination to abort deployment. In the event of session timeout or connection disruption, run `screen -d -r` to recover the deployment session.
+To escape the script at any time, use the kbd:[Ctrl+D] keyboard combination to abort deployment. In the event of session timeout or connection disruption, run `tmux a` to recover the deployment session.
 ====
 . When prompted, enter *Yes* to begin the deployment:
 +


### PR DESCRIPTION
replace screen with tmux in proc-Deploying_the_Self-Hosted_Engine_Using_the_CLI.adoc

Changes proposed in this pull request:
- replace screen with tmux in proc-Deploying_the_Self-Hosted_Engine_Using_the_CLI.adoc

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @spameier