### PR TITLE
upgrade_guide_docinfo Restored missing docinfo.xml file.

### DIFF
--- a/source/documentation/upgrade_guide/docinfo.xml
+++ b/source/documentation/upgrade_guide/docinfo.xml
@@ -1,0 +1,18 @@
+<title>Upgrade Guide</title>
+<productname>Red Hat Virtualization</productname>
+<productnumber>{vernum_rhv}</productnumber>
+<subtitle>Update and upgrade tasks for Red Hat Virtualization</subtitle>
+<abstract><para>A comprehensive guide to upgrading and updating components in a Red Hat Virtualization environment.</para></abstract>
+<authorgroup id="Author_Group">
+	<author>
+		<firstname>Red Hat Virtualization</firstname><surname>Documentation Team</surname>
+		<affiliation>
+			<orgname>
+				Red Hat
+			</orgname>
+			<orgdiv>
+				Customer Content Services
+			</orgdiv>
+		</affiliation><email>rhev-docs@redhat.com</email>
+	</author>
+</authorgroup>


### PR DESCRIPTION
Restores missing docinfo.xml file to upgrade guide.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @stoobie 

This pull request needs review by: @RichardHoch 
