### PR TITLE
handle deprecation notice for bundler options

### DIFF
--- a/run-server.sh
+++ b/run-server.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
 
-bundle install --quiet --path vendor/bundle
+bundle config --local path 'vendor/bundle'
+bundle install --quiet
 bundle exec jekyll s -t -l $@

--- a/setup.sh
+++ b/setup.sh
@@ -20,5 +20,5 @@ else
     echo "Could not verify system is RedHat or Debian."
     exit 1
 fi
-
-bundle install --path vendor/bundle
+bundle config --local path 'vendor/bundle'
+bundle install


### PR DESCRIPTION

Changes proposed in this pull request:

- Solves:
```
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across
bundler invocations, which bundler will no longer do in future versions.
Instead please use `bundle config set path 'vendor/bundle'`, and stop using this flag
```

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @duck-rh 
