### PR TITLE
BZ#1991914 note regarding minor version compatibility for backup restore

### DIFF
--- a/source/documentation/administration_guide/topics/Restoring_a_Backup_with_the_engine-backup_Command.adoc
+++ b/source/documentation/administration_guide/topics/Restoring_a_Backup_with_the_engine-backup_Command.adoc
@@ -6,6 +6,6 @@ Restoring a backup using the engine-backup command involves more steps than crea
 [IMPORTANT]
 ====
 The version of the {virt-product-fullname} {engine-name} (such as 4.4.8) used to restore a backup must be later than or equal to the {virt-product-fullname} {engine-name} version (such as 4.4.7) used to create the backup.
-Starting with {virt-product-fullname} 4.4.7, this policy is strictly enforced by the engine-backup command. See link:{URL_virt_product_docs}{URL_format}upgrade_guide/index#Updating_the_Red_Hat_Virtualization_Manager_minor_updates[Updating the {virt-product-fullname} {engine-name}] in the _Upgrade Guide_.
+Starting with {virt-product-fullname} 4.4.7, this policy is strictly enforced by the engine-backup command.
 To view the version of {virt-product-fullname} contained in a backup file, unpack the backup file and read the value in the *version* file located in the root directory of the unpacked files.
 ====

--- a/source/documentation/administration_guide/topics/Restoring_a_Backup_with_the_engine-backup_Command.adoc
+++ b/source/documentation/administration_guide/topics/Restoring_a_Backup_with_the_engine-backup_Command.adoc
@@ -5,6 +5,7 @@ Restoring a backup using the engine-backup command involves more steps than crea
 
 [IMPORTANT]
 ====
-Backups can only be restored to environments of the same major release as that of the backup. For example, a backup of a {virt-product-fullname} version 4.2 environment can only be restored to another {virt-product-fullname} version 4.2 environment. Starting with {virt-product-fullname} 4.4.7, when using the engine-backup command, the minor version of the {engine-name} (such as 4.4.8) must be later than or equal to the minor version of the backup (such as 4.4.7). 
+The version of the {virt-product-fullname} {engine-name} (such as 4.4.8) used to restore a backup must be later than or equal to the {virt-product-fullname} {engine-name} version (such as 4.4.7) used to create the backup.
+Starting with {virt-product-fullname} 4.4.7, this policy is strictly enforced by the engine-backup command. See link:{URL_virt_product_docs}{URL_format}upgrade_guide/index#Updating_the_Red_Hat_Virtualization_Manager_minor_updates[Updating the {virt-product-fullname} {engine-name}] in the _Upgrade Guide_.
 To view the version of {virt-product-fullname} contained in a backup file, unpack the backup file and read the value in the *version* file located in the root directory of the unpacked files.
 ====

--- a/source/documentation/administration_guide/topics/Restoring_a_Backup_with_the_engine-backup_Command.adoc
+++ b/source/documentation/administration_guide/topics/Restoring_a_Backup_with_the_engine-backup_Command.adoc
@@ -5,8 +5,5 @@ Restoring a backup using the engine-backup command involves more steps than crea
 
 [IMPORTANT]
 ====
-Backups can only be restored to environments of the same major release as that of the backup. For example, a backup of a {virt-product-fullname} version 4.2 environment can only be restored to another {virt-product-fullname} version 4.2 environment. To view the version of {virt-product-fullname} contained in a backup file, unpack the backup file and read the value in the *version* file located in the root directory of the unpacked files.
+Backups can only be restored to environments of the same release as that of the backup or later. For example, a backup of a {virt-product-fullname} version 4.2.6 environment can only be restored to a {virt-product-fullname} version 4.2.6 or later environment. To view the version of {virt-product-fullname} contained in a backup file, unpack the backup file and read the value in the *version* file located in the root directory of the unpacked files.
 ====
-
-
-

--- a/source/documentation/administration_guide/topics/Restoring_a_Backup_with_the_engine-backup_Command.adoc
+++ b/source/documentation/administration_guide/topics/Restoring_a_Backup_with_the_engine-backup_Command.adoc
@@ -5,5 +5,6 @@ Restoring a backup using the engine-backup command involves more steps than crea
 
 [IMPORTANT]
 ====
-Backups can only be restored to environments of the same release as that of the backup or later. For example, a backup of a {virt-product-fullname} version 4.2.6 environment can only be restored to a {virt-product-fullname} version 4.2.6 or later environment. To view the version of {virt-product-fullname} contained in a backup file, unpack the backup file and read the value in the *version* file located in the root directory of the unpacked files.
+Backups can only be restored to environments of the same major release as that of the backup. For example, a backup of a {virt-product-fullname} version 4.2 environment can only be restored to another {virt-product-fullname} version 4.2 environment. Starting with {virt-product-fullname} 4.4.7, when using the engine-backup command, the minor version of the {engine-name} (such as 4.4.8) must be later than or equal to the minor version of the backup (such as 4.4.7). 
+To view the version of {virt-product-fullname} contained in a backup file, unpack the backup file and read the value in the *version* file located in the root directory of the unpacked files.
 ====

--- a/source/documentation/common/backup-restore/assembly-Backing_up_and_Restoring_a_Self-Hosted_Engine.adoc
+++ b/source/documentation/common/backup-restore/assembly-Backing_up_and_Restoring_a_Self-Hosted_Engine.adoc
@@ -25,7 +25,9 @@ This procedure assumes that you have access and can make changes to the original
 
 * A fully qualified domain name prepared for your {engine-name} and the host. Forward and reverse lookup records must both be set in the DNS. The new {engine-name} must have the same fully qualified domain name as the original {engine-name}.
 
-* The original {engine-name} must be updated to the latest minor version. Backups can only be restored to environments of the same major release as that of the backup. For example, a backup of a {virt-product-fullname} version 4.2 environment can only be restored to another {virt-product-fullname} version 4.2 environment. Starting with {virt-product-fullname} 4.4.7, when using the engine-backup command, the minor version of the {engine-name} (such as 4.4.8) must be later than or equal to the minor version of the backup (such as 4.4.7). See link:{URL_virt_product_docs}{URL_format}upgrade_guide/index#Updating_the_Red_Hat_Virtualization_Manager_minor_updates[Updating the {virt-product-fullname} {engine-name}] in the _Upgrade Guide_.
+* The original {engine-name} must be updated to the latest minor version.
+The version of the {virt-product-fullname} {engine-name} (such as 4.4.8) used to restore a backup must be later than or equal to the {virt-product-fullname} {engine-name} version (such as 4.4.7) used to create the backup.
+Starting with {virt-product-fullname} 4.4.7, this policy is strictly enforced by the engine-backup command. See link:{URL_virt_product_docs}{URL_format}upgrade_guide/index#Updating_the_Red_Hat_Virtualization_Manager_minor_updates[Updating the {virt-product-fullname} {engine-name}] in the _Upgrade Guide_.
 
 * The data center compatibility level must be set to the latest version to ensure compatibility with the updated storage version.
 

--- a/source/documentation/common/backup-restore/assembly-Backing_up_and_Restoring_a_Self-Hosted_Engine.adoc
+++ b/source/documentation/common/backup-restore/assembly-Backing_up_and_Restoring_a_Self-Hosted_Engine.adoc
@@ -26,9 +26,12 @@ This procedure assumes that you have access and can make changes to the original
 * A fully qualified domain name prepared for your {engine-name} and the host. Forward and reverse lookup records must both be set in the DNS. The new {engine-name} must have the same fully qualified domain name as the original {engine-name}.
 
 * The original {engine-name} must be updated to the latest minor version.
-The version of the {virt-product-fullname} {engine-name} (such as 4.4.8) used to restore a backup must be later than or equal to the {virt-product-fullname} {engine-name} version (such as 4.4.7) used to create the backup.
+[The version of the {virt-product-fullname} {engine-name} (such as 4.4.8) used to restore a backup must be later than or equal to the {virt-product-fullname} {engine-name} version (such as 4.4.7) used to create the backup.
 Starting with {virt-product-fullname} 4.4.7, this policy is strictly enforced by the engine-backup command. See link:{URL_virt_product_docs}{URL_format}upgrade_guide/index#Updating_the_Red_Hat_Virtualization_Manager_minor_updates[Updating the {virt-product-fullname} {engine-name}] in the _Upgrade Guide_.
-
+[NOTE]
+====
+If you need to restore a backup, but do not have a new appliance, the restore process will pause, and you can log into the temporary {engine-name} machine via SSH, register, subscribe, or configure channels as needed, and upgrade the {engine-name} packages before resuming the restore process.
+====
 * The data center compatibility level must be set to the latest version to ensure compatibility with the updated storage version.
 
 * There must be at least one regular host in the environment. This host (and any other regular hosts) will remain active to host the SPM role and any running virtual machines. If a regular host is not already the SPM, move the SPM role before creating the backup by selecting a regular host and clicking menu:Management[Select as SPM].

--- a/source/documentation/common/backup-restore/assembly-Backing_up_and_Restoring_a_Self-Hosted_Engine.adoc
+++ b/source/documentation/common/backup-restore/assembly-Backing_up_and_Restoring_a_Self-Hosted_Engine.adoc
@@ -28,10 +28,12 @@ This procedure assumes that you have access and can make changes to the original
 * The original {engine-name} must be updated to the latest minor version.
 [The version of the {virt-product-fullname} {engine-name} (such as 4.4.8) used to restore a backup must be later than or equal to the {virt-product-fullname} {engine-name} version (such as 4.4.7) used to create the backup.
 Starting with {virt-product-fullname} 4.4.7, this policy is strictly enforced by the engine-backup command. See link:{URL_virt_product_docs}{URL_format}upgrade_guide/index#Updating_the_Red_Hat_Virtualization_Manager_minor_updates[Updating the {virt-product-fullname} {engine-name}] in the _Upgrade Guide_.
++
 [NOTE]
 ====
 If you need to restore a backup, but do not have a new appliance, the restore process will pause, and you can log into the temporary {engine-name} machine via SSH, register, subscribe, or configure channels as needed, and upgrade the {engine-name} packages before resuming the restore process.
 ====
++
 * The data center compatibility level must be set to the latest version to ensure compatibility with the updated storage version.
 
 * There must be at least one regular host in the environment. This host (and any other regular hosts) will remain active to host the SPM role and any running virtual machines. If a regular host is not already the SPM, move the SPM role before creating the backup by selecting a regular host and clicking menu:Management[Select as SPM].

--- a/source/documentation/common/backup-restore/assembly-Backing_up_and_Restoring_a_Self-Hosted_Engine.adoc
+++ b/source/documentation/common/backup-restore/assembly-Backing_up_and_Restoring_a_Self-Hosted_Engine.adoc
@@ -25,7 +25,7 @@ This procedure assumes that you have access and can make changes to the original
 
 * A fully qualified domain name prepared for your {engine-name} and the host. Forward and reverse lookup records must both be set in the DNS. The new {engine-name} must have the same fully qualified domain name as the original {engine-name}.
 
-* The original {engine-name} must be updated to the latest minor version. The {engine-name} version in the backup file must match the version of the new {engine-name}. See link:{URL_virt_product_docs}{URL_format}upgrade_guide/index#Updating_the_Red_Hat_Virtualization_Manager_minor_updates[Updating the {virt-product-fullname} {engine-name}] in the _Upgrade Guide_.
+* The original {engine-name} must be updated to the latest minor version. Backups can only be restored to environments of the same major release as that of the backup. For example, a backup of a {virt-product-fullname} version 4.2 environment can only be restored to another {virt-product-fullname} version 4.2 environment. Starting with {virt-product-fullname} 4.4.7, when using the engine-backup command, the minor version of the {engine-name} (such as 4.4.8) must be later than or equal to the minor version of the backup (such as 4.4.7). See link:{URL_virt_product_docs}{URL_format}upgrade_guide/index#Updating_the_Red_Hat_Virtualization_Manager_minor_updates[Updating the {virt-product-fullname} {engine-name}] in the _Upgrade Guide_.
 
 * The data center compatibility level must be set to the latest version to ensure compatibility with the updated storage version.
 


### PR DESCRIPTION
Fixes issue [BZ#1991914](https://bugzilla.redhat.com/show_bug.cgi?id=1991914)

Changes proposed in this pull request:
update note regarding matching version of backup and engine environment version - 
- in Admin Guide under "Restoring a Backup with the engine-backup Command"
- in Upgrade Guide under "Backing up and restoring a Self-hosted engine" > prerequisites

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (@emarcusRH )

This pull request needs review by: (@didib )
