### PR TITLE
ovirt-issue2595 update javapackages enable command

### DIFF
--- a/source/documentation/common/install/proc-Enabling_the_Red_Hat_Virtualization_Manager_Repositories.adoc
+++ b/source/documentation/common/install/proc-Enabling_the_Red_Hat_Virtualization_Manager_Repositories.adoc
@@ -104,7 +104,7 @@ You can check which repositories are currently enabled by running `dnf repolist`
 +
 [options="nowrap" subs="normal"]
 ----
-# dnf module -y javapackages-tools
+# dnf module -y enable javapackages-tools
 ----
 
 endif::ovirt-doc[]


### PR DESCRIPTION
Fixes issue # 2595

Changes proposed in this pull request:

- add the word ENABLE to the javapackages-tools command in the installation guides// enabling ovirt-engine repositories

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): ( @emarcusRH )

This pull request needs review by: (@sandrobonazzola )
