### PR TITLE
Deprecation message for deployment with remote engine database

### DIFF
--- a/source/documentation/common/install/proc-Configuring_the_Red_Hat_Virtualization_Manager.adoc
+++ b/source/documentation/common/install/proc-Configuring_the_Red_Hat_Virtualization_Manager.adoc
@@ -251,6 +251,12 @@ Engine database password:
 endif::SM_localDB_deploy[]
 
 ifdef::SM_remoteDB_deploy[]
+
+[NOTE]
+====
+Deployment with a remote engine database is now deprecated. This functionality will be removed in a future release.
+====
+
 ** If you select `Remote`, input the following values for the preconfigured remote database server. Replace `localhost` with the ip address or FQDN of the remote database server:
 +
 [options="nowrap" subs="normal"]


### PR DESCRIPTION
Fixes issue https://bugzilla.redhat.com/show_bug.cgi?id=1996036

Changes proposed in this pull request:

- Adds deprecation note to step 13 of the "Installing and Configuring the Red Hat Virtualization Manager" as specified by the BZ. 

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @RichardHoch

This pull request needs review by: @stoobie.  
