### PR TITLE
link Incremental Backup API

### DIFF
--- a/source/documentation/index.haml
+++ b/source/documentation/index.haml
@@ -39,6 +39,8 @@ authors: dneary, metao, quaid, sandrobonazzola
 
       - [oVirt REST API documentation](http://ovirt.github.io/ovirt-engine-api-model/)
 
+      - [Incremental Backup API](incremental-backup-guide/incremental-backup-guide.html)
+
 
   .col-md-6.listNotAsUL
     :markdown


### PR DESCRIPTION
Changes proposed in this pull request:

- Incremental Backup API documentation was not linked from any other page within oVirt site. Added to documentation page within API section.


I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @shenitzky / @nirs 
