### PR TITLE
update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 # See https://help.github.com/articles/about-code-owners/ for more info on this file
 
-/source/release/ @sandrobonazzola
+/source/release/ @oVirt/ovirt-release-engineering
+/source/documentation/ @oVirt/ovirt-documentation


### PR DESCRIPTION
Changes proposed in this pull request:

- Adding ownership of the documentation tree to oVirt Documentation team and moving ownership of the release docs to oVirt Release team.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 
