### PR TITLE
update engine-supported-time-zones tutorial

### DIFF
--- a/source/develop/developer-guide/engine/engine-supported-time-zones.md
+++ b/source/develop/developer-guide/engine/engine-supported-time-zones.md
@@ -1,19 +1,31 @@
 ---
 title: Engine supported Time Zones
-authors: mbetak
+authors:
+- mbetak
+- sabusale
 ---
 
 # Engine supported Time Zones
 
-Due to the fact the supported timezone list needs to be shared between the engine frontend, backend and also the engine-config tool the list of supported time zones is concentrated in
+Engine default time-zones can be found in `<ENGINE_DEPLOYMENT>/etc/ovirt-engine/timezones/00-defaults.properties`
 
-<http://gerrit.ovirt.org/gitweb?p=ovirt-engine.git;a=blob;f=backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/TimeZoneType.java>
+####Timezones file format:
 
-There are two basic sets of timezone keys:
+key must be valid General timezone from tz database, value must be a valid Windows timezone
+*   General - time zones used for non-Windows OS types, that follows the standard [tz format](http://en.wikipedia.org/wiki/Tz_database) e.g. 'Etc/GMT' or 'Asia/Jerusalem'
 
 *   Windows - time zones specifically supported in [Windows](http://msdn.microsoft.com/en-us/library/ms912391(v=winembedded.11).aspx) e.g. 'GMT Standard Time' or 'Israel Standard Time'
-*   General - time zones used for non-Windows OS types. Keys follow the standard [tz format](http://en.wikipedia.org/wiki/Tz_database) e.g. 'Etc/GMT' or 'Asia/Jerusalem'
 
-Note that one must differentiate between timezone **Key** and **Display value**. Time zone key is the string used when configuring DefaultWindowsTimeZone or DefaultGeneralTimeZone using the engine-config tool. Display value on the other hand is displayed in webadmin UI and multiple timezone keys may correspond to the same display value.
 
-All (currently supported) mappings or time zone keys to display value can be found in the [TimeZoneType.java](http://gerrit.ovirt.org/gitweb?p=ovirt-engine.git;a=blob;f=backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/TimeZoneType.java) file. Due to occasional changes in the TZ data this may get out of date so when in doubt, please reference the current master version of the file.
+for example, see [here](https://github.com/oVirt/ovirt-engine/blob/ovirt-engine-4.4.8.4/packaging/conf/timezones-defaults.properties#L12)
+
+
+## Extending the time zone list:
+ovirt users can extend the default time zone list and add their own timezones
+
+In order to do that:
+- add new file in `<ENGINE_DEPLOYMENT>/etc/ovirt-engine/timezones`, for example: `10-timezones.properties`
+- add your own time zone with correct format (as described above)
+- restart the engine
+
+After following this steps new time zone should appear on the engine and can be used


### PR DESCRIPTION
Changes proposed in this pull request:

This pull request updates the engine-supported-time-zones tutorial to support latest functionality change that was done here since version 4.4.8 [here](https://gerrit.ovirt.org/c/ovirt-engine/+/115342)

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @mention yourself to sign)

This pull request needs review by: (please @mention the reviewer if relevant)
@ahadas @sandrobonazzola 