### PR TITLE
Add note about migrating VMs with CPU Passthrough

### DIFF
--- a/source/documentation/common/upgrade/proc-Upgrading_hosts_to_4-4.adoc
+++ b/source/documentation/common/upgrade/proc-Upgrading_hosts_to_4-4.adoc
@@ -12,6 +12,13 @@ This process requires migrating all virtual machines from one host so as to make
 
 include::snip_WARNING-detach_data_storage.adoc[]
 
+[NOTE]
+====
+CPU-passthrough virtual machines might not migrate properly from {virt-product-shortname} 4.3 to {virt-product-shortname} 4.4.
+
+{virt-product-shortname} 4.3 and {virt-product-shortname} 4.4 are based on {enterprise-linux-shortname} 7 and {enterprise-linux-shortname} 8, respectively, which have different kernel versions with different CPU flags and microcodes. This can cause problems in migrating CPU-passthrough virtual machines.
+====
+
 .Prerequisites
 
 * Hosts for {virt-product-shortname} 4.4 require {enterprise-linux} 8.2 or later. A clean installation of {enterprise-linux} 8.2 or later, or {hypervisor-fullname} 4.4 is required, even if you are using the same physical machine that you use to run hosts for {virt-product-shortname} 4.3.

--- a/source/documentation/common/upgrade/snip_NOTE-CPU_passthrough.adoc
+++ b/source/documentation/common/upgrade/snip_NOTE-CPU_passthrough.adoc
@@ -1,6 +1,0 @@
-[NOTE]
-====
-CPU-passthrough virtual machines might not migrate properly from {virt-product-shortname} 4.3 to {virt-product-shortname} 4.4.
-
-{virt-product-shortname} 4.3 and {virt-product-shortname} 4.4 are based on {enterprise-linux-shortname} 7 and {enterprise-linux-shortname} 8, respectively, which have different kernel versions with different CPU flags and microcodes. This can cause problems in migrating CPU-passthrough virtual machines. 
-====

--- a/source/documentation/common/upgrade/snip_NOTE-CPU_passthrough.adoc
+++ b/source/documentation/common/upgrade/snip_NOTE-CPU_passthrough.adoc
@@ -1,0 +1,6 @@
+[NOTE]
+====
+CPU-passthrough virtual machines might not migrate properly from {virt-product-shortname} 4.3 to {virt-product-shortname} 4.4.
+
+{virt-product-shortname} 4.3 and {virt-product-shortname} 4.4 are based on {enterprise-linux-shortname} 7 and {enterprise-linux-shortname} 8, respectively, which have different kernel versions with different CPU flags and microcodes. This can cause problems in migrating CPU-passthrough virtual machines. 
+====

--- a/source/documentation/virtual_machine_management_guide/topics/Automatic_virtual_machine_migration.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Automatic_virtual_machine_migration.adoc
@@ -8,10 +8,3 @@ From version 4.3, all virtual machines defined with manual or automatic migratio
 The {engine-name} automatically initiates live migration of virtual machines in order to maintain load-balancing or power-saving levels in line with scheduling policy. Specify the scheduling policy that best suits the needs of your environment. You can also disable automatic, or even manual, live migration of specific virtual machines where required.
 
 If your virtual machines are configured for high performance, and/or if they have been pinned (by setting Passthrough Host CPU, CPU Pinning, or NUMA Pinning), the migration mode is set to *Allow manual migration only*. However, this can be changed to *Allow Manual and Automatic* mode if required. Special care should be taken when changing the default migration setting so that it does not result in a virtual machine migrating to a host that does not support high performance or pinning.
-
-[NOTE]
-====
-CPU-passthrough virtual machines might not migrate properly from {virt-product-shortname} 4.3 to {virt-product-shortname} 4.4.
-
-{virt-product-shortname} 4.3 and {virt-product-shortname} 4.4 are based on {enterprise-linux-shortname} 7 and {enterprise-linux-shortname} 8, respectively, which have different kernel versions with different CPU flags and microcodes. This can cause problems in migrating CPU-passthrough virtual machines.
-====

--- a/source/documentation/virtual_machine_management_guide/topics/Automatic_virtual_machine_migration.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Automatic_virtual_machine_migration.adoc
@@ -3,8 +3,15 @@
 
 {virt-product-fullname} {engine-name} automatically initiates live migration of all virtual machines running on a host when the host is moved into maintenance mode. The destination host for each virtual machine is assessed as the virtual machine is migrated, in order to spread the load across the cluster.
 
-From version 4.3, all virtual machines defined with manual or automatic migration modes are migrated when the host is moved into maintenance mode. However, for high performance and/or pinned virtual machines, a *Maintenance Host* window is displayed, asking you to confirm the action because the performance on the target host may be less than the performance on the current host.   
+From version 4.3, all virtual machines defined with manual or automatic migration modes are migrated when the host is moved into maintenance mode. However, for high performance and/or pinned virtual machines, a *Maintenance Host* window is displayed, asking you to confirm the action because the performance on the target host may be less than the performance on the current host.
 
-The {engine-name} automatically initiates live migration of virtual machines in order to maintain load-balancing or power-saving levels in line with scheduling policy. Specify the scheduling policy that best suits the needs of your environment. You can also disable automatic, or even manual, live migration of specific virtual machines where required. 
+The {engine-name} automatically initiates live migration of virtual machines in order to maintain load-balancing or power-saving levels in line with scheduling policy. Specify the scheduling policy that best suits the needs of your environment. You can also disable automatic, or even manual, live migration of specific virtual machines where required.
 
 If your virtual machines are configured for high performance, and/or if they have been pinned (by setting Passthrough Host CPU, CPU Pinning, or NUMA Pinning), the migration mode is set to *Allow manual migration only*. However, this can be changed to *Allow Manual and Automatic* mode if required. Special care should be taken when changing the default migration setting so that it does not result in a virtual machine migrating to a host that does not support high performance or pinning.
+
+[NOTE]
+====
+CPU-passthrough virtual machines might not migrate properly from {virt-product-shortname} 4.3 to {virt-product-shortname} 4.4.
+
+{virt-product-shortname} 4.3 and {virt-product-shortname} 4.4 are based on {enterprise-linux-shortname} 7 and {enterprise-linux-shortname} 8, respectively, which have different kernel versions with different CPU flags and microcodes. This can cause problems in migrating CPU-passthrough virtual machines.
+====

--- a/source/documentation/virtual_machine_management_guide/topics/Manually_migrating_virtual_machines.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Manually_migrating_virtual_machines.adoc
@@ -15,6 +15,12 @@ When you place a host into maintenance mode, the virtual machines running on tha
 Live migrating virtual machines between different clusters is generally not recommended. The currently only supported use case is documented at link:https://access.redhat.com/articles/1390733[].
 ====
 
+[NOTE]
+====
+CPU-passthrough virtual machines might not migrate properly from {virt-product-shortname} 4.3 to {virt-product-shortname} 4.4.
+
+{virt-product-shortname} 4.3 and {virt-product-shortname} 4.4 are based on {enterprise-linux-shortname} 7 and {enterprise-linux-shortname} 8, respectively, which have different kernel versions with different CPU flags and microcodes. This can cause problems in migrating CPU-passthrough virtual machines.
+====
 
 *Manually Migrating Virtual Machines*
 

--- a/source/documentation/virtual_machine_management_guide/topics/Manually_migrating_virtual_machines.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Manually_migrating_virtual_machines.adoc
@@ -15,14 +15,7 @@ When you place a host into maintenance mode, the virtual machines running on tha
 Live migrating virtual machines between different clusters is generally not recommended. The currently only supported use case is documented at link:https://access.redhat.com/articles/1390733[].
 ====
 
-[NOTE]
-====
-CPU-passthrough virtual machines might not migrate properly from {virt-product-shortname} 4.3 to {virt-product-shortname} 4.4.
-
-{virt-product-shortname} 4.3 and {virt-product-shortname} 4.4 are based on {enterprise-linux-shortname} 7 and {enterprise-linux-shortname} 8, respectively, which have different kernel versions with different CPU flags and microcodes. This can cause problems in migrating CPU-passthrough virtual machines.
-====
-
-*Manually Migrating Virtual Machines*
+.Procedure
 
 . Click menu:Compute[Virtual Machines] and select a running virtual machine.
 . Click btn:[Migrate].


### PR DESCRIPTION
Fixes issue https://bugzilla.redhat.com/show_bug.cgi?id=2002146

Changes proposed in this pull request:

- Adds note about why migrating VMs with CPU passthrough from RHV 4.3 to 4.4 might not work.

Previews:

Upgrade guide: same note for each relevant upgrade option:

http://file.emea.redhat.com/rhoch/20112021/upgrade/html-single/#Upgrading_hosts_to_4-4_4-3_local_db

http://file.emea.redhat.com/rhoch/20112021/upgrade/html-single/#Upgrading_hosts_to_4-4_4-3_remote_db

http://file.emea.redhat.com/rhoch/20112021/upgrade/html-single/#Upgrading_hosts_to_4-4_4-3_SHE


I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @RichardHoch 

This pull request needs review by the reporter of the BZ.
