### PR TITLE
Remove link to conference registration in home page

### DIFF
--- a/source/index.haml
+++ b/source/index.haml
@@ -23,9 +23,6 @@ hide_metadata: true
 %div.banner
   %a(href="https://blogs.ovirt.org/ovirt-2021-online-conference/")
     %img#rome(src="images/banners/BannerConf2021.png" style="display:block; margin-left: auto; margin-right: auto; align-items: center; margin-bottom: 50px;")
-  %h2(style="display:block; margin-left: auto; margin-right: auto; align-items: center; margin-bottom: 50px; text-align: center; font-weight: bold;")
-    %a(href="https://www.eventbrite.it/e/ovirt-2021-online-conference-registration-165090567331?aff=website")
-      REGISTER NOW!
 
 %section.intro
   .container


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove link to conference registration in home page

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

