### PR TITLE
DRAFT: BZ1974729 - Update Cinderlib installation instructions

### DIFF
--- a/source/documentation/common/install/appe-Set_up_Cinderlib.adoc
+++ b/source/documentation/common/install/appe-Set_up_Cinderlib.adoc
@@ -17,7 +17,7 @@ endif::[]
 +
 ----
 
-# subscription-manager repos --enable=openstack-16.1-cinderlib-for-rhel-8-x86_64-rpms
+# subscription-manager repos --enable=openstack-16.2-cinderlib-for-rhel-8-x86_64-rpms
 ----
 
 ifdef::ovirt-doc[]
@@ -50,7 +50,7 @@ endif::[]
 . Enable the `openstack-cinderlib` repositories on Red Hat Enterprise Linux:
 +
 ----
-# subscription-manager repos --enable=openstack-16.1-cinderlib-for-rhel-8-x86_64-rpms
+# subscription-manager repos --enable=openstack-16.2-cinderlib-for-rhel-8-x86_64-rpms
 ----
 
 ifdef::ovirt-doc[]
@@ -80,9 +80,7 @@ If you are using Cinderlib together with a ceph driver:
 . Enable the following repositories on Red Hat Enterprise Linux:
 +
 ----
-# subscription-manager repos --enable=rhceph-4-osd-for-rhel-8-x86_64-rpms \
-                                          --enable=rhceph-4-mon-for-rhel-8-x86_64-rpms \
-                                          --enable=rhceph-4-tools-for-rhel-8-x86_64-rpms
+# subscription-manager repos --enable=rhceph-4-tools-for-rhel-8-x86_64-rpms
 ----
 
 ifdef::ovirt-doc[]

--- a/source/documentation/common/install/proc-Configuring_the_Red_Hat_Virtualization_Manager.adoc
+++ b/source/documentation/common/install/proc-Configuring_the_Red_Hat_Virtualization_Manager.adoc
@@ -47,9 +47,6 @@ Set up Cinderlib integration
 (Currently in tech preview)
 (Yes, No) [No]:
 ----
-+
-For instructions on setting up Cinderlib, see xref:Set_up_Cinderlib[Setting up Cinderlib].
-+
 
 [IMPORTANT]
 ====

--- a/source/documentation/common/install/proc-Enabling_the_Red_Hat_Enterprise_Linux_Host_Repositories.adoc
+++ b/source/documentation/common/install/proc-Enabling_the_Red_Hat_Enterprise_Linux_Host_Repositories.adoc
@@ -50,7 +50,9 @@ To list all enabled repositories:
     --enable=rhel-8-for-x86_64-appstream-rpms \
     --enable=rhv-4-mgmt-agent-for-rhel-8-x86_64-rpms \
     --enable=fast-datapath-for-rhel-8-x86_64-rpms \
-    --enable=advanced-virt-for-rhel-8-x86_64-rpms
+    --enable=advanced-virt-for-rhel-8-x86_64-rpms \
+    --enable=openstack-16.2-cinderlib-for-rhel-8-x86_64-rpms \
+    --enable=rhceph-4-tools-for-rhel-8-x86_64-rpms
 ----
 +
 ifdef::SM_localDB_deploy,SM_remoteDB_deploy[]
@@ -66,6 +68,8 @@ For {enterprise-linux} 8 hosts, little endian, on IBM POWER8 or IBM POWER9 hardw
     --enable=advanced-virt-for-rhel-8-ppc64le-rpms \
     --enable=rhel-8-for-ppc64le-appstream-rpms \
     --enable=rhel-8-for-ppc64le-baseos-rpms \
+    --enable=openstack-16.2-cinderlib-for-rhel-8-x86_64-rpms \
+    --enable=rhceph-4-tools-for-rhel-8-x86_64-rpms
 ----
 endif::SM_localDB_deploy,SM_remoteDB_deploy[]
 

--- a/source/documentation/common/install/proc-Enabling_the_Red_Hat_Enterprise_Linux_Host_Repositories.adoc
+++ b/source/documentation/common/install/proc-Enabling_the_Red_Hat_Enterprise_Linux_Host_Repositories.adoc
@@ -68,8 +68,6 @@ For {enterprise-linux} 8 hosts, little endian, on IBM POWER8 or IBM POWER9 hardw
     --enable=advanced-virt-for-rhel-8-ppc64le-rpms \
     --enable=rhel-8-for-ppc64le-appstream-rpms \
     --enable=rhel-8-for-ppc64le-baseos-rpms \
-    --enable=openstack-16.2-cinderlib-for-rhel-8-x86_64-rpms \
-    --enable=rhceph-4-tools-for-rhel-8-x86_64-rpms
 ----
 endif::SM_localDB_deploy,SM_remoteDB_deploy[]
 

--- a/source/documentation/common/install/proc-Enabling_the_Red_Hat_Virtualization_Manager_Repositories.adoc
+++ b/source/documentation/common/install/proc-Enabling_the_Red_Hat_Virtualization_Manager_Repositories.adoc
@@ -64,7 +64,10 @@ ifndef::remote_database_install,manual_database_install,migrate_SHE_DB,migrate_D
     --enable=rhel-8-for-x86_64-appstream-rpms \
     --enable=rhv-4.4-manager-for-rhel-8-x86_64-rpms \
     --enable=fast-datapath-for-rhel-8-x86_64-rpms \
-    --enable=jb-eap-7.4-for-rhel-8-x86_64-rpms
+    --enable=jb-eap-7.4-for-rhel-8-x86_64-rpms \
+    --enable=openstack-16.2-cinderlib-for-rhel-8-x86_64-rpms \
+    --enable=rhceph-4-tools-for-rhel-8-x86_64-rpms
+
 ----
 endif::remote_database_install,manual_database_install,migrate_SHE_DB,migrate_DWH_DB,install_DWH_remote,migrate_manager_db[]
 ifdef::remote_database_install,manual_database_install,migrate_DWH_DB,install_DWH_remote[]

--- a/source/documentation/installing_ovirt_as_a_self-hosted_engine_using_the_cockpit_web_interface/master.adoc
+++ b/source/documentation/installing_ovirt_as_a_self-hosted_engine_using_the_cockpit_web_interface/master.adoc
@@ -133,9 +133,6 @@ include::common/database/assembly-Migrating_Data_Warehouse_to_a_Separate_Machine
 //end sect
 
 [appendix]
-include::common/install/appe-Set_up_Cinderlib.adoc[leveloffset=+1]
-
-[appendix]
 include::common/install/proc-Configuring_a_Host_for_PCI_Passthrough.adoc[leveloffset=+1]
 
 ifdef::context[:parent-context: {context}]

--- a/source/documentation/installing_ovirt_as_a_self-hosted_engine_using_the_command_line/master.adoc
+++ b/source/documentation/installing_ovirt_as_a_self-hosted_engine_using_the_command_line/master.adoc
@@ -125,9 +125,6 @@ include::common/database/assembly-Migrating_Data_Warehouse_to_a_Separate_Machine
 //end sect
 
 [appendix]
-include::common/install/appe-Set_up_Cinderlib.adoc[leveloffset=+1]
-
-[appendix]
 include::common/install/proc-Configuring_a_Host_for_PCI_Passthrough.adoc[leveloffset=+1]
 
 ifdef::context[:parent-context: {context}]

--- a/source/documentation/installing_ovirt_as_a_standalone_manager_with_local_databases/index.adoc
+++ b/source/documentation/installing_ovirt_as_a_standalone_manager_with_local_databases/index.adoc
@@ -106,9 +106,6 @@ include::common/database/proc-Preparing_a_Local_Manually-Configured_PostgreSQL_D
 include::common/install/proc-Configuring_a_Host_for_PCI_Passthrough.adoc[leveloffset=+1]
 
 [appendix]
-include::common/install/appe-Set_up_Cinderlib.adoc[leveloffset=+1]
-
-[appendix]
 include::common/admin/proc-Removing_Red_Hat_Virtualization_Manager.adoc[leveloffset=+1]
 
 ifdef::context[:parent-context: {context}]

--- a/source/documentation/installing_ovirt_as_a_standalone_manager_with_local_databases/master.adoc
+++ b/source/documentation/installing_ovirt_as_a_standalone_manager_with_local_databases/master.adoc
@@ -104,9 +104,6 @@ include::common/database/proc-Preparing_a_Local_Manually-Configured_PostgreSQL_D
 :context: SM_localDB_deploy
 
 [appendix]
-include::common/install/appe-Set_up_Cinderlib.adoc[leveloffset=+1]
-
-[appendix]
 include::common/install/proc-Configuring_a_Host_for_PCI_Passthrough.adoc[leveloffset=+1]
 
 [appendix]

--- a/source/documentation/installing_ovirt_as_a_standalone_manager_with_remote_databases/index.adoc
+++ b/source/documentation/installing_ovirt_as_a_standalone_manager_with_remote_databases/index.adoc
@@ -107,9 +107,6 @@ include::common/storage/assembly-Adding_Storage_Domains_to_RHV.adoc[leveloffset=
 include::common/install/proc-Configuring_a_Host_for_PCI_Passthrough.adoc[leveloffset=+1]
 
 [appendix]
-include::common/install/appe-Set_up_Cinderlib.adoc[leveloffset=+1]
-
-[appendix]
 include::common/admin/proc-Removing_Red_Hat_Virtualization_Manager.adoc[leveloffset=+1]
 
 ifdef::context[:parent-context: {context}]

--- a/source/documentation/installing_ovirt_as_a_standalone_manager_with_remote_databases/master.adoc
+++ b/source/documentation/installing_ovirt_as_a_standalone_manager_with_remote_databases/master.adoc
@@ -105,9 +105,6 @@ include::common/install/proc-Configuring_an_Offline_Repository_for_Red_Hat_Virtu
 :context: SM_remoteDB_deploy
 
 [appendix]
-include::common/install/appe-Set_up_Cinderlib.adoc[leveloffset=+1]
-
-[appendix]
 include::common/install/proc-Configuring_a_Host_for_PCI_Passthrough.adoc[leveloffset=+1]
 
 [appendix]


### PR DESCRIPTION
Fixes issue https://bugzilla.redhat.com/show_bug.cgi?id=1974729 and https://bugzilla.redhat.com/show_bug.cgi?id=1997666

Changes proposed in this pull request:

- remove reference to two channels -osd- and -mon- as described in https://bugzilla.redhat.com/show_bug.cgi?id=1997666
- change references cinderlib from 16.1 to 16.2 - rename channel openstack-16.1-cinderlib-for-rhel-8-x86_64-rpms to openstack-16.2-cinderlib-for-rhel-8-x86_64-rpms
- https://bugzilla.redhat.com/show_bug.cgi?id=1974729#c2 - i.e. remove appendix C and move part of the content to install section (i.e. add the cinderlib and ceph-tools channels) for both manager and engine

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (@dcdacosta)

This pull request needs review by: (@michalskrivanek @bennyz )
