### PR TITLE
drop feature_* metadata

### DIFF
--- a/.github/workflows/website_tests.yml
+++ b/.github/workflows/website_tests.yml
@@ -36,6 +36,13 @@ jobs:
             exit 2
           fi
 
+      - name: "Check for obsolete feature headers"
+        run: |
+          if grep -rEi "^feature_[^ ]+: " source/; then
+            echo '/!\ Feature headers are obsolete (see previous log entries)'
+            exit 2
+          fi
+
       - name: "Check for nonbreaking space in markdowns"
         run: |
           if grep -P '\xa0' `find source/ -name "*.md"` ; then

--- a/source/develop/api/design/vm-parameters-in-rest-api-for-vm-pools.md
+++ b/source/develop/api/design/vm-parameters-in-rest-api-for-vm-pools.md
@@ -1,10 +1,7 @@
 ---
 title: Vm Parameters in REST API for Vm Pools
-category: api
+category: feature
 authors: sandrobonazzola, smelamud
-feature_name: Vm Parameters in REST API for Vm Pools
-feature_modules: rest-api
-feature_status: Implemented
 ---
 
 <!-- TODO: Content review -->

--- a/source/develop/developer-guide/vdsm/momvdsmseparation.md
+++ b/source/develop/developer-guide/vdsm/momvdsmseparation.md
@@ -1,10 +1,7 @@
 ---
 title: MomVdsmSeparation
-category: vdsm
+category: feature
 authors: fromani, msivak
-feature_name: Starting MOM as a separate process instead of VDSM threa
-feature_modules: vdsm,mom
-feature_status: Draft
 ---
 
 # Mom Vdsm Separation

--- a/source/develop/release-management/features/feature-template.md
+++ b/source/develop/release-management/features/feature-template.md
@@ -3,9 +3,6 @@ title: Feature template
 category: feature
 authors: acathrow, danken, dneary, lvernia, nsoffer, ovedo, quaid, sandrobonazzola,
   vered
-feature_name: Your feature name
-feature_modules: engine,network,vdsm
-feature_status: Released
 ---
 
 # Feature template

--- a/source/develop/release-management/features/gluster/detailed-gluster-geo-rep.md
+++ b/source/develop/release-management/features/gluster/detailed-gluster-geo-rep.md
@@ -1,6 +1,6 @@
 ---
 title: Detailed Gluster Geo Rep
-category: template
+category: feature
 authors: sahina
 ---
 

--- a/source/develop/release-management/features/gluster/detailed-gluster-volume-asynchronous-tasks-management.md
+++ b/source/develop/release-management/features/gluster/detailed-gluster-volume-asynchronous-tasks-management.md
@@ -1,6 +1,6 @@
 ---
 title: Detailed Gluster Volume Asynchronous Tasks Management
-category: detailedfeature
+category: feature
 authors: sahina
 ---
 

--- a/source/develop/release-management/features/gluster/gdeploy-cockpit-integration.md
+++ b/source/develop/release-management/features/gluster/gdeploy-cockpit-integration.md
@@ -2,9 +2,6 @@
 title: Gdeploy Cockpit Integration
 category: feature
 authors: rnachimu
-feature_name: Gdeploy Integration with Cockpit
-feature_modules: cockpit plugin for ovirt
-feature_status: Obsolete
 ---
 
 # Gdeploy integration with Cockpit-oVirt Plugin

--- a/source/develop/release-management/features/gluster/gluster-arbiter-volume.md
+++ b/source/develop/release-management/features/gluster/gluster-arbiter-volume.md
@@ -2,9 +2,6 @@
 title: Gluster Arbiter Volume
 category: feature
 authors: rnahcimu, sahina
-feature_name: Gluster Arbiter Volume
-feature_modules: all
-feature_status: Inception
 ---
 
 # Gluster Arbiter Volume

--- a/source/develop/release-management/features/gluster/gluster-dashboard.md
+++ b/source/develop/release-management/features/gluster/gluster-dashboard.md
@@ -1,9 +1,7 @@
 ---
 title: Gluster Dashboard
 authors: rnahcimu
-feature_name: Gluster Dashboard
-feature_modules: UI PLugin
-feature_status: In Progress
+category: feature
 ---
 
 # Gluster Dashboard

--- a/source/develop/release-management/features/gluster/gluster-dr.md
+++ b/source/develop/release-management/features/gluster/gluster-dr.md
@@ -2,9 +2,6 @@
 title: Disaster Recovery for Gluster based storage domains
 category: feature
 authors: Sahina Bose
-feature_name: Disaster recovery for gluster storage domains
-feature_modules: engine,gluster,geo-replication,storage
-feature_status: Design
 ---
 
 # Disaster Recovery for Gluster based storage domains

--- a/source/develop/release-management/features/gluster/gluster-geo-replication.md
+++ b/source/develop/release-management/features/gluster/gluster-geo-replication.md
@@ -2,9 +2,6 @@
 title: Gluster Geo Replication
 category: feature
 authors: kmayilsa, sahina, sandrobonazzola, shtripat
-feature_name: Geo replication
-feature_modules: engine,gluster
-feature_status: Completed
 ---
 
 # Gluster Geo Replication

--- a/source/develop/release-management/features/gluster/gluster-hooks-management.md
+++ b/source/develop/release-management/features/gluster/gluster-hooks-management.md
@@ -2,9 +2,6 @@
 title: Gluster Hooks Management
 category: feature
 authors: kmayilsa, prasanth, sahina, shireesh, Gobinda Das
-feature_name: Gluster Hooks management
-feature_modules: engine,gluster
-feature_status: Released
 ---
 
 # Gluster Hooks Management

--- a/source/develop/release-management/features/gluster/gluster-import-existing-cluster.md
+++ b/source/develop/release-management/features/gluster/gluster-import-existing-cluster.md
@@ -2,9 +2,6 @@
 title: Gluster Import Existing Cluster
 category: feature
 authors: kmayilsa, sahina
-feature_name: Import cluster
-feature_modules: engine,gluster
-feature_status: Released
 ---
 
 # Gluster Import Existing Cluster

--- a/source/develop/release-management/features/gluster/gluster-multiple-bricks-per-storage.md
+++ b/source/develop/release-management/features/gluster/gluster-multiple-bricks-per-storage.md
@@ -2,9 +2,6 @@
 title: Support for multiple GlusterFS bricks on a block device(s)
 category: feature
 authors: dchaplyg
-feature_name: Support for multiple GlusterFS bricks on a block device(s)
-feature_modules: engine/vdsm
-feature_status: Planning
 ---
 
 # Support for multiple GlusterFS bricks on a block device(s)

--- a/source/develop/release-management/features/gluster/gluster-reset-brick-support.md
+++ b/source/develop/release-management/features/gluster/gluster-reset-brick-support.md
@@ -2,9 +2,6 @@
 title: Support reset brick
 category: feature
 authors: godas
-feature_name: Gluster management
-feature_modules: engine,gluster
-feature_status: Completed
 ---
 
 # Gluster Support

--- a/source/develop/release-management/features/gluster/gluster-self-heal-monitoring.md
+++ b/source/develop/release-management/features/gluster/gluster-self-heal-monitoring.md
@@ -2,9 +2,6 @@
 title: Gluster Self-Heal Monitoring
 category: feature
 authors: rnachimu
-feature_name: Gluster Self-Heal Monitoring
-feature_modules: Gluster
-feature_status: WIP
 ---
 
 # Gluster Self Heal Monitoring

--- a/source/develop/release-management/features/gluster/gluster-support.md
+++ b/source/develop/release-management/features/gluster/gluster-support.md
@@ -2,9 +2,6 @@
 title: Gluster Support
 category: feature
 authors: ekohl, rmiddle, sahina, sandrobonazzola, shireesh
-feature_name: Gluster management
-feature_modules: engine,gluster
-feature_status: Completed
 ---
 
 # Gluster Support

--- a/source/develop/release-management/features/gluster/gluster-sync-configuration-with-cli.md
+++ b/source/develop/release-management/features/gluster/gluster-sync-configuration-with-cli.md
@@ -2,10 +2,6 @@
 title: Gluster Sync Configuration With CLI
 category: feature
 authors: kmayilsa, shireesh
-feature_name: Sync Gluster configuration with CLI
-feature_modules: api,engine,vdsm, gluster
-feature_status: Completed
-
 ---
 
 # Gluster Sync Configuration With CLI

--- a/source/develop/release-management/features/gluster/gluster-volume-asynchronous-tasks-management.md
+++ b/source/develop/release-management/features/gluster/gluster-volume-asynchronous-tasks-management.md
@@ -2,9 +2,6 @@
 title: Gluster Volume Asynchronous Tasks Management
 category: feature
 authors: dusmant, kmayilsa, sahina, shireesh
-feature_name: Gluster tasks management
-feature_modules: engine,gluster
-feature_status: Completed
 ---
 
 # Gluster Volume Asynchronous Tasks Management

--- a/source/develop/release-management/features/gluster/gluster-volume-capacity.md
+++ b/source/develop/release-management/features/gluster/gluster-volume-capacity.md
@@ -2,9 +2,6 @@
 title: Gluster Volume Capacity
 category: feature
 authors: anmol babu, rnahcimu, sahina, shtripat
-feature_name: Gluster Volume Capacity
-feature_modules: api,engine,vdsm, gluster
-feature_status: Completed
 
 ---
 

--- a/source/develop/release-management/features/gluster/gluster-volume-performance-statistics.md
+++ b/source/develop/release-management/features/gluster/gluster-volume-performance-statistics.md
@@ -2,10 +2,6 @@
 title: Gluster Volume Performance Statistics
 category: feature
 authors: kmayilsa, sahina
-feature_name: Gluster Volume Performance Statistics
-feature_modules: api,engine,gluster,vdsm
-feature_status: Completed
-
 ---
 
 # Gluster Volume Performance Statistics

--- a/source/develop/release-management/features/gluster/glusterbricklvmcache.md
+++ b/source/develop/release-management/features/gluster/glusterbricklvmcache.md
@@ -2,8 +2,6 @@
 title: LVMCache configuration for gluster brick provisioning
 category: feature
 authors: dchaplyg, sabose
-feature_name: LVMCache configuration for gluster brick provisioning
-feature_modules: engine,gluster
 ---
 
 # LVMCache configuration for gluster brick provisioning

--- a/source/develop/release-management/features/gluster/glusterfs-hyperconvergence.md
+++ b/source/develop/release-management/features/gluster/glusterfs-hyperconvergence.md
@@ -1,9 +1,7 @@
 ---
 title: GlusterFS-Hyperconvergence
 authors: fsimonce,sabose
-feature_name: GlusterFS Hyperconvergence
-feature_modules: engine,gluster
-feature_status: In Progress
+category: feature
 ---
 
 # GlusterFS Hyperconvergence

--- a/source/develop/release-management/features/gluster/glusterhostdiskmanagement.md
+++ b/source/develop/release-management/features/gluster/glusterhostdiskmanagement.md
@@ -2,9 +2,6 @@
 title: GlusterHostDiskManagement
 category: feature
 authors: bala, rnahcimu, sahina, sandrobonazzola
-feature_name: Host Device Management
-feature_modules: engine,gluster
-feature_status: Completed
 ---
 
 # Gluster Host Disk Management

--- a/source/develop/release-management/features/gluster/glustervolumequota.md
+++ b/source/develop/release-management/features/gluster/glustervolumequota.md
@@ -2,9 +2,6 @@
 title: GlusterVolumeQuota
 category: feature
 authors: shtripat
-feature_name: Gluster Volume Quota
-feature_modules: engine
-feature_status: Not Started
 ---
 
 # Gluster Volume Quota

--- a/source/develop/release-management/features/gluster/glustervolumesnapshots.md
+++ b/source/develop/release-management/features/gluster/glustervolumesnapshots.md
@@ -2,9 +2,6 @@
 title: GlusterVolumeSnapshots
 category: feature
 authors: sandrobonazzola, shtripat
-feature_name: Gluster Volume Snapshot
-feature_modules: engine
-feature_status: Inception
 ---
 
 # Gluster Volume Snapshot

--- a/source/develop/release-management/features/gluster/select-network-for-gluster.md
+++ b/source/develop/release-management/features/gluster/select-network-for-gluster.md
@@ -2,9 +2,6 @@
 title: Select Network For Gluster
 category: feature
 authors: danken, sahina, sandrobonazzola
-feature_name: Select Network for Gluster traffic
-feature_modules: engine,gluster
-feature_status: Done
 ---
 
 # Select Network For Gluster

--- a/source/develop/release-management/features/infra/Engine_vacuum.md
+++ b/source/develop/release-management/features/infra/Engine_vacuum.md
@@ -2,9 +2,6 @@
 title: Engine Vacuum Tool
 category: feature
 authors: rgolan@redhat.com
-feature_name: Engine Vacuum Tool
-feature_status: complete, merged Dec 2016
-last_update: Jan 17, 2017
 ---
 
 # Engine Vacuum

--- a/source/develop/release-management/features/infra/aaa-jdbc.md
+++ b/source/develop/release-management/features/infra/aaa-jdbc.md
@@ -2,9 +2,6 @@
 title: AAA JDBC
 category: feature
 authors: alonbl, moolit, mperina, rmohr
-feature_name: AAA_JDBC
-feature_modules: engine, extension
-feature_status: FINISHED
 ---
 
 # AAA JDBC

--- a/source/develop/release-management/features/infra/aaa_faq.md
+++ b/source/develop/release-management/features/infra/aaa_faq.md
@@ -2,9 +2,6 @@
 title: AAA FAQ
 category: feature
 authors: omachace, mperina
-feature_name: AAA Frequently asked questions
-feature_modules: ovirt-engine-extensions-aaa
-feature_status: Verified
 ---
 
 # AAA Frequently asked questions

--- a/source/develop/release-management/features/infra/ansible_modules.md
+++ b/source/develop/release-management/features/infra/ansible_modules.md
@@ -2,8 +2,6 @@
 title: Ansible oVirt modules
 category: feature
 authors: omachace
-feature_name: Ansible oVirt modules
-feature_status: Released
 ---
 
 ### Summary

--- a/source/develop/release-management/features/infra/api.md
+++ b/source/develop/release-management/features/infra/api.md
@@ -1,6 +1,6 @@
 ---
 title: Api
-category: api
+category: feature
 authors: michael pasternak
 ---
 

--- a/source/develop/release-management/features/infra/backupawareness.md
+++ b/source/develop/release-management/features/infra/backupawareness.md
@@ -2,9 +2,6 @@
 title: BackupAwareness
 category: feature
 authors: didi, doron, emesika, sandrobonazzola
-feature_name: Adding Backup Awareness to oVirt
-feature_modules: engine
-feature_status: Partially implemented
 ---
 
 # Backup Awareness

--- a/source/develop/release-management/features/infra/cli.md
+++ b/source/develop/release-management/features/infra/cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI
-category: cli
+category: feature
 authors: j.bittner, jfenal, mgoldboi, michael pasternak, tsaban, val0x00ff
 ---
 

--- a/source/develop/release-management/features/infra/command-coordinator-flows-and-events.md
+++ b/source/develop/release-management/features/infra/command-coordinator-flows-and-events.md
@@ -2,9 +2,6 @@
 title: CommandCoordinator Flows and Events
 category: feature
 authors: masayag, laravot
-feature_name: CommandCoordinator Framework Enhancements to Support Flows and Events
-feature_modules: engine
-feature_status: In Progress
 ---
 
 # CommandCoordinator Flows and Events

--- a/source/develop/release-management/features/infra/commandcoordinator.md
+++ b/source/develop/release-management/features/infra/commandcoordinator.md
@@ -2,10 +2,6 @@
 title: CommandCoordinator
 category: feature
 authors: moti, rnori
-feature_name: Introduce CommandCoordinator Framework and Ability To Persist Commands
-  in Database
-feature_modules: engine
-feature_status: Completed
 ---
 
 # Command Coordinator

--- a/source/develop/release-management/features/infra/detailedexternalevents.md
+++ b/source/develop/release-management/features/infra/detailedexternalevents.md
@@ -1,6 +1,6 @@
 ---
 title: DetailedExternalEvents
-category: event
+category: feature
 authors: emesika, yair zaslavsky
 ---
 

--- a/source/develop/release-management/features/infra/engine-nic-health-check.md
+++ b/source/develop/release-management/features/infra/engine-nic-health-check.md
@@ -1,9 +1,7 @@
 ---
 title: engine NIC health check
 authors: mmucha
-feature_name: Engine NIC health check
-feature_modules: engine,network
-feature_status: To be Released
+category: feature
 ---
 
 # Engine NIC health check

--- a/source/develop/release-management/features/infra/engine-snmp3.md
+++ b/source/develop/release-management/features/infra/engine-snmp3.md
@@ -2,9 +2,6 @@
 title: SNMPv3
 category: feature
 authors: rnori
-feature_name: Add support to send SNMPv3 traps from notifier
-feature_modules: engine
-feature_status: In Development
 ---
 # engine-snmp
 

--- a/source/develop/release-management/features/infra/events.md
+++ b/source/develop/release-management/features/infra/events.md
@@ -1,10 +1,7 @@
 ---
 title: Events
-category: event
+category: feature
 authors: ovedo, pkliczewski
-feature_name: Event mechanism to send events from the host to the engine
-feature_modules: vdsm, engine
-feature_status: ON_QA
 ---
 
 # Event processing built on top of JSON-RPC

--- a/source/develop/release-management/features/infra/externalevents.md
+++ b/source/develop/release-management/features/infra/externalevents.md
@@ -1,6 +1,6 @@
 ---
 title: ExternalEvents
-category: event
+category: feature
 authors: emesika, mkenneth
 ---
 

--- a/source/develop/release-management/features/infra/fencing-refactoring.md
+++ b/source/develop/release-management/features/infra/fencing-refactoring.md
@@ -2,9 +2,6 @@
 title: Fencing refactoring
 category: feature
 authors: mperina, sandrobonazzola
-feature_name: Fencing refactoring
-feature_modules: engine
-feature_status: Design
 ---
 
 # Fencing refactoring

--- a/source/develop/release-management/features/infra/inclusterupgrade.md
+++ b/source/develop/release-management/features/infra/inclusterupgrade.md
@@ -1,9 +1,7 @@
 ---
 title: InClusterUpgrade
 authors: rmohr
-feature_name: In Cluster Upgrade
-feature_modules: engine
-feature_status: Completed. Since 3.6.6
+category: feature
 ---
 
 # InClusterUpgrade

--- a/source/develop/release-management/features/infra/java-sdk.md
+++ b/source/develop/release-management/features/infra/java-sdk.md
@@ -1,6 +1,6 @@
 ---
 title: Java-sdk
-category: sdk
+category: feature
 authors: adahms, michael pasternak, moti
 ---
 

--- a/source/develop/release-management/features/infra/jsonrpc.md
+++ b/source/develop/release-management/features/infra/jsonrpc.md
@@ -2,10 +2,6 @@
 title: JsonRpc
 category: feature
 authors: adahms, apuimedo, pkliczewski, sandrobonazzola, smizrahi, ybronhei
-feature_name: Introduce Messaged communication to VDSM using JSON-RPC on top of various
-  transport protocols
-feature_modules: vdsm, engine
-feature_status: In Development
 ---
 
 # Json Rpc

--- a/source/develop/release-management/features/infra/jsonrpc3.5.md
+++ b/source/develop/release-management/features/infra/jsonrpc3.5.md
@@ -1,9 +1,7 @@
 ---
 title: JSON RPC 3.5
-feature_name: JSON RPC 3.5
-feature_modules: engine, vdsm
-feature_status: Released in oVirt 3.5
 authors: pkliczewski
+category: feature
 ---
 
 # Json Rpc 3.5

--- a/source/develop/release-management/features/infra/katellointegration.md
+++ b/source/develop/release-management/features/infra/katellointegration.md
@@ -2,9 +2,6 @@
 title: KatelloIntegration
 category: feature
 authors: gshereme, moti
-feature_name: Katello Integration
-feature_modules: engine
-feature_status: Done
 ---
 
 # Katello Integration

--- a/source/develop/release-management/features/infra/link-following.md
+++ b/source/develop/release-management/features/infra/link-following.md
@@ -2,9 +2,6 @@
 title: API Link Following
 category: feature
 authors: oliel
-feature_name: Link Following
-feature_modules: api (engine)
-feature_status: Released
 ---
 
 ## Feature Name

--- a/source/develop/release-management/features/infra/python-sdk.md
+++ b/source/develop/release-management/features/infra/python-sdk.md
@@ -1,6 +1,6 @@
 ---
 title: Python-sdk
-category: sdk
+category: feature
 authors: adahms, bproffitt, michael pasternak
 ---
 

--- a/source/develop/release-management/features/infra/python3-compatibility.md
+++ b/source/develop/release-management/features/infra/python3-compatibility.md
@@ -1,6 +1,6 @@
 ---
 title: Vdsm python3 compatibility
-category: vdsm
+category: feature
 authors: apuimedo, danken, vfeenstr
 ---
 

--- a/source/develop/release-management/features/infra/rsdl.md
+++ b/source/develop/release-management/features/infra/rsdl.md
@@ -1,6 +1,6 @@
 ---
 title: RSDL
-category: api
+category: feature
 authors: michael pasternak
 toc: true
 ---

--- a/source/develop/release-management/features/infra/serial-execution-of-asynchronous-tasks.md
+++ b/source/develop/release-management/features/infra/serial-execution-of-asynchronous-tasks.md
@@ -2,9 +2,6 @@
 title: Serial Execution of Asynchronous Tasks
 category: feature
 authors: amureini
-feature_name: Serial Execution of Asynchronous Tasks
-feature_modules: engine
-feature_status: Removed in 4.1
 ---
 
 # Serial Execution of Asynchronous Tasks Detailed Design

--- a/source/develop/release-management/features/infra/supervdsm-service.md
+++ b/source/develop/release-management/features/infra/supervdsm-service.md
@@ -1,6 +1,6 @@
 ---
 title: Supervdsm service
-category: vdsm
+category: feature
 authors: lvroyce, ybronhei
 ---
 

--- a/source/develop/release-management/features/infra/taskmanagercanceltask.md
+++ b/source/develop/release-management/features/infra/taskmanagercanceltask.md
@@ -1,6 +1,6 @@
 ---
 title: TaskManagerCancelTask
-category: template
+category: feature
 authors: mkublin
 ---
 

--- a/source/develop/release-management/features/infra/upgrademanager.md
+++ b/source/develop/release-management/features/infra/upgrademanager.md
@@ -1,9 +1,7 @@
 ---
 title: UpgradeManager
 authors: moti, ovedo
-feature_name: Upgrade Manager
-feature_modules: engine,infra
-feature_status: Released in oVirt 3.6
+category: features
 ---
 
 # Upgrade Manager

--- a/source/develop/release-management/features/infra/user-portal-permissions.md
+++ b/source/develop/release-management/features/infra/user-portal-permissions.md
@@ -2,9 +2,6 @@
 title: User Portal Permissions
 category: feature
 authors: amureini, ekohl, lpeer, ovedo
-feature_name: User Portal Permissions
-feature_status: Released in oVirt 3.1
-feature_modules: engine
 ---
 
 # User Portal Permissions

--- a/source/develop/release-management/features/integration/allinone.md
+++ b/source/develop/release-management/features/integration/allinone.md
@@ -2,9 +2,6 @@
 title: AllInOne
 category: feature
 authors: acathrow, alourie, didi, dneary, jbrooks, netbulae, oschreib, sandrobonazzola
-feature_name: All in One
-feature_modules: engine,node
-feature_status: Removed
 ---
 
 # All in One

--- a/source/develop/release-management/features/integration/cockpit.md
+++ b/source/develop/release-management/features/integration/cockpit.md
@@ -2,9 +2,6 @@
 title: CockpitOvirtPlugin
 category: feature
 authors: mlibra
-feature_name: Cockpit-oVirt Plugin
-feature_modules: engine
-feature_status: WIP, 4.0 proposed feature
 ---
 
 # Proposed Feature 4.0: Cockpit-oVirt Plugin

--- a/source/develop/release-management/features/integration/container-support.md
+++ b/source/develop/release-management/features/integration/container-support.md
@@ -2,9 +2,6 @@
 title: Container support
 category: feature
 authors: fromani
-feature_name: Container support
-feature_modules: vdsm, engine?
-feature_status: Planning
 ---
 
 # Container support

--- a/source/develop/release-management/features/integration/engine-backup.md
+++ b/source/develop/release-management/features/integration/engine-backup.md
@@ -2,9 +2,6 @@
 title: oVirt-engine-backup
 category: feature
 authors: bobdrad, bproffitt, didi, emesika, mlipchuk, oschreib
-feature_name: Ovirt-engine-backup
-feature_modules: utils
-feature_status: Released
 ---
 
 # oVirt-engine-backup

--- a/source/develop/release-management/features/integration/engine-cleanup.md
+++ b/source/develop/release-management/features/integration/engine-cleanup.md
@@ -2,9 +2,6 @@
 title: engine-cleanup
 category: feature
 authors: herrold, simong
-feature_name: Engine
-feature_modules: "[nil]"
-feature_status: Partial
 ---
 
 # engine-cleanup

--- a/source/develop/release-management/features/integration/fedora-22-support.md
+++ b/source/develop/release-management/features/integration/fedora-22-support.md
@@ -2,9 +2,6 @@
 title: Fedora 22 Support
 category: feature
 authors: sandrobonazzola
-feature_name: Fedora 22 Support
-feature_modules: all
-feature_status: Delivered in oVirt 3.6
 ---
 
 # Fedora 22 Support

--- a/source/develop/release-management/features/integration/fedora-24-support.md
+++ b/source/develop/release-management/features/integration/fedora-24-support.md
@@ -2,9 +2,6 @@
 title: Fedora 24 Support
 category: feature
 authors: sandrobonazzola
-feature_name: Fedora 24 Support
-feature_modules: all
-feature_status: Delivered in oVirt 4.0
 ---
 
 # Fedora 24 Support

--- a/source/develop/release-management/features/integration/heapplianceflow.md
+++ b/source/develop/release-management/features/integration/heapplianceflow.md
@@ -2,9 +2,6 @@
 title: HEApplianceFlow
 category: feature
 authors: stirabos
-feature_name: oVirt hosted-engine appliance flow
-feature_modules: hosted-engine
-feature_status: WIP
 ---
 
 # HE Appliance Flow

--- a/source/develop/release-management/features/integration/otopi-infra-migration.md
+++ b/source/develop/release-management/features/integration/otopi-infra-migration.md
@@ -1,6 +1,6 @@
 ---
 title: Otopi Infra Migration
-category: infra
+category: feature
 authors: alonbl, alourie, sandrobonazzola
 ---
 

--- a/source/develop/release-management/features/integration/ovirtappliance.md
+++ b/source/develop/release-management/features/integration/ovirtappliance.md
@@ -2,9 +2,6 @@
 title: oVirtAppliance
 category: feature
 authors: didi, doron, fabiand, mgoldboi, obasan
-feature_name: oVirt Appliance
-feature_modules: node
-feature_status: Done
 ---
 
 # oVirt Appliance

--- a/source/develop/release-management/features/integration/separate-dwh-host.md
+++ b/source/develop/release-management/features/integration/separate-dwh-host.md
@@ -2,9 +2,6 @@
 title: Separate-DWH-Host
 category: feature
 authors: didi, sandrobonazzola, sradco
-feature_name: Separate DWH Host
-feature_modules: engine
-feature_status: Released
 ---
 
 # Separate DWH Host

--- a/source/develop/release-management/features/integration/websocketproxy-on-a-separate-host.md
+++ b/source/develop/release-management/features/integration/websocketproxy-on-a-separate-host.md
@@ -2,9 +2,6 @@
 title: WebSocketProxy on a separate host
 category: feature
 authors: sandrobonazzola, stirabos
-feature_name: WebSocketProxy on a separate host
-feature_modules: websocket-proxy
-feature_status: completed
 ---
 
 # WebSocketProxy on a separate host

--- a/source/develop/release-management/features/integration/windows-guest-tools.md
+++ b/source/develop/release-management/features/integration/windows-guest-tools.md
@@ -2,9 +2,6 @@
 title: oVirt Windows Guest Tools
 category: feature
 authors: lveyde, mpavlik, sandrobonazzola
-feature_name: oVirt Windows Guest Tools ISO
-feature_modules: engine
-feature_status: Removed
 ---
 
 # oVirt Windows Guest Tools ISO

--- a/source/develop/release-management/features/network/allowExplicitDnsConfiguration.md
+++ b/source/develop/release-management/features/network/allowExplicitDnsConfiguration.md
@@ -2,14 +2,11 @@
 title: AllowExplicitDnsConfiguration
 category: feature
 authors: mmucha
-feature_name: Allow Explicit Dns Configuration
-feature_modules: Networking
-feature_status: Design
-rfe: https://bugzilla.redhat.com/show_bug.cgi?id=1160667
-
 ---
 
 # Allow Explicit DNS Configuration
+
+rfe: https://bugzilla.redhat.com/show_bug.cgi?id=1160667
 
 ### Owner
 

--- a/source/develop/release-management/features/network/apidatacenternetworks.md
+++ b/source/develop/release-management/features/network/apidatacenternetworks.md
@@ -1,10 +1,7 @@
 ---
 title: ApiDataCenterNetworks
-category: api
+category: feature
 authors: rnori
-feature_name: Api Data Center Networks
-feature_modules: engine,api
-feature_status: ON_QA
 ---
 
 # Api Data Center Networks

--- a/source/develop/release-management/features/network/arbitraryvlandevicename.md
+++ b/source/develop/release-management/features/network/arbitraryvlandevicename.md
@@ -2,9 +2,6 @@
 title: ArbitraryVlanDeviceName
 category: feature
 authors: alkaplan
-feature_name: Arbitrary VLAN Device Name
-feature_modules: engine
-feature_status: Released in oVirt 3.5
 ---
 
 # Arbitrary VLAN Device Name

--- a/source/develop/release-management/features/network/autodefine-external-network.md
+++ b/source/develop/release-management/features/network/autodefine-external-network.md
@@ -2,9 +2,6 @@
 title: Autodefine External Network
 category: feature
 authors: Ales Musil
-feature_name: Autodefine External Network
-feature_modules: engine
-feature_status: In Development
 ---
 
 # Autodefine External Network

--- a/source/develop/release-management/features/network/bridgeless-networks.md
+++ b/source/develop/release-management/features/network/bridgeless-networks.md
@@ -2,9 +2,6 @@
 title: Bridgeless Networks
 category: feature
 authors: adrian15, danken, roy, ykaul
-feature_name: Bridgeless Networks
-feature_modules: engine
-feature_status: Released
 ---
 
 # Bridgeless Networks

--- a/source/develop/release-management/features/network/copy-host-networking.html.md
+++ b/source/develop/release-management/features/network/copy-host-networking.html.md
@@ -2,9 +2,6 @@
 title: Copy Host Networking
 category: feature
 authors: Ales Musil
-feature_name: Copy Host Networking
-feature_modules: copy-host-networking
-feature_status: In Development
 ---
 
 # Copy Host Networking

--- a/source/develop/release-management/features/network/cumulative-rx-tx-statistics.md
+++ b/source/develop/release-management/features/network/cumulative-rx-tx-statistics.md
@@ -2,9 +2,6 @@
 title: Cumulative RX TX Statistics
 category: feature
 authors: danken, lvernia
-feature_name: Cumulative Network Usage Statistics
-feature_modules: engine,vdsm
-feature_status: Done
 ---
 
 # Cumulative Network Usage Statistics

--- a/source/develop/release-management/features/network/detailed-host-network-qos.md
+++ b/source/develop/release-management/features/network/detailed-host-network-qos.md
@@ -2,9 +2,6 @@
 title: Detailed Host Network QoS
 category: feature
 authors: amuller, apuimedo, danken, lvernia
-feature_name: Host Network QoS
-feature_modules: engine,vdsm, api
-feature_status: Implementation
 ---
 
 # Detailed Host Network QoS

--- a/source/develop/release-management/features/network/detailed-osn-integration.md
+++ b/source/develop/release-management/features/network/detailed-osn-integration.md
@@ -1,6 +1,6 @@
 ---
 title: Detailed OSN Integration
-category: detailedfeature
+category: feature
 authors: danken, lvernia, mkolesni, moti, mpavlik
 ---
 

--- a/source/develop/release-management/features/network/detailedhostnetworkingapi.md
+++ b/source/develop/release-management/features/network/detailedhostnetworkingapi.md
@@ -1,10 +1,7 @@
 ---
 title: DetailedHostNetworkingApi
-category: api
+category: feature
 authors: mmucha, moti, sandrobonazzola
-feature_name: Host Networking API
-feature_modules: Networking
-feature_status: Design
 ---
 
 # Detailed Host Networking Api

--- a/source/develop/release-management/features/network/detailedmanagementnetworkasarole.md
+++ b/source/develop/release-management/features/network/detailedmanagementnetworkasarole.md
@@ -1,10 +1,7 @@
 ---
 title: DetailedManagementNetworkAsARole
-category: detailedfeature
+category: feature
 authors: yevgenyz
-feature_name: Management network as a role - Detailed
-feature_modules: Networking
-feature_status: WIP
 ---
 
 # Detailed Management Network As A Role

--- a/source/develop/release-management/features/network/detailednetworklinking.md
+++ b/source/develop/release-management/features/network/detailednetworklinking.md
@@ -1,6 +1,6 @@
 ---
 title: DetailedNetworkLinking
-category: template
+category: feature
 authors: alkaplan, apuimedo, danken, lpeer, moti
 ---
 

--- a/source/develop/release-management/features/network/detailedreportingvnicinformation.md
+++ b/source/develop/release-management/features/network/detailedreportingvnicinformation.md
@@ -1,6 +1,6 @@
 ---
 title: DetailedReportingVnicInformation
-category: template
+category: feature
 authors: moti
 ---
 

--- a/source/develop/release-management/features/network/ethtool-options.md
+++ b/source/develop/release-management/features/network/ethtool-options.md
@@ -2,9 +2,6 @@
 title: Ethtool options
 category: feature
 authors: apuimedo, danken
-feature_name: Device ethtool options
-feature_modules: engine,network,vdsm
-feature_status: To be Released
 ---
 
 # Ethtool options

--- a/source/develop/release-management/features/network/external-network-provider.md
+++ b/source/develop/release-management/features/network/external-network-provider.md
@@ -2,9 +2,6 @@
 title: External Network Providers
 category: feature
 authors: mmirecki
-feature_name: External Network Providers
-feature_modules: engine,vdsm
-feature_status: In Development
 ---
 
 # External Network Providers

--- a/source/develop/release-management/features/network/get-route.md
+++ b/source/develop/release-management/features/network/get-route.md
@@ -2,9 +2,6 @@
 title: Get Route
 category: feature
 authors: lvernia, phoracek
-feature_name: Get Route
-feature_modules: engine, api
-feature_status: Proposed
 ---
 
 # Get Route

--- a/source/develop/release-management/features/network/host-network-qos.md
+++ b/source/develop/release-management/features/network/host-network-qos.md
@@ -2,9 +2,6 @@
 title: Host Network QoS
 category: feature
 authors: amuller, danken, gvallarelli, lvernia
-feature_name: Host Network QoS
-feature_modules: engine,vdsm, api
-feature_status: Implementation
 ---
 
 # Host Network QoS

--- a/source/develop/release-management/features/network/hostnetworkingapi.md
+++ b/source/develop/release-management/features/network/hostnetworkingapi.md
@@ -1,10 +1,7 @@
 ---
 title: HostNetworkingApi
-category: api
+category: feature
 authors: danken, mmucha, moti, sandrobonazzola
-feature_name: Host Networking API
-feature_modules: Networking
-feature_status: Design
 ---
 
 # Host Networking Api

--- a/source/develop/release-management/features/network/hotplugnic.md
+++ b/source/develop/release-management/features/network/hotplugnic.md
@@ -2,9 +2,6 @@
 title: HotplugNic
 category: feature
 authors: danken, ekohl, ilvovsky, moti
-feature_name: Hotplug/Hotunplug of Network Interface Cards
-feature_modules: vdsm,engine,api
-feature_status: Released
 ---
 
 # Hotplug Nic

--- a/source/develop/release-management/features/network/import-vm-net-changes-2.md
+++ b/source/develop/release-management/features/network/import-vm-net-changes-2.md
@@ -2,9 +2,6 @@
 title: Expand vNic profile mapping options for VM import from Storage Domain via REST API
 category: feature
 authors: eraviv
-feature_name: Expand vNic profile mapping options for VM import from Storage Domain via REST API
-feature_modules: engine backend/api-model
-feature_status: release 4.2
 ---
 
 # Expand vNic profile mapping options for VM import from Storage Domain via REST API

--- a/source/develop/release-management/features/network/import-vm-net-changes.md
+++ b/source/develop/release-management/features/network/import-vm-net-changes.md
@@ -2,9 +2,6 @@
 title: Change network information in VM import
 category: feature
 authors: yevgenyz
-feature_name: Change network information in VM import
-feature_modules: engine/api-model
-feature_status: Work in progress for oVirt 4.1
 ---
 
 # Change network information in VM import

--- a/source/develop/release-management/features/network/ipv6_subnets.md
+++ b/source/develop/release-management/features/network/ipv6_subnets.md
@@ -2,9 +2,6 @@
 title: IPv6 subnets on ovirt-provider-ovn
 category: feature
 authors: mdbarroso
-feature_name: Support IPv6 subnets on ovirt-provider-ovn
-feature_modules: ovirt-provider-ovn
-feature_status: In Development
 ---
 
 # IPv6 subnets on ovirt-provider-ovn

--- a/source/develop/release-management/features/network/isolated-ports.md
+++ b/source/develop/release-management/features/network/isolated-ports.md
@@ -2,9 +2,6 @@
 title: Isolated ports
 category: feature
 authors: dholler
-feature_name: Isolated ports
-feature_modules: engine,network
-feature_status: In Development
 ---
 
 # Isolated ports

--- a/source/develop/release-management/features/network/isolatednetworks.md
+++ b/source/develop/release-management/features/network/isolatednetworks.md
@@ -2,9 +2,6 @@
 title: IsolatedNetworks
 category: feature
 authors: moti, sandrobonazzola
-feature_name: Isolated Network
-feature_modules: Networking
-feature_status: Design
 ---
 
 # Isolated Networks

--- a/source/develop/release-management/features/network/liveMigrationSupportForSRIOV.md
+++ b/source/develop/release-management/features/network/liveMigrationSupportForSRIOV.md
@@ -2,15 +2,12 @@
 title: LiveMigrationSupportForSRIOV
 category: feature
 authors: mmucha
-feature_name: Live Migration Support For SRIOV
-feature_modules: Networking
-feature_status: Design
-rfe: https://bugzilla.redhat.com/show_bug.cgi?id=868811
-
 ---
 
 
 # Live Migration Support For SRIOV
+
+rfe: https://bugzilla.redhat.com/show_bug.cgi?id=868811
 
 ### Owner
 

--- a/source/develop/release-management/features/network/lldp.md
+++ b/source/develop/release-management/features/network/lldp.md
@@ -2,10 +2,6 @@
 title: Link Layer Discovery Protocol (LLDP) Support
 category: feature
 authors: Dominik Holler
-category: feature
-feature_name: Link Layer Discovery Protocol (LLDP) Support
-feature_modules: engine,network,vdsm,rest-api
-feature_status: Released
 ---
 
 # Link Layer Discovery Protocol (LLDP) Support

--- a/source/develop/release-management/features/network/managed_mtu_for_vm_networks.md
+++ b/source/develop/release-management/features/network/managed_mtu_for_vm_networks.md
@@ -2,9 +2,6 @@
 title: Managed MTU for VM Networks
 category: feature
 authors: dholler
-feature_name: Managed MTU for VM Networks
-feature_modules: engine,provider-ovn
-feature_status: In Development
 ---
 
 # Managed MTU for VM Networks

--- a/source/develop/release-management/features/network/manageiq_ovn.md
+++ b/source/develop/release-management/features/network/manageiq_ovn.md
@@ -2,9 +2,6 @@
 title: Integrating OVN with ManageIQ
 category: feature
 authors: Alona Kaplan
-feature_name: Integrating OVN to ManageIQ
-feature_modules: manageiq_providers_ovirt - infra_manager, network_manager, manageiq-ui-classic - network related controllers
-feature_status: In Development
 ---
 
 # Integrating OVN to ManageIQ

--- a/source/develop/release-management/features/network/management-network-as-a-role.md
+++ b/source/develop/release-management/features/network/management-network-as-a-role.md
@@ -2,9 +2,6 @@
 title: Management Network As A Role
 category: feature
 authors: danken, moti, sandrobonazzola, yevgenyz
-feature_name: Management network as a role
-feature_modules: Networking
-feature_status: design
 ---
 
 # Management Network As A Role

--- a/source/develop/release-management/features/network/mangeiqOvn.md
+++ b/source/develop/release-management/features/network/mangeiqOvn.md
@@ -2,9 +2,6 @@
 title: Integrating OVN to ManageIq
 category: feature
 authors: Alona Kaplan
-feature_name: Integrating OVN to ManageIq
-feature_modules: manageiq_providers_ovirt- infra_manager, network_namager, manageiq-ui-classic- network related controllers
-feature_status: In Development
 ---
 
 # Integrating OVN to ManageIq

--- a/source/develop/release-management/features/network/network-custom-properties.md
+++ b/source/develop/release-management/features/network/network-custom-properties.md
@@ -2,9 +2,6 @@
 title: Network Custom Properties
 category: feature
 authors: apuimedo, danken, lvernia, sandrobonazzola
-feature_name: Network Custom Properties
-feature_modules: engine,network,vdsm
-feature_status: To be Released
 ---
 
 # Network Custom Properties

--- a/source/develop/release-management/features/network/network-qos-detailed-design.md
+++ b/source/develop/release-management/features/network/network-qos-detailed-design.md
@@ -1,6 +1,6 @@
 ---
 title: Network QoS - detailed design
-category: sla
+category: feature
 authors: lhornyak, ofri
 ---
 

--- a/source/develop/release-management/features/network/networkfilter.md
+++ b/source/develop/release-management/features/network/networkfilter.md
@@ -2,9 +2,6 @@
 title: NetworkFilter
 category: feature
 authors: elevi
-feature_name: Network filter
-feature_modules: engine,network
-feature_status: new
 ---
 
 # Network Filter

--- a/source/develop/release-management/features/network/networkfiltering.md
+++ b/source/develop/release-management/features/network/networkfiltering.md
@@ -1,6 +1,6 @@
 ---
 title: NetworkFiltering
-category: template
+category: feature
 authors: lpeer, moti
 ---
 

--- a/source/develop/release-management/features/network/networkfilterparameters.md
+++ b/source/develop/release-management/features/network/networkfilterparameters.md
@@ -2,9 +2,6 @@
 title: Network Filter Parameters
 category: feature
 authors: dholler
-feature_name: Network Filter Parameters
-feature_modules: engine,vdsm
-feature_status: In Development
 ---
 
 # Network Filter Parameters

--- a/source/develop/release-management/features/network/networking-api-security-groups.md
+++ b/source/develop/release-management/features/network/networking-api-security-groups.md
@@ -2,9 +2,6 @@
 title: ovirt-provider-ovn security groups
 category: feature
 authors: mdbarroso
-feature_name: security-group-support
-feature_modules: engine,ovirt-provider-ovn
-feature_status: Released
 ---
 
 

--- a/source/develop/release-management/features/network/networklabels.md
+++ b/source/develop/release-management/features/network/networklabels.md
@@ -2,9 +2,6 @@
 title: NetworkLabels
 category: feature
 authors: alkaplan, danken, lvernia, moti, mpavlik
-feature_name: Network Labels
-feature_modules: Networking
-feature_status: Released
 ---
 
 # Network Labels

--- a/source/develop/release-management/features/network/nicless-network.md
+++ b/source/develop/release-management/features/network/nicless-network.md
@@ -2,9 +2,6 @@
 title: Nicless Network
 category: feature
 authors: danken
-feature_name: Nic-less Network
-feature_modules: engine,api
-feature_status: Dormant
 ---
 
 # Nic-less Network

--- a/source/develop/release-management/features/network/openstack_identity_api_v3.md
+++ b/source/develop/release-management/features/network/openstack_identity_api_v3.md
@@ -2,9 +2,6 @@
 title: Support OpenStack Identity API v3
 category: feature
 authors: dholler
-feature_name:  Support OpenStack Identity API v3
-feature_modules: engine
-feature_status: In Development
 ---
 
 # Support OpenStack Identity API v3

--- a/source/develop/release-management/features/network/openvswitch/native-openvswitch.md
+++ b/source/develop/release-management/features/network/openvswitch/native-openvswitch.md
@@ -2,9 +2,6 @@
 title: Native Open vSwitch
 category: feature
 authors: phoracek danken edwardh amusil
-feature_name: Native Open vSwitch
-feature_modules: Networking
-feature_status: Spec
 ---
 
 # Native Open vSwitch

--- a/source/develop/release-management/features/network/ovirt-lldp-labeler.md
+++ b/source/develop/release-management/features/network/ovirt-lldp-labeler.md
@@ -2,9 +2,6 @@
 title: oVirt LLDP labeler
 category: feature
 authors: Ales Musil
-feature_name: oVirt LLDP labeler
-feature_modules: ovirt-lldp-labeler
-feature_status: In Development
 ---
 
 # oVirt LLDP labeler

--- a/source/develop/release-management/features/network/ovirt-ovn-provider.md
+++ b/source/develop/release-management/features/network/ovirt-ovn-provider.md
@@ -2,9 +2,6 @@
 title: oVirt OVN Provider
 category: feature
 authors: mmirecki,dholler
-feature_name: oVirt OVN Provider
-feature_modules: engine,vdsm,ovn-provider
-feature_status: In Development
 ---
 
 # oVirt OVN Provider

--- a/source/develop/release-management/features/network/predictable-vnic-order.md
+++ b/source/develop/release-management/features/network/predictable-vnic-order.md
@@ -2,9 +2,6 @@
 title: Predictable vNIC Order
 category: feature
 authors: danken
-feature_name: Predictable vNIC Order
-feature_modules: engine
-feature_status: Released
 ---
 
 # Predictable vNIC Order

--- a/source/develop/release-management/features/network/provider-physical-network.md
+++ b/source/develop/release-management/features/network/provider-physical-network.md
@@ -2,9 +2,6 @@
 title: Provider Physical Network
 category: feature
 authors: phoracek,amusil,dholler
-feature_name: Provider Physical Network
-feature_modules: engine,vdsm,ovn-provider
-feature_status: In Development
 ---
 
 # Provider Physical Network

--- a/source/develop/release-management/features/network/remove-dc-entity-network.md
+++ b/source/develop/release-management/features/network/remove-dc-entity-network.md
@@ -2,9 +2,6 @@
 title: Remove-DC-Entity-Network
 category: feature
 authors: alkaplan
-feature_name: Eliminate DC entity (Network aspects)
-feature_modules: engine, api
-feature_status: Design
 ---
 
 # Remove-DC-Entity-Network

--- a/source/develop/release-management/features/network/resolveactiveinterface.md
+++ b/source/develop/release-management/features/network/resolveactiveinterface.md
@@ -2,9 +2,6 @@
 title: ResolveActiveInterface
 category: feature
 authors: elevi
-feature_name: Resolve Active Interface
-feature_modules: engine,network
-feature_status: Development
 ---
 
 Features/ResolveActiveInterface

--- a/source/develop/release-management/features/network/sr-iov.md
+++ b/source/develop/release-management/features/network/sr-iov.md
@@ -2,9 +2,6 @@
 title: SR-IOV
 category: feature
 authors: alkaplan, danken, ibarkan
-feature_name: SR_IOV
-feature_modules: engine,vdsm, api
-feature_status: Design
 ---
 
 # SR-IOV

--- a/source/develop/release-management/features/network/sriov-live-migration.md
+++ b/source/develop/release-management/features/network/sriov-live-migration.md
@@ -2,9 +2,6 @@
 title: SR-IOV Live Migration without downtime
 category: feature
 authors: amusil
-feature_name: SR-IOV Live Migration without downtime
-feature_modules: engine,network,vdsm
-feature_status: In Development
 ---
 
 # SR-IOV Live Migration without downtime

--- a/source/develop/release-management/features/network/ucs-integration.md
+++ b/source/develop/release-management/features/network/ucs-integration.md
@@ -2,9 +2,6 @@
 title: UCS Integration
 category: feature
 authors: apuimedo, danken, mburman
-feature_name: Cisco UCS integration
-feature_modules: engine,network,vdsm
-feature_status: Partially Released
 ---
 
 # UCS Integration

--- a/source/develop/release-management/features/network/unrestricted-network-names.md
+++ b/source/develop/release-management/features/network/unrestricted-network-names.md
@@ -2,9 +2,6 @@
 title: Unrestricted Network Names
 category: feature
 authors: danken
-feature_name: Unrestricted Network Names
-feature_modules: engine,api
-feature_status: Proposed
 ---
 
 # Unrestricted Network Names

--- a/source/develop/release-management/features/node/cockpit.md
+++ b/source/develop/release-management/features/node/cockpit.md
@@ -2,9 +2,6 @@
 title: Cockpit
 category: feature
 authors: tlitovsk
-feature_name: Cockpit
-feature_modules: node
-feature_status: In Progress
 ---
 
 # Cockpit

--- a/source/develop/release-management/features/node/genericregistration.md
+++ b/source/develop/release-management/features/node/genericregistration.md
@@ -2,9 +2,6 @@
 title: GenericRegistration
 category: feature
 authors: dougsland
-feature_name: GenericRegistration
-feature_modules: vdsm, ovirt-node
-feature_status: Merged
 ---
 
 # Generic Registration

--- a/source/develop/release-management/features/node/glusterfs-support.md
+++ b/source/develop/release-management/features/node/glusterfs-support.md
@@ -1,6 +1,6 @@
 ---
 title: Node Glusterfs Support
-category: node
+category: feature
 authors: mburns
 ---
 

--- a/source/develop/release-management/features/node/node-next-persistence.md
+++ b/source/develop/release-management/features/node/node-next-persistence.md
@@ -2,9 +2,6 @@
 title: Next Gen Node RPM persistence
 category: feature
 authors: rbarry
-feature_name: Reinstall/Persist RPMs after Node upgrades
-feature_modules: node persistence
-feature_status: On QA
 ---
 
 # Node RPM Persistence After Upgrades

--- a/source/develop/release-management/features/node/node-validate-pre-conditions-during-installation.md
+++ b/source/develop/release-management/features/node/node-validate-pre-conditions-during-installation.md
@@ -2,9 +2,6 @@
 title: Validate pre-conditions during installation
 category: feature
 authors: dougsland
-feature_name: Installation/Validate Node Pre Coditions for Installation
-feature_modules: node installation
-feature_status: WIP, 4.1 proposed feature
 ---
 
 # Node RPM Persistence After Upgrades

--- a/source/develop/release-management/features/node/node.next.md
+++ b/source/develop/release-management/features/node/node.next.md
@@ -1,10 +1,7 @@
 ---
 title: Node.next
-category: node
+category: feature
 authors: fabiand
-feature_name: Node.next
-feature_modules: engine,network,vdsm,node
-feature_status: New
 ---
 
 # Node.next

--- a/source/develop/release-management/features/node/nodeautomation.md
+++ b/source/develop/release-management/features/node/nodeautomation.md
@@ -1,6 +1,6 @@
 ---
 title: NodeAutomation
-category: node
+category: feature
 authors: fabiand
 ---
 

--- a/source/develop/release-management/features/platform/openshift-on-ovirt.md
+++ b/source/develop/release-management/features/platform/openshift-on-ovirt.md
@@ -2,9 +2,6 @@
 title: Openshift On oVirt
 category: feature
 authors: rgolan
-feature_name: Openshift On oVirt
-feature_modules: external
-feature_status: release 4.3
 ---
 
 ## Owner

--- a/source/develop/release-management/features/sla/affinity-labels-management-via-admin-portal.md
+++ b/source/develop/release-management/features/sla/affinity-labels-management-via-admin-portal.md
@@ -2,9 +2,6 @@
 title: Affinity Labels Management via the Administration Portal
 category: feature
 authors: phbailey
-feature_name: Affinity Labels Management via the Administration Portal
-feature_modules: Administration Portal
-feature_status: Complete
 ---
 
 # Affinity Labels Management via the Administration Portal

--- a/source/develop/release-management/features/sla/affinity-rules-enforcement-manager.md
+++ b/source/develop/release-management/features/sla/affinity-rules-enforcement-manager.md
@@ -2,9 +2,6 @@
 title: Affinity Rules Enforcement Manager
 category: feature
 authors: doron, maroshi, rmohr, tsaban
-feature_name: Affinity Rules Enforcement Manager
-feature_modules: engine
-feature_status: On QA
 ---
 
 # Affinity Rules Enforcement Manager

--- a/source/develop/release-management/features/sla/cluster-maintenance.md
+++ b/source/develop/release-management/features/sla/cluster-maintenance.md
@@ -1,6 +1,6 @@
 ---
 title: Cluster maintenance scheduling policy
-category: sla
+category: feature
 authors: msivak
 ---
 # Cluster maintenance scheduling policy

--- a/source/develop/release-management/features/sla/cluster-optimization-host-change-notification.md
+++ b/source/develop/release-management/features/sla/cluster-optimization-host-change-notification.md
@@ -2,9 +2,6 @@
 title: Cluster Optimization Host Change Notification
 category: feature
 authors: phbailey
-feature_name: Cluster Optimization Host Change Notification
-feature_modules: Webadmin
-feature_status: Development
 ---
 
 # Cluster Optimization Host Change Notification

--- a/source/develop/release-management/features/sla/cockpit-he-wizard-ui-update.md
+++ b/source/develop/release-management/features/sla/cockpit-he-wizard-ui-update.md
@@ -2,9 +2,6 @@
 title: Cockpit Hosted Engine Wizard UI Update
 category: feature
 authors: phbailey
-feature_name: Cockpit Hosted Engine Wizard UI Update
-feature_modules: cockpit-ovirt
-feature_status: Development
 ---
 
 # Cockpit Hosted Engine Wizard UI Update

--- a/source/develop/release-management/features/sla/deploy-hosted-engine-hosts-via-engine.md
+++ b/source/develop/release-management/features/sla/deploy-hosted-engine-hosts-via-engine.md
@@ -2,9 +2,6 @@
 title: Deploy Hosted Engine Hosts via Engine
 authors: rgolan
 category: feature
-feature_name: 'Hosted Engine: add hosts with Web UI'
-feature_modules: ovirt-engine otopi
-feature_status: Merged in ovirt-4.0
 ---
 
 # overview

--- a/source/develop/release-management/features/sla/external-scheduling-proxy.md
+++ b/source/develop/release-management/features/sla/external-scheduling-proxy.md
@@ -1,6 +1,6 @@
 ---
 title: oVirt External Scheduling Proxy
-category: sla
+category: feature
 authors: doron, lhornyak
 ---
 

--- a/source/develop/release-management/features/sla/hosted-engine-add-hosts-with-web-ui.md
+++ b/source/develop/release-management/features/sla/hosted-engine-add-hosts-with-web-ui.md
@@ -2,9 +2,6 @@
 title: Hosted Engine add hosts with Web UI
 category: feature
 authors: sandrobonazzola
-feature_name: 'Hosted Engine: add hosts with Web UI'
-feature_modules: all
-feature_status: NEW
 ---
 
 # Hosted Engine: add hosts with Web UI

--- a/source/develop/release-management/features/sla/hosted-engine-agent-offloading.md
+++ b/source/develop/release-management/features/sla/hosted-engine-agent-offloading.md
@@ -2,8 +2,6 @@
 title: Hosted Engine Agent Offloading
 category: feature
 authors: dchaplyg
-feature_name: 'Hosted Engine: Move all the hardwork from agent to the broker'
-feature_status: Done
 ---
 
 # Hosted Engine: Move all the hard work from the agent to the broker

--- a/source/develop/release-management/features/sla/hosted-engine-configuration-on-shared-storage.md
+++ b/source/develop/release-management/features/sla/hosted-engine-configuration-on-shared-storage.md
@@ -2,9 +2,6 @@
 title: Hosted Engine configuration on shared storage
 category: feature
 authors: sandrobonazzola, stirabos
-feature_name: Hosted Engine configuration on shared storage
-feature_modules: all
-feature_status: QA
 ---
 
 # Hosted Engine configuration on shared storage

--- a/source/develop/release-management/features/sla/hosted-engine-edit-configuration-on-shared-storage.md
+++ b/source/develop/release-management/features/sla/hosted-engine-edit-configuration-on-shared-storage.md
@@ -2,9 +2,6 @@
 title: hosted-engine-edit-configuration-on-shared-storage
 category: feature
 authors: jtokar
-feature_name: Allow updating Hosted Engine configuration on shared storage
-feature_modules: sla
-feature_status: Design / partly implementaion stage
 ---
 
 # Allow updating Hosted Engine configuration on shared storage

--- a/source/develop/release-management/features/sla/hosted-engine-improve-management-in-host-dialogs.md
+++ b/source/develop/release-management/features/sla/hosted-engine-improve-management-in-host-dialogs.md
@@ -2,8 +2,6 @@
 title: Hosted Engine Improve Management in Host Dialogs
 category: feature
 authors: phbailey
-feature_name: 'Hosted Engine: Improve Management in Host Dialogs'
-feature_status: In Development
 ---
 
 # Hosted Engine: Improve Management in Host Dialogs

--- a/source/develop/release-management/features/sla/hosted-engine-indicate-host-in-web-ui.md
+++ b/source/develop/release-management/features/sla/hosted-engine-indicate-host-in-web-ui.md
@@ -2,9 +2,6 @@
 title: Hosted Engine indicate hosted engine host in Web UI
 category: feature
 authors: pcbailey
-feature_name: 'Hosted Engine: indicate hosted engine host in Web UI'
-feature_modules: all
-feature_status: NEW
 ---
 
 # Hosted Engine: Indicate Host Running the Hosted Engine VM

--- a/source/develop/release-management/features/sla/hosted-engine-indicators-ui.md
+++ b/source/develop/release-management/features/sla/hosted-engine-indicators-ui.md
@@ -2,9 +2,6 @@
 title: Hosted Engine related changes in the UI
 category: feature
 authors: akrejcir
-feature_name: Hosted Engine related changes in the UI
-feature_modules: webadmin
-feature_status: new, WIP
 ---
 
 ## Hosted Engine related changes in the UI

--- a/source/develop/release-management/features/sla/hosted-engine-migration-to-4-0.md
+++ b/source/develop/release-management/features/sla/hosted-engine-migration-to-4-0.md
@@ -2,9 +2,6 @@
 title: Hosted-engine migration to 4.0
 category: feature
 authors: stirabos
-feature_name: Hosted-engine migration to 4.0
-feature_modules: ovirt-hosted-engine-setup
-feature_status: On QA
 ---
 
 Hosted-engine migration to 4.0

--- a/source/develop/release-management/features/sla/hosted-engine-network-check.md
+++ b/source/develop/release-management/features/sla/hosted-engine-network-check.md
@@ -2,9 +2,6 @@
 title: Configurable Network Check for Self Hosted Engine
 category: feature
 authors: dholler
-feature_name: Configurable Network Check for Self Hosted Engine
-feature_modules: ovirt-hosted-engine-ha, cockpit-ovirt, ovirt-ansible-hosted-engine-setup, ovirt-hosted-engine-setup
-feature_status: In Development
 ---
 
 # Configurable Network Check for Self Hosted Engine

--- a/source/develop/release-management/features/sla/hosted-engine-ovf-extraction.md
+++ b/source/develop/release-management/features/sla/hosted-engine-ovf-extraction.md
@@ -2,8 +2,6 @@
 title: Hosted engine shared configuration extraction and caching
 category: feature
 authors: dchaplyg
-feature_name: 'Hosted engine shared configuration extraction and caching'
-feature_status: Planning
 ---
 
 # Hosted engine shared configuration extraction and caching

--- a/source/develop/release-management/features/sla/hosted-engine-vm-management.md
+++ b/source/develop/release-management/features/sla/hosted-engine-vm-management.md
@@ -2,9 +2,6 @@
 title: Hosted engine VM management
 category: feature
 authors: roy, sandrobonazzola
-feature_name: Hosted engine VM management enhancements
-feature_modules: api,engine,hosted-engine-setup,vdsm
-feature_status: Design & research
 ---
 
 # Hosted engine VM management enhancements

--- a/source/develop/release-management/features/sla/hosted-engine.md
+++ b/source/develop/release-management/features/sla/hosted-engine.md
@@ -1,10 +1,7 @@
 ---
 title: Node Hosted Engine
-category: node
+category: feature
 authors: dougsland, fabiand, jboggs
-feature_name: Node Hosted Engine
-feature_modules: node
-feature_status: Released
 ---
 
 # Node Hosted Engine

--- a/source/develop/release-management/features/sla/list-vms-pinned-to-host.md
+++ b/source/develop/release-management/features/sla/list-vms-pinned-to-host.md
@@ -2,9 +2,6 @@
 title: List VMs pinned to a host
 category: feature
 authors: akrejcir
-feature_name: List VMs pinned to a host
-feature_modules: engine
-feature_status: Done
 ---
 
 # List VMs pinned to a host

--- a/source/develop/release-management/features/sla/memory-aware-even-distribution-policy.md
+++ b/source/develop/release-management/features/sla/memory-aware-even-distribution-policy.md
@@ -1,6 +1,6 @@
 ---
 title: Memory-aware Even-distribution Policy
-category: sla
+category: feature
 authors: ofri
 ---
 

--- a/source/develop/release-management/features/sla/memorybasedbalancing.md
+++ b/source/develop/release-management/features/sla/memorybasedbalancing.md
@@ -2,9 +2,6 @@
 title: MemoryBasedBalancing
 category: feature
 authors: msivak
-feature_name: CPU and Memory based cluster auto balancing
-feature_modules: engine
-feature_status: Draft
 ---
 
 # Memory Based Balancing

--- a/source/develop/release-management/features/sla/minimum-guaranteed-memory.md
+++ b/source/develop/release-management/features/sla/minimum-guaranteed-memory.md
@@ -1,6 +1,6 @@
 ---
 title: Minimum guaranteed memory
-category: sla
+category: feature
 authors: didi, lhornyak
 ---
 

--- a/source/develop/release-management/features/sla/mom-declarative-language.md
+++ b/source/develop/release-management/features/sla/mom-declarative-language.md
@@ -2,9 +2,6 @@
 title: New policy language for MOM
 category: feature
 authors: akrejcir
-feature_name: New policy language for MOM
-feature_modules: mom
-feature_status: design
 ---
 
 # New policy language for MOM

--- a/source/develop/release-management/features/sla/numaawareksmsupport.md
+++ b/source/develop/release-management/features/sla/numaawareksmsupport.md
@@ -2,9 +2,6 @@
 title: NumaAwareKsmSupport
 category: feature
 authors: maroshi
-feature_name: NUMA aware KSM support
-feature_modules: engine, vdsm, MoM, GUI, REST
-feature_status: Design
 ---
 
 ## NUMA aware KSM support

--- a/source/develop/release-management/features/sla/optaplanner.md
+++ b/source/develop/release-management/features/sla/optaplanner.md
@@ -2,9 +2,6 @@
 title: Optaplanner
 category: feature
 authors: adahms, msivak
-feature_name: Optaplanner integration with scheduling
-feature_status: Removed
-feature_modules: ovirt-optimizer
 ---
 
 # Optaplanner integration with scheduling

--- a/source/develop/release-management/features/sla/ovirtschedulerapi.md
+++ b/source/develop/release-management/features/sla/ovirtschedulerapi.md
@@ -1,6 +1,6 @@
 ---
 title: oVirtSchedulerAPI
-category: api
+category: feature
 authors: doron, gchaplik, lhornyak, nslomian
 ---
 

--- a/source/develop/release-management/features/sla/pendingresourcemanager.md
+++ b/source/develop/release-management/features/sla/pendingresourcemanager.md
@@ -2,9 +2,6 @@
 title: PendingResourceManager
 category: feature
 authors: msivak
-feature_name: Pending Resource Manager
-feature_modules: engine
-feature_status: Draft
 ---
 
 # Pending Resource Manager

--- a/source/develop/release-management/features/sla/quota-3.2.md
+++ b/source/develop/release-management/features/sla/quota-3.2.md
@@ -1,6 +1,6 @@
 ---
 title: Quota-3.2
-category: sla
+category: feature
 authors: doron, ofri, ykaul
 ---
 

--- a/source/develop/release-management/features/sla/quota.md
+++ b/source/develop/release-management/features/sla/quota.md
@@ -1,6 +1,6 @@
 ---
 title: Quota
-category: sla
+category: feature
 authors: doron, gchaplik, jumper45, lpeer, mlipchuk, ovedo, sandrobonazzola
 ---
 

--- a/source/develop/release-management/features/sla/scheduling-weight-normalization.md
+++ b/source/develop/release-management/features/sla/scheduling-weight-normalization.md
@@ -2,9 +2,6 @@
 title: Normalizing scheduling policy weights
 category: feature
 authors: msivak
-feature_name: Normalizing scheduling policy weights
-feature_modules: engine
-feature_status: Draft
 ---
 
 ## Normalizing scheduling policy weights

--- a/source/develop/release-management/features/sla/self-hosted-engine-fc-support.md
+++ b/source/develop/release-management/features/sla/self-hosted-engine-fc-support.md
@@ -2,9 +2,6 @@
 title: Self Hosted Engine FC Support
 category: feature
 authors: sandrobonazzola, stirabos
-feature_name: Self Hosted Engine FC Support
-feature_modules: ovirt-hosted-engine-setup
-feature_status: completed
 ---
 
 # Self Hosted Engine FC Support

--- a/source/develop/release-management/features/sla/self-hosted-engine-gluster-support.md
+++ b/source/develop/release-management/features/sla/self-hosted-engine-gluster-support.md
@@ -2,9 +2,6 @@
 title: Self Hosted Engine Gluster Support
 category: feature
 authors: sandrobonazzola, sabose
-feature_name: Self Hosted Engine Gluster Support
-feature_modules: ovirt-hosted-engine-setup
-feature_status: ON_QA
 ---
 
 # Self Hosted Engine Gluster Support

--- a/source/develop/release-management/features/sla/self-hosted-engine-hyper-converged-gluster-support.md
+++ b/source/develop/release-management/features/sla/self-hosted-engine-hyper-converged-gluster-support.md
@@ -2,9 +2,6 @@
 title: Self Hosted Engine Hyper Converged Gluster Support
 category: feature
 authors: sandrobonazzola,sabose
-feature_name: Self Hosted Engine Hyper Converged Gluster Support
-feature_modules: ovirt-hosted-engine-setup
-feature_status: POST
 ---
 
 # Self Hosted Engine Hyper Converged Gluster Support

--- a/source/develop/release-management/features/sla/self-hosted-engine-iscsi-support.md
+++ b/source/develop/release-management/features/sla/self-hosted-engine-iscsi-support.md
@@ -2,9 +2,6 @@
 title: Self Hosted Engine iSCSI Support
 category: feature
 authors: doron, jmoskovc, sandrobonazzola
-feature_name: Self Hosted Engine iSCSI Support
-feature_modules: ovirt-hosted-engine-setup,ovirt-hosted-engine-ha
-feature_status: Completed
 ---
 
 # Self Hosted Engine iSCSI Support

--- a/source/develop/release-management/features/sla/self-hosted-engine-maintenance-flows.md
+++ b/source/develop/release-management/features/sla/self-hosted-engine-maintenance-flows.md
@@ -2,9 +2,6 @@
 title: Self Hosted Engine Maintenance Flows
 category: feature
 authors: gpadgett, mlipchuk, sandrobonazzola
-feature_name: Hosted Engine Maintenance Flow Unification
-feature_modules: virt
-feature_status: Released
 ---
 
 # Self Hosted Engine Maintenance Flows

--- a/source/develop/release-management/features/sla/self-hosted-engine.md
+++ b/source/develop/release-management/features/sla/self-hosted-engine.md
@@ -3,9 +3,6 @@ title: Self Hosted Engine
 category: feature
 authors: didi, dneary, doron, dyasny, fabiand, gpadgett, jmoskovc, lveyde, mgoldboi,
   mlipchuk, msivak, sandrobonazzola, scohen
-feature_name: Self Hosted Engine
-feature_modules: virt,storage
-feature_status: Released
 ---
 
 # Self Hosted Engine

--- a/source/develop/release-management/features/sla/sla-for-storage-io-bandwidth.md
+++ b/source/develop/release-management/features/sla/sla-for-storage-io-bandwidth.md
@@ -1,6 +1,6 @@
 ---
 title: SLA for storage io bandwidth
-category: sla
+category: feature
 authors: mei liu
 ---
 

--- a/source/develop/release-management/features/sla/sla-mom-ballooning-tp.md
+++ b/source/develop/release-management/features/sla/sla-mom-ballooning-tp.md
@@ -1,6 +1,6 @@
 ---
 title: SLA-mom-ballooning-tp
-category: sla
+category: feature
 authors: aglitke
 ---
 

--- a/source/develop/release-management/features/sla/soft-host-to-vm-affinity-support.md
+++ b/source/develop/release-management/features/sla/soft-host-to-vm-affinity-support.md
@@ -2,9 +2,6 @@
 title: soft-host-to-vm-affinity-support
 category: feature
 authors: yquinn,msivak
-feature_name: Soft host to VM affinity support
-feature_modules: sla
-feature_status: Design / partly implementaion stage
 ---
 
 # Soft host to VM affinity support and Rack use case

--- a/source/develop/release-management/features/sla/stateless-broker.md
+++ b/source/develop/release-management/features/sla/stateless-broker.md
@@ -2,9 +2,6 @@
 title: Stateless Hosted Engine broker
 category: feature
 authors: dchaplyg
-feature_name: Stateless broker
-feature_modules: he
-feature_status: Done
 ---
 
 # Stateless Hosted Engine broker

--- a/source/develop/release-management/features/sla/vmpinningtomultiplehosts.md
+++ b/source/develop/release-management/features/sla/vmpinningtomultiplehosts.md
@@ -2,9 +2,6 @@
 title: VmPinningToMultipleHosts
 category: feature
 authors: maroshi
-feature_name: VM pinning to multiple hosts
-feature_modules: engine,database,rest
-feature_status: Released in 3.6
 ---
 
 # VM Pinning To Multiple Hosts

--- a/source/develop/release-management/features/sla/vnic-profiles.md
+++ b/source/develop/release-management/features/sla/vnic-profiles.md
@@ -1,6 +1,6 @@
 ---
 title: Vnic Profiles
-category: sla
+category: feature
 authors: moti, ofri, ovedo
 ---
 

--- a/source/develop/release-management/features/sla/watchdog-engine-support.md
+++ b/source/develop/release-management/features/sla/watchdog-engine-support.md
@@ -2,9 +2,6 @@
 title: Watchdog engine support
 category: feature
 authors: doron, lhornyak, mlipchuk
-feature_name: Watchdog engine support
-feature_modules: SOA
-feature_status: Released
 ---
 
 # Watchdog support in Engine

--- a/source/develop/release-management/features/storage/advancednfsoptions.md
+++ b/source/develop/release-management/features/storage/advancednfsoptions.md
@@ -2,9 +2,6 @@
 title: AdvancedNfsOptions
 category: feature
 authors: derez, ecohen, ekohl, lhornyak, smizrahi
-feature_name: Advanced Nfs Options
-feature_modules: engine
-feature_status: Released
 ---
 
 # Advanced Nfs Options

--- a/source/develop/release-management/features/storage/backup-restore-api-integration.md
+++ b/source/develop/release-management/features/storage/backup-restore-api-integration.md
@@ -2,9 +2,6 @@
 title: Backup-Restore API Integration
 category: feature
 authors: adahms, aglitke, dpkshetty, laravot, mlipchuk, scohen, snmishra, ydary
-feature_modules: vdsm, engine
-feature_status: Released
-feature_name: Backup-Restore API Integration
 ---
 
 # Backup-Restore API Integration

--- a/source/develop/release-management/features/storage/backup-restore-disk-snapshots.md
+++ b/source/develop/release-management/features/storage/backup-restore-disk-snapshots.md
@@ -2,9 +2,6 @@
 title: Backup-Restore Disk-Snapshots
 category: feature
 authors: derez
-feature_modules: engine, rest-api
-feature_status: planning
-feature_name: Backup-Restore Disk-Snapshots
 ---
 
 # Backup-Restore Disk-Snapshots

--- a/source/develop/release-management/features/storage/cd-block-storage.md
+++ b/source/develop/release-management/features/storage/cd-block-storage.md
@@ -2,9 +2,6 @@
 title: CD-ROM support for block storage
 category: feature
 authors: vjuranek, nsoffer
-feature_name: CD-ROM support for block storage
-feature_modules: engine,vdsm
-feature_status: Design
 ---
 
 # CD-ROM support for block storage

--- a/source/develop/release-management/features/storage/cinder-integration.md
+++ b/source/develop/release-management/features/storage/cinder-integration.md
@@ -2,9 +2,6 @@
 title: Cinder Integration
 category: feature
 authors: derez, sandrobonazzola
-feature_name: Cinder Integration
-feature_modules: engine/vdsm
-feature_status: Released in oVirt 3.6
 ---
 
 # Cinder Integration

--- a/source/develop/release-management/features/storage/cinderlib-integration.md
+++ b/source/develop/release-management/features/storage/cinderlib-integration.md
@@ -2,9 +2,6 @@
 title: Managed Block Storage
 category: feature
 authors: frolland, bzlotnik, eshenitz
-feature_name: Managed Block Storage - Cinderlib integration
-feature_modules: storage,engine,vdsm
-feature_status: WIP 4.3
 ---
 
 # Managed Block Storage

--- a/source/develop/release-management/features/storage/copy-disks.md
+++ b/source/develop/release-management/features/storage/copy-disks.md
@@ -1,9 +1,7 @@
 ---
 title: Copy Disks
 authors: tjelinek
-feature_name: Copy Disks
-feature_modules: engine
-feature_status: Released in oVirt 3.6
+category: feature
 ---
 
 # Copy Disks

--- a/source/develop/release-management/features/storage/data-path-operations.md
+++ b/source/develop/release-management/features/storage/data-path-operations.md
@@ -2,9 +2,6 @@
 title: Data Path operations on any host
 category: feature
 authors: alitke, nsoffer, laravot, frolland
-feature_name: Data Path Operations On Any Host
-feature_modules: storage,engine,vdsm
-feature_status: WIP 4.1
 ---
 
 # Data Path Operations On Any Host

--- a/source/develop/release-management/features/storage/detailedfloatingdisk.md
+++ b/source/develop/release-management/features/storage/detailedfloatingdisk.md
@@ -2,9 +2,6 @@
 title: DetailedFloatingDisk
 category: feature
 authors: derez, mlipchuk
-feature_name: Floating Disk
-feature_modules: engine
-feature_status: Released
 ---
 
 # Detailed Floating Disk

--- a/source/develop/release-management/features/storage/direct-lun.md
+++ b/source/develop/release-management/features/storage/direct-lun.md
@@ -2,9 +2,6 @@
 title: Direct Lun
 category: feature
 authors: derez, eduardo, ekohl, ilvovsky, lpeer, mkublin, sandrobonazzola
-feature_name: Direct LUN
-feature_modules: engine/vdsm
-feature_status: Released
 ---
 
 # Direct LUN

--- a/source/develop/release-management/features/storage/discard-after-delete.md
+++ b/source/develop/release-management/features/storage/discard-after-delete.md
@@ -2,9 +2,6 @@
 title: DiscardAfterDelete
 category: feature
 authors: ishaby
-feature_name: Discard after delete
-feature_modules: vdsm/engine
-feature_status: First phase was released in oVirt 4.0, second phase was released in oVirt 4.1.
 ---
 
 # Discard after delete

--- a/source/develop/release-management/features/storage/disk-hooks.md
+++ b/source/develop/release-management/features/storage/disk-hooks.md
@@ -2,9 +2,6 @@
 title: Disk Hooks
 category: feature
 authors: vered
-feature_name: Disk Hooks
-feature_modules: storage
-feature_status: Released
 ---
 
 # Disk Hooks

--- a/source/develop/release-management/features/storage/diskalignment.md
+++ b/source/develop/release-management/features/storage/diskalignment.md
@@ -1,8 +1,7 @@
 ---
 title: DiskAlignment
 authors: fsimonce
-feature_name: Disk Alignment
-feature_status: Obsolete
+category: feature
 ---
 
 **Note**: this feature is now obsolete. It was introduced in oVirt 3.3 and dropped in oVirt 4.4 [(Bug #1533086)](https://bugzilla.redhat.com/show_bug.cgi?id=1533086)

--- a/source/develop/release-management/features/storage/diskpermissions.md
+++ b/source/develop/release-management/features/storage/diskpermissions.md
@@ -2,9 +2,6 @@
 title: DiskPermissions
 category: feature
 authors: amureini, derez, lpeer, moti, ofrenkel, smelamud
-feature_name: Disk Permissions
-feature_modules: engine
-feature_status: Released
 ---
 
 # Disk Permissions

--- a/source/develop/release-management/features/storage/domain-scan.md
+++ b/source/develop/release-management/features/storage/domain-scan.md
@@ -2,9 +2,6 @@
 title: Domain Scan
 category: feature
 authors: derez, djasa, dustin.schoenbrun
-feature_name: Domain Scan
-feature_modules: engine
-feature_status: Released
 ---
 
 # Domain Scan

--- a/source/develop/release-management/features/storage/editing-floating-disks.md
+++ b/source/develop/release-management/features/storage/editing-floating-disks.md
@@ -2,9 +2,6 @@
 title: Editing Floating Disks
 category: feature
 authors: sleviim
-feature_name: Editing Floating Disks
-feature_modules: storage,engine,model
-feature_status: 4.4
 ---
 
 # Editing Floating Disks

--- a/source/develop/release-management/features/storage/floatingdisk.md
+++ b/source/develop/release-management/features/storage/floatingdisk.md
@@ -2,9 +2,6 @@
 title: FloatingDisk
 category: feature
 authors: derez, ekohl, mlipchuk
-feature_name: Floating Disk
-feature_modules: engine
-feature_status: Released
 ---
 
 # Floating Disk

--- a/source/develop/release-management/features/storage/glance-integration.md
+++ b/source/develop/release-management/features/storage/glance-integration.md
@@ -2,9 +2,6 @@
 title: Glance Integration
 category: feature
 authors: fsimonce
-feature_name: Glance Integration
-feature_status: Released in oVirt 3.3
-feature_modules: engine, vdsm
 ---
 
 # Glance Integration

--- a/source/develop/release-management/features/storage/glusterfs-storage-domain.md
+++ b/source/develop/release-management/features/storage/glusterfs-storage-domain.md
@@ -3,9 +3,6 @@ title: GlusterFS Storage Domain
 category: feature
 authors: derez, dpkshetty, drbao, moti, sahina, sandrobonazzola, shtripat, snmishra,
   thildred, dchaplyg
-feature_name: GlusterFS Storage Domain
-feature_modules: engine/vdsm
-feature_status: Released
 ---
 
 # GlusterFS Storage Domain

--- a/source/develop/release-management/features/storage/hotplugdisk.md
+++ b/source/develop/release-management/features/storage/hotplugdisk.md
@@ -1,10 +1,7 @@
 ---
 title: Hot Plug and Unplug Disk
-category: template
+category: feature
 authors: derez, mkublin, ykaul
-feature_name: Disk Hot Plug
-feature_modules: engine
-feature_status: Released
 ---
 
 # Hot Plug Disk

--- a/source/develop/release-management/features/storage/image-upload.md
+++ b/source/develop/release-management/features/storage/image-upload.md
@@ -2,9 +2,6 @@
 title: oVirt Image I/O
 category: feature
 authors: aaviram, gpadgett, nsoffer, derez
-feature_name: Image I/O
-feature_modules: Engine, Storage, VDSM, ovirt-imageio
-feature_status: Released
 ---
 
 # oVirt Image I/O

--- a/source/develop/release-management/features/storage/importmorethanonce.md
+++ b/source/develop/release-management/features/storage/importmorethanonce.md
@@ -2,9 +2,6 @@
 title: ImportMoreThanOnce
 category: feature
 authors: derez, ekohl, gchaplik
-feature_name: Import VM or Template More than Once
-feature_modules: engine
-feature_status: Released
 ---
 
 # Import VM or Template More than Once Feature

--- a/source/develop/release-management/features/storage/importstoragedomain.md
+++ b/source/develop/release-management/features/storage/importstoragedomain.md
@@ -2,9 +2,6 @@
 title: ImportStorageDomain
 category: feature
 authors: derez, mlipchuk, sandrobonazzola, vered
-feature_name: Import Storage Domain
-feature_modules: engine/vdsm
-feature_status: Released
 ---
 
 # Import Storage Domain

--- a/source/develop/release-management/features/storage/importunregisteredentities.md
+++ b/source/develop/release-management/features/storage/importunregisteredentities.md
@@ -1,9 +1,7 @@
 ---
 title: ImportUnregisteredEntities
 authors: mlipchuk
-feature_name: Detach/Attach Storage Domain with Entities
-feature_modules: engine
-feature_status: Released in oVirt 3.5
+category: feature
 ---
 
 # Import Unregistered Entities

--- a/source/develop/release-management/features/storage/incremental-backup.md
+++ b/source/develop/release-management/features/storage/incremental-backup.md
@@ -2,9 +2,6 @@
 title: Incremental Backup
 category: feature
 authors: nsoffer, derez, eshenitz
-feature_name: Incremental Backup
-feature_modules: imageio,engine,vdsm
-feature_status: Design
 ---
 
 # Incremental Backup

--- a/source/develop/release-management/features/storage/ioprocess.md
+++ b/source/develop/release-management/features/storage/ioprocess.md
@@ -2,9 +2,6 @@
 title: ioprocess
 category: feature
 authors: derez, ykaplan
-feature_name: ioprocess
-feature_status: Released in oVirt 3.5
-feature_modules: ioprocess, vdsm
 ---
 
 # ioprocess

--- a/source/develop/release-management/features/storage/iscsi-multipath.md
+++ b/source/develop/release-management/features/storage/iscsi-multipath.md
@@ -2,9 +2,6 @@
 title: iSCSI-Multipath
 category: feature
 authors: mlipchuk, sandrobonazzola, sgotliv
-feature_name: Configure iSCSI Multipathing
-feature_modules: storage
-feature_status: Released in oVirt 3.4
 ---
 
 # iSCSI Multipath

--- a/source/develop/release-management/features/storage/live-merge.md
+++ b/source/develop/release-management/features/storage/live-merge.md
@@ -2,10 +2,6 @@
 title: Live Merge
 category: feature
 authors: aglitke, gpadgett
-status: Released in oVirt 3.5.1
-feature_name: Live Merge
-feature_modules: engine,vdsm
-feature_status: Released in oVirt 3.5.1
 ---
 
 # Live Merge

--- a/source/develop/release-management/features/storage/live-storage-migration-between-mixed-domains.md
+++ b/source/develop/release-management/features/storage/live-storage-migration-between-mixed-domains.md
@@ -2,9 +2,6 @@
 title: Live storage migration between mixed domains
 category: feature
 authors: nsoffer
-feature_name: Live storage migration between mixed domains
-feature_modules: engine,vdsm
-feature_status: Released in oVirt 3.6
 ---
 
 # Live storage migration between mixed domains

--- a/source/develop/release-management/features/storage/lun-resize.md
+++ b/source/develop/release-management/features/storage/lun-resize.md
@@ -2,9 +2,6 @@
 title: Refresh LUN Size
 category: feature
 authors: frolland, nsoffer
-feature_name: Refresh LUN Size
-feature_modules: engine/vdsm
-feature_status: Released in oVirt 3.6
 ---
 
 # Refresh LUN Size

--- a/source/develop/release-management/features/storage/manage-storage-connections.md
+++ b/source/develop/release-management/features/storage/manage-storage-connections.md
@@ -2,9 +2,6 @@
 title: Manage Storage Connections
 category: feature
 authors: abonas, derez, sgotliv, amureini
-feature_name: Manage storage connections
-feature_modules: engine
-feature_status: Released (oVirt 3.3)
 ---
 
 # Manage storage connections

--- a/source/develop/release-management/features/storage/managed-block-storage-copy.md
+++ b/source/develop/release-management/features/storage/managed-block-storage-copy.md
@@ -2,9 +2,6 @@
 title: Managed Block Storage Copy
 category: feature
 authors: bzlotnik
-feature_name: Managed Block Storage - Copying
-feature_modules: storage,engine,vdsm
-feature_status: WIP 4.4.6
 ---
 
 # Managed Block Storage Copy

--- a/source/develop/release-management/features/storage/mixed-types-data-center.md
+++ b/source/develop/release-management/features/storage/mixed-types-data-center.md
@@ -2,9 +2,6 @@
 title: Mixed Types Data Center
 category: feature
 authors: tnisan
-feature_name: Mixed Type Data Center
-feature_modules: engine
-feature_status: Released in oVirt 3.4
 ---
 
 # Mixed Types Data Center

--- a/source/develop/release-management/features/storage/moveascopyanddelete.md
+++ b/source/develop/release-management/features/storage/moveascopyanddelete.md
@@ -1,9 +1,6 @@
 ---
 title: MoveAsCopyAndDelete
 category: feature
-feature_name: Move As Copy And Delete
-feature_modules: Engine
-feature_status: Released in oVirt 3.3
 authors: laravot
 ---
 

--- a/source/develop/release-management/features/storage/multipath-events.md
+++ b/source/develop/release-management/features/storage/multipath-events.md
@@ -2,9 +2,6 @@
 title: Multipath Alerts
 category: feature
 authors: Fred Rolland
-feature_name: Multipath Alerts
-feature_modules: engine,vdsm
-feature_status:  Released in oVirt 4.2.0
 ---
 
 # Multipath Alerts

--- a/source/develop/release-management/features/storage/multiplestoragedomains.md
+++ b/source/develop/release-management/features/storage/multiplestoragedomains.md
@@ -2,9 +2,6 @@
 title: Multiple storage domains
 category: feature
 authors: derez, jumper45, mkublin
-feature_name: Multiple Storage Domains
-feature_modules: engine
-feature_status: Released in oVirt 3.1
 ---
 
 # Design for multiple storage domains

--- a/source/develop/release-management/features/storage/nfsv4.md
+++ b/source/develop/release-management/features/storage/nfsv4.md
@@ -2,9 +2,6 @@
 title: NFSv4
 category: feature
 authors: derez, ecohen, ekohl, sandrobonazzola, smizrahi
-feature_name: NFSv4
-feature_modules: engine/vdsm
-feature_status: Released
 ---
 
 # NFSv4

--- a/source/develop/release-management/features/storage/online-virtual-drive-resize.md
+++ b/source/develop/release-management/features/storage/online-virtual-drive-resize.md
@@ -2,9 +2,6 @@
 title: Online Virtual Drive Resize
 category: feature
 authors: derez, fsimonce, sgotliv
-feature_name: Online Virtual Drive Resize
-feature_modules: engine/vdsm
-feature_status: Released in oVirt 3.3
 ---
 
 # Enable Online Virtual Drive Resize

--- a/source/develop/release-management/features/storage/ovfautoupdater.md
+++ b/source/develop/release-management/features/storage/ovfautoupdater.md
@@ -2,9 +2,6 @@
 title: OvfAutoUpdater
 category: feature
 authors: abaron, laravot
-feature_name: OvfAutoUpdater
-feature_modules: engine
-feature_status: Released in oVirt 3.3
 ---
 
 # OvfAutoUpdater

--- a/source/develop/release-management/features/storage/ovfonanydomain.md
+++ b/source/develop/release-management/features/storage/ovfonanydomain.md
@@ -2,9 +2,6 @@
 title: OVF On Any Domain
 category: feature
 authors: laravot
-feature_name: OVF On Any Domain
-feature_modules: engine
-feature_status: Released in oVirt 3.3
 ---
 
 # OvfOnAnyDomains

--- a/source/develop/release-management/features/storage/pass-discard-from-guest-to-underlying-storage.md
+++ b/source/develop/release-management/features/storage/pass-discard-from-guest-to-underlying-storage.md
@@ -2,9 +2,6 @@
 title: PassDiscardFromGuestToUnderlyingStorage
 category: feature
 authors: ishaby
-feature_name: Pass discard from guest to underlying storage
-feature_modules: engine/vdsm/api-model
-feature_status: Released in oVirt 4.1
 ---
 
 # Pass discard from guest to underlying storage

--- a/source/develop/release-management/features/storage/posixfsconnection.md
+++ b/source/develop/release-management/features/storage/posixfsconnection.md
@@ -2,9 +2,6 @@
 title: PosixFSConnection
 category: feature
 authors: abaron, derez, ecohen, ekohl, sandrobonazzola, smizrahi, yair zaslavsky
-feature_name: PosixFS Connection
-feature_modules: engine/vdsm
-feature_status: Released
 ---
 
 Also known as SharedFS support

--- a/source/develop/release-management/features/storage/qcow2v3.md
+++ b/source/develop/release-management/features/storage/qcow2v3.md
@@ -2,9 +2,6 @@
 title: QCOW2 compat levels
 category: feature
 authors: mlipchuk
-feature_name: QCOW2 compat levels
-feature_modules: engine,vdsm
-feature_status:  Released in oVirt 4.1
 ---
 
 # QCOW2 compat levels

--- a/source/develop/release-management/features/storage/read-only-disk.md
+++ b/source/develop/release-management/features/storage/read-only-disk.md
@@ -2,9 +2,6 @@
 title: Read Only Disk
 category: feature
 authors: sgotliv, vered
-feature_name: Read-Only Disks
-feature_modules: storage
-feature_status: Released
 ---
 
 # Read Only Disk

--- a/source/develop/release-management/features/storage/reduce-luns-from-sd.md
+++ b/source/develop/release-management/features/storage/reduce-luns-from-sd.md
@@ -2,9 +2,6 @@
 title: Reduce LUNs from a Storage Domain
 category: feature
 authors: laravot
-feature_name: Reduce LUNs from Storage Domain
-feature_modules: vdsm, engine
-feature_status: Released in oVirt 4.1
 ---
 
 # Reduce LUNs from a Storage Domain

--- a/source/develop/release-management/features/storage/remove-snapshot.md
+++ b/source/develop/release-management/features/storage/remove-snapshot.md
@@ -2,9 +2,6 @@
 title: Remove Snapshot
 category: feature
 authors: ahino
-feature_name: Remove Snapshot
-feature_modules: engine/vdsm
-feature_status: Released in 4.1
 ---
 
 # Remove Snapshot

--- a/source/develop/release-management/features/storage/reportguestdiskslogicaldevicename.md
+++ b/source/develop/release-management/features/storage/reportguestdiskslogicaldevicename.md
@@ -2,9 +2,6 @@
 title: ReportGuestDisksLogicalDeviceName
 category: feature
 authors: laravot
-feature_name: Report Guest Disks Logical Device Name
-feature_modules: engine,vdsm,guest-agent
-feature_status: Released in oVirt 3.6
 ---
 
 # Report Guest Disks Logical Device Name

--- a/source/develop/release-management/features/storage/sanlock-fencing.md
+++ b/source/develop/release-management/features/storage/sanlock-fencing.md
@@ -2,9 +2,6 @@
 title: Sanlock Fencing
 category: feature
 authors: nsoffer, vered, ybronhei
-feature_name: Sanlock Fencing
-feature_modules: engine,vdsm
-feature_status: Design
 ---
 
 # Sanlock Fencing

--- a/source/develop/release-management/features/storage/sharedStorageDomainsAttachedToLocalDC.md
+++ b/source/develop/release-management/features/storage/sharedStorageDomainsAttachedToLocalDC.md
@@ -2,9 +2,6 @@
 title: Attach shared Storage Domains to a local DC.
 category: feature
 authors: mlipchuk
-feature_name: Attach shared Storage Domains to a local DC.
-feature_modules: engine
-feature_status: Released in oVirt 4.1
 ---
 
 # Attach shared Storage Domains to a local DC.

--- a/source/develop/release-management/features/storage/sharedrawdisk.md
+++ b/source/develop/release-management/features/storage/sharedrawdisk.md
@@ -2,9 +2,6 @@
 title: SharedRawDisk
 category: feature
 authors: abaron, derez, mlipchuk, sandrobonazzola
-feature_name: Shared Raw Disk
-feature_modules: engine
-feature_status: Released in oVirt 3.1
 ---
 
 # Shared Raw Disk

--- a/source/develop/release-management/features/storage/single-disk-snapshot.md
+++ b/source/develop/release-management/features/storage/single-disk-snapshot.md
@@ -1,9 +1,6 @@
 ---
 title: Single Disk Snapshot
 authors: amureini, derez, vered
-feature_name: Single Disk Snapshot
-feature_modules: engine
-feature_status: Released in oVirt 3.4
 category: feature
 ---
 

--- a/source/develop/release-management/features/storage/snapshots-overview.md
+++ b/source/develop/release-management/features/storage/snapshots-overview.md
@@ -1,9 +1,7 @@
 ---
 title: Snapshots Overview
+category: feature
 authors: derez
-feature_name: Snapshot Overview
-feature_modules: engine
-feature_status: Released in oVirt 3.5
 ---
 
 # Snapshots Overview

--- a/source/develop/release-management/features/storage/spmpriority.md
+++ b/source/develop/release-management/features/storage/spmpriority.md
@@ -2,9 +2,6 @@
 title: SPM Priority
 category: feature
 authors: derez, msalem, ovedo
-feature_name: SPM Priority
-feature_modules: engine
-feature_status: Released in oVirt 3.1
 ---
 
 # SPM Priority

--- a/source/develop/release-management/features/storage/storage_domain_v4.md
+++ b/source/develop/release-management/features/storage/storage_domain_v4.md
@@ -1,10 +1,7 @@
 ---
-title: Storage Domain V4 
+title: Storage Domain V4
 category: feature
 authors: mlipchuk
-feature_name: Storage Domain V4
-feature_status: Released in oVirt 4.1
-feature_modules: engine/vdsm
 ---
 
 ## Summary

--- a/source/develop/release-management/features/storage/storagedomainliveupgrade.md
+++ b/source/develop/release-management/features/storage/storagedomainliveupgrade.md
@@ -1,8 +1,5 @@
 ---
 title: StorageDomainLiveUpgrade
-feature_name: Storage Domain Live Upgrade
-feature_modules: engine, vdsm
-feature_status: Released in oVirt 3.1
 category: feature
 authors: ekohl, smizrahi, vered
 ---

--- a/source/develop/release-management/features/storage/storagelivemigration.md
+++ b/source/develop/release-management/features/storage/storagelivemigration.md
@@ -1,9 +1,7 @@
 ---
 title: StorageLiveMigration
 authors: abaron, fsimonce, amureini, derez
-feature_name: Storage Live Migration
-feature_modules: engine, vdsm
-feature_status: Released in oVirt 3.1
+category: feature
 ---
 
 # Storage Live Migration

--- a/source/develop/release-management/features/storage/storagepool-metadata-removal.md
+++ b/source/develop/release-management/features/storage/storagepool-metadata-removal.md
@@ -2,9 +2,6 @@
 title: StoragePool Metadata Removal
 category: feature
 authors: amureini, fsimonce
-feature_name: StoragePool Metadata Removal
-feature_status: Released in oVirt 3.5
-feature_modules: vdsm, engine
 ---
 
 # StoragePool Metadata Removal

--- a/source/develop/release-management/features/storage/virtio-scsi.md
+++ b/source/develop/release-management/features/storage/virtio-scsi.md
@@ -1,9 +1,7 @@
 ---
 title: Virtio-SCSI
 authors: derez
-feature_name: Virtio-SCSI
-feature_modules: engine, vdsm
-feature_status: Released in oVirt 3.3
+category: feature
 ---
 
 # Virtio-SCSI

--- a/source/develop/release-management/features/storage/vm-leases-and-snapshots-behavior.md
+++ b/source/develop/release-management/features/storage/vm-leases-and-snapshots-behavior.md
@@ -2,9 +2,6 @@
 title: VM leases and snapshots behavior
 category: feature
 authors: eshenitz
-feature_name: VM leases and snapshots integration
-feature_modules: engine
-feature_status: Released in oVirt 4.2.2.1
 ---
 
 # VM leases and snapshots behavior

--- a/source/develop/release-management/features/storage/vm-leases.md
+++ b/source/develop/release-management/features/storage/vm-leases.md
@@ -2,9 +2,6 @@
 title: VM Leases
 category: feature
 authors: nsoffer
-feature_name: VM Leases
-feature_modules: engine,vdsm
-feature_status: Design
 ---
 
 # VM Leases

--- a/source/develop/release-management/features/storage/wipe-volumes-using-blkdiscard.md
+++ b/source/develop/release-management/features/storage/wipe-volumes-using-blkdiscard.md
@@ -2,9 +2,6 @@
 title: WipeVolumesUsingBlkdiscard
 category: feature
 authors: ishaby
-feature_name: Wipe volumes using blkdiscard
-feature_modules: vdsm
-feature_status: Work in progress for oVirt 4.1
 ---
 
 # Wipe volumes using blkdiscard

--- a/source/develop/release-management/features/ux/branding.md
+++ b/source/develop/release-management/features/ux/branding.md
@@ -2,9 +2,6 @@
 title: Branding
 category: feature
 authors: awels
-feature_name: Branding
-feature_modules: Branding
-feature_status: Released
 ---
 
 # Branding Support

--- a/source/develop/release-management/features/ux/uirefreshsynchronization.md
+++ b/source/develop/release-management/features/ux/uirefreshsynchronization.md
@@ -2,9 +2,6 @@
 title: UIRefreshSynchronization
 category: feature
 authors: awels
-feature_name: Refresh Synchronization
-feature_modules: webadmin,userportal
-feature_status: Released
 ---
 
 # UI Refresh Synchronization

--- a/source/develop/release-management/features/vdsm/libvdsm.md
+++ b/source/develop/release-management/features/vdsm/libvdsm.md
@@ -1,6 +1,6 @@
 ---
 title: libvdsm
-category: vdsm
+category: feature
 authors: aglitke
 ---
 

--- a/source/develop/release-management/features/vdsm/vdsm-plugin.md
+++ b/source/develop/release-management/features/vdsm/vdsm-plugin.md
@@ -1,6 +1,6 @@
 ---
 title: Node vdsm plugin
-category: node
+category: feature
 authors: mburns
 ---
 

--- a/source/develop/release-management/features/vdsm/vdsm-vm-query-api.md
+++ b/source/develop/release-management/features/vdsm/vdsm-vm-query-api.md
@@ -1,10 +1,7 @@
 ---
 title: VDSM VM Query API
-category: api
+category: feature
 authors: vfeenstr
-feature_name: VDSM VM Data Query API
-feature_modules: vdsm, engine-backend
-feature_status: Proposed
 ---
 
 # VDSM VM Data Query API

--- a/source/develop/release-management/features/virt/KvmToOvirt.md
+++ b/source/develop/release-management/features/virt/KvmToOvirt.md
@@ -2,9 +2,6 @@
 title: Importing Libvirt KVM VMs to oVirt
 category: feature
 authors: Shahar Havivi
-feature_name: 'v2v: Importing Libvirt Kvm Vms to oVirt'
-feature_modules: all
-feature_status: Released in oVirt 4.1
 ---
 
 # Importing Libvirt KVM VMs to oVirt

--- a/source/develop/release-management/features/virt/XenToOvirt.md
+++ b/source/develop/release-management/features/virt/XenToOvirt.md
@@ -2,9 +2,6 @@
 title: Importing Xen on REHL 5.x to oVirt
 category: feature
 authors: Shahar Havivi
-feature_name: 'v2v: Importing Xen on EL to oVirt'
-feature_modules: all
-feature_status: Released in oVirt 4.0
 ---
 
 # Importing Xen on EL 5.x VMs to oVirt

--- a/source/develop/release-management/features/virt/autoinstall-windows-drivers.md
+++ b/source/develop/release-management/features/virt/autoinstall-windows-drivers.md
@@ -2,9 +2,6 @@
 title: Automatic installation of Windows drivers
 category: feature
 authors: Tomáš Golembiovský
-feature_name: Automatic installation of Windows drivers
-feature_modules: engine, vdsm
-feature_status: In Progress
 ---
 
 # Automatic installation of Windows drivers

--- a/source/develop/release-management/features/virt/blank-to-defaults.md
+++ b/source/develop/release-management/features/virt/blank-to-defaults.md
@@ -1,9 +1,7 @@
 ---
 title: Blank to Defaults
 authors: tjelinek
-feature_name: Blank to Defaults
-feature_status: Released in oVirt 3.6
-feature_modules: engine
+category: feature
 ---
 
 # Blank to Defaults

--- a/source/develop/release-management/features/virt/bochs-display.md
+++ b/source/develop/release-management/features/virt/bochs-display.md
@@ -2,9 +2,6 @@
 title: Bochs-display
 category: feature
 authors: smelamud
-feature_name: Bochs-display
-feature_modules: engine
-feature_status: In development
 ---
 
 # Bochs-display

--- a/source/develop/release-management/features/virt/cluster-parameters-override.md
+++ b/source/develop/release-management/features/virt/cluster-parameters-override.md
@@ -2,9 +2,6 @@
 title: Cluster parameters override
 category: feature
 authors: eshachar, ofrenkel, sandrobonazzola
-feature_name: Cluster parameters override
-feature_modules: engine
-feature_status: On QA
 ---
 
 # Cluster parameters override

--- a/source/develop/release-management/features/virt/coreos-ignition-support.md
+++ b/source/develop/release-management/features/virt/coreos-ignition-support.md
@@ -2,9 +2,6 @@
 title: CoreOS ignition support
 category: feature
 authors: rgolan, lrotenbe
-feature_name: CoreOS ignition support
-feature_modules: engine
-feature_status: Merged
 ---
 
 # CoreOS ignition support

--- a/source/develop/release-management/features/virt/engine-support-for-ppc64.md
+++ b/source/develop/release-management/features/virt/engine-support-for-ppc64.md
@@ -2,9 +2,6 @@
 title: Engine support for PPC64
 category: feature
 authors: gustavo.pedrosa, lbianc, ppinatti, roy, vitordelima
-feature_name: Engine support for PPC64
-feature_modules: Engine, REST, UI
-feature_status: Released
 ---
 
 # Engine support for PPC64

--- a/source/develop/release-management/features/virt/enhance-import-export-with-ova.md
+++ b/source/develop/release-management/features/virt/enhance-import-export-with-ova.md
@@ -2,9 +2,6 @@
 title: Enhance import-export with OVA
 category: feature
 authors: arik, nirs, danielerez
-feature_name: Enhance import-export with OVA
-feature_modules: engine, vdsm
-feature_status: planning
 ---
 
 # Background

--- a/source/develop/release-management/features/virt/for-ppc64.md
+++ b/source/develop/release-management/features/virt/for-ppc64.md
@@ -1,10 +1,7 @@
 ---
 title: Vdsm for PPC64
-category: vdsm
+category: feature
 authors: bpradipt, danken, gustavo.pedrosa, lbianc, sandrobonazzola, vitordelima
-feature_name: VDSM for PPC64
-feature_modules: VDSM
-feature_status: Released
 ---
 
 # Vdsm for PPC64

--- a/source/develop/release-management/features/virt/guestagent.md
+++ b/source/develop/release-management/features/virt/guestagent.md
@@ -1,6 +1,6 @@
 ---
 title: GuestAgent
-category: debian
+category: feature
 authors: vfeenstr
 ---
 

--- a/source/develop/release-management/features/virt/guestagentdebian.md
+++ b/source/develop/release-management/features/virt/guestagentdebian.md
@@ -2,9 +2,6 @@
 title: GuestAgentDebian
 category: feature
 authors: vfeenstr
-feature_name: oVirt Guest Agent on Debian
-feature_modules: ovirt-guest-agent
-feature_status: Done
 ---
 
 # Guest Agent Debian

--- a/source/develop/release-management/features/virt/guestagentopensuse.md
+++ b/source/develop/release-management/features/virt/guestagentopensuse.md
@@ -2,9 +2,6 @@
 title: GuestAgentOpenSUSE
 category: feature
 authors: vfeenstr
-feature_name: oVirt Guest Agent on OpenSUSE
-feature_modules: ovirt-guest-agent
-feature_status: Done
 ---
 
 # Guest Agent Open SUSE

--- a/source/develop/release-management/features/virt/guestagentsles.md
+++ b/source/develop/release-management/features/virt/guestagentsles.md
@@ -2,9 +2,6 @@
 title: GuestAgentSLES
 category: feature
 authors: vfeenstr
-feature_name: oVirt Guest Agent on SLE(S)
-feature_modules: ovirt-guest-agent
-feature_status: Done
 ---
 
 # Guest Agent SLES

--- a/source/develop/release-management/features/virt/guestagentubuntu.md
+++ b/source/develop/release-management/features/virt/guestagentubuntu.md
@@ -2,9 +2,6 @@
 title: GuestAgentUbuntu
 category: feature
 authors: vfeenstr
-feature_name: oVirt Guest Agent on Ubuntu
-feature_modules: ovirt-guest-agent
-feature_status: Obsolete
 ---
 
 # Guest Agent Ubuntu

--- a/source/develop/release-management/features/virt/headless-vm.md
+++ b/source/develop/release-management/features/virt/headless-vm.md
@@ -1,10 +1,7 @@
 ---
-title: Headless VM 
+title: Headless VM
 category: feature
 authors: SharonG
-feature_name: Headless VM
-feature_modules: engine
-feature_status: Merged
 ---
 
 # Headless VM

--- a/source/develop/release-management/features/virt/high-performance-vm-migration.md
+++ b/source/develop/release-management/features/virt/high-performance-vm-migration.md
@@ -2,9 +2,6 @@
 title: Live migration for High Performance VMs
 category: feature
 authors: SharonG
-feature_name: Live migration for High Performance VMs
-feature_modules: engine
-feature_status: Merged
 ---
 
 # Live migration for High Performance VMs

--- a/source/develop/release-management/features/virt/high-performance-vm.md
+++ b/source/develop/release-management/features/virt/high-performance-vm.md
@@ -1,10 +1,7 @@
 ---
-title: High Performance VM 
+title: High Performance VM
 category: feature
 authors: SharonG
-feature_name: High Performance VM
-feature_modules: engine
-feature_status: Merged
 ---
 
 # High Performance VM

--- a/source/develop/release-management/features/virt/hostusb.md
+++ b/source/develop/release-management/features/virt/hostusb.md
@@ -1,9 +1,7 @@
 ---
 title: hostusb
+category: feature
 authors: dyasny, herrold
-feature_name: Expose Host attached USB to a Node
-feature_modules: "[Node(s) of feature]"
-feature_status: Obsolete
 ---
 
 # hostusb

--- a/source/develop/release-management/features/virt/hot-plug-memory.md
+++ b/source/develop/release-management/features/virt/hot-plug-memory.md
@@ -2,9 +2,6 @@
 title: Hot Plug Memory
 category: feature
 authors: ofrenkel
-feature_name: Hot plug memory
-feature_modules: engine
-feature_status: Done
 ---
 
 # Hot plug memory

--- a/source/develop/release-management/features/virt/hot-unplug-memory.md
+++ b/source/develop/release-management/features/virt/hot-unplug-memory.md
@@ -2,9 +2,6 @@
 title: Hot Unplug Memory
 category: feature
 authors: mzamazal,jniederm
-feature_name: Hot Unplug Memory
-feature_modules: engine,vdsm
-feature_status: Merged
 ---
 
 # Hot unplug memory

--- a/source/develop/release-management/features/virt/iothreads-support.md
+++ b/source/develop/release-management/features/virt/iothreads-support.md
@@ -1,8 +1,7 @@
 ---
 title: IOThreads Support
+category: feature
 authors: tjelinek
-feature_name: IOThreads Support
-feature_status: Released in oVirt 3.6
 ---
 
 # IOThreads Support

--- a/source/develop/release-management/features/virt/maximum-memory-size.md
+++ b/source/develop/release-management/features/virt/maximum-memory-size.md
@@ -1,9 +1,7 @@
 ---
 title: Maximum memory size
+category: feature
 authors: jniederm
-feature_name: Maximum memory size
-feature_modules: engine
-feature_status: Done
 ---
 
 # Maximum memory size

--- a/source/develop/release-management/features/virt/migration-encryption.md
+++ b/source/develop/release-management/features/virt/migration-encryption.md
@@ -2,8 +2,6 @@
 title: Migration encryption
 category: feature
 authors: mzamazal, ljelinko
-feature_name: Migration encryption
-feature_modules: engine, vdsm
 ---
 
 # Migration encryption

--- a/source/develop/release-management/features/virt/migration-enhancements.md
+++ b/source/develop/release-management/features/virt/migration-enhancements.md
@@ -2,9 +2,6 @@
 title: Migration Enhancements
 category: feature
 authors: mpolednik, mskrivan, ofrenkel, sandrobonazzola, tjelinek
-feature_name: Migration Enhancements
-feature_modules: engine, vdsm
-feature_status: Partly available in oVirt 4.0
 ---
 
 # Migration Enhancements

--- a/source/develop/release-management/features/virt/nvdimm-device.md
+++ b/source/develop/release-management/features/virt/nvdimm-device.md
@@ -2,9 +2,6 @@
 title: NVDIMM devices
 category: feature
 authors: mzamazal
-feature_name: NVDIMM devices
-feature_modules: engine,vdsm
-feature_status: In development
 ---
 
 # NVDIMM devices

--- a/source/develop/release-management/features/virt/nvram-data.md
+++ b/source/develop/release-management/features/virt/nvram-data.md
@@ -2,9 +2,6 @@
 title: Secure boot NVRAM data persistence
 category: feature
 authors: tgolembi,mzamazal
-feature_name: NVRAM data persistence
-feature_modules: engine,vdsm
-feature_status: In development
 ---
 
 # Secure boot NVRAM data persistence

--- a/source/develop/release-management/features/virt/os-info.md
+++ b/source/develop/release-management/features/virt/os-info.md
@@ -2,9 +2,6 @@
 title: OS info
 category: feature
 authors: mlipchuk, roy, sandrobonazzola
-feature_name: OS info
-feature_modules: oVirt
-feature_status: Released
 ---
 
 # OS info

--- a/source/develop/release-management/features/virt/ppc64le-support.md
+++ b/source/develop/release-management/features/virt/ppc64le-support.md
@@ -1,9 +1,7 @@
 ---
 title: ppc64le support
-category: ovirt-3.6-proposed-feature
+category: feature
 authors: mpolednik
-feature_name: ppc64le support
-feature_status: Released in oVirt 3.6
 ---
 
 # ppc64le Support

--- a/source/develop/release-management/features/virt/prestartedvm.md
+++ b/source/develop/release-management/features/virt/prestartedvm.md
@@ -1,6 +1,6 @@
 ---
 title: PrestartedVm
-category: template
+category: feature
 authors: msalem, ovedo, tdosek
 ---
 

--- a/source/develop/release-management/features/virt/qemu-ga.md
+++ b/source/develop/release-management/features/virt/qemu-ga.md
@@ -2,9 +2,6 @@
 title: QEMU Guest Agent integration
 category: feature
 authors: tgolembi
-feature_name: QEMU Guest Agent
-feature_modules: vdsm
-feature_status: In Development
 ---
 
 # QEMU Guest Agent integration

--- a/source/develop/release-management/features/virt/ram-snapshots.md
+++ b/source/develop/release-management/features/virt/ram-snapshots.md
@@ -2,8 +2,6 @@
 title: RAM Snapshots
 category: feature
 authors: arik
-feature_name: RAM Snapshots
-feature_status: Released in oVirt 3.3
 ---
 
 # RAM Snapshots

--- a/source/develop/release-management/features/virt/secure-cpus.md
+++ b/source/develop/release-management/features/virt/secure-cpus.md
@@ -2,8 +2,6 @@
 title: Default / Secure CPU Type Concept
 category: feature
 authors: ljelinko, mskrivan
-feature_name: Default / Secure CPU Type Concept
-feature_modules: engine
 ---
 
 # Default / Secure CPU Type Concept

--- a/source/develop/release-management/features/virt/serial-console.md
+++ b/source/develop/release-management/features/virt/serial-console.md
@@ -2,9 +2,6 @@
 title: Serial Console
 category: feature
 authors: alonbl, fromani, vitordelima
-feature_name: oVirt serial console
-feature_modules: vdsm,engine,ovirt-host-deploy-ovirt-vmconsole
-feature_status: In QA
 ---
 
 # oVirt Serial Console

--- a/source/develop/release-management/features/virt/tpm-device.md
+++ b/source/develop/release-management/features/virt/tpm-device.md
@@ -2,9 +2,6 @@
 title: TPM devices
 category: feature
 authors: mzamazal
-feature_name: TPM devices
-feature_modules: engine,vdsm
-feature_status: In development
 ---
 
 # TPM devices

--- a/source/develop/release-management/features/virt/virt-sparsify.md
+++ b/source/develop/release-management/features/virt/virt-sparsify.md
@@ -2,9 +2,6 @@
 title: Virt-Sparsify
 category: feature
 authors: doron, shaharh, smelamud
-feature_name: Virt-Sparsify
-feature_modules: Engine, VDSM
-feature_status: Released
 ---
 
 

--- a/source/develop/release-management/features/virt/virt-sysprep.md
+++ b/source/develop/release-management/features/virt/virt-sysprep.md
@@ -1,9 +1,7 @@
 ---
 title: virt-sysprep
 authors: smelamud
-feature_name: Sealing a VM Template
-feature_modules: engine,vdsm
-feature_status: Released
+category: feature
 ---
 
 # Sealing a VM Template

--- a/source/develop/release-management/features/virt/virt-v2v-integration.md
+++ b/source/develop/release-management/features/virt/virt-v2v-integration.md
@@ -2,9 +2,6 @@
 title: virt-v2v Integration
 category: feature
 authors: arik
-feature_name: Extended import of Virtual Machines
-feature_modules: engine,vdsm
-feature_status: Merged
 ---
 
 # virt-v2v Integration

--- a/source/develop/release-management/features/virt/virtio-rng-enhancements.md
+++ b/source/develop/release-management/features/virt/virtio-rng-enhancements.md
@@ -1,9 +1,6 @@
 ---
 title: Virtio RNG Enhancements
 authors: jniederm
-feature_name: Virtio RNG Enhancements
-feature_modules: virtio
-feature_status: WIP
 ---
 
 # Virtio RNG Enhancements

--- a/source/develop/release-management/features/virt/vm-icons.md
+++ b/source/develop/release-management/features/virt/vm-icons.md
@@ -2,9 +2,6 @@
 title: VM Icons
 category: feature
 authors: jniederm
-feature_name: VM Icons
-feature_modules: engine
-feature_status: Done
 ---
 
 # VM Icons

--- a/source/develop/release-management/features/virt/vm-lifecycle-with-kubevirt.md
+++ b/source/develop/release-management/features/virt/vm-lifecycle-with-kubevirt.md
@@ -1,10 +1,7 @@
 ---
-title: VM lifecycle in Kubevirt 
+title: VM lifecycle in Kubevirt
 category: feature
 authors: arik
-feature_name: VM lifecycle in Kubevirt
-feature_modules: engine
-feature_status: 
 ---
 
 This page proposes a gradual way to integrate the virtualization management platform oVirt and containers management platform Kubernetes.

--- a/source/develop/sla/affinity-labels.md
+++ b/source/develop/sla/affinity-labels.md
@@ -1,8 +1,5 @@
 ---
 authors: msivak
-feature_name: Affinity labels
-feature_modules: engine
-feature_status: Released in oVirt 4.0 RC
 ---
 
 # Affinity labels
@@ -26,6 +23,7 @@ feature_status: Released in oVirt 4.0 RC
 
 1. Each VM can be pinned to multiple specific hosts with the given HW. It will start on one of the listed hosts and no migration is enabled.
 1. VM to VM affinity is supported and can be used, but it only tries to put all those VMs on the same host. Subcluster is not supported.
+1. Released in oVirt 4.0 RC
 
 
 ## Feature goals


### PR DESCRIPTION
Changes proposed in this pull request:

- Dropped legacy and outdated feature_ metadata. They were supposed to be used for populating "At a glance" box like in
https://web.archive.org/web/20160228214221/http://www.ovirt.org/develop/release-management/features/network/detailedhostnetworkingapi

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @duck-rh @bproffitt @dneary @thatdocslady 
