### PR TITLE
4.4.9: explicitly require 8.5 beta or newer

### DIFF
--- a/source/release/4.4.9/index.md
+++ b/source/release/4.4.9/index.md
@@ -18,7 +18,7 @@ designed to manage your entire enterprise infrastructure.
 oVirt uses the trusted KVM hypervisor and is built upon several other community
 projects, including libvirt, Gluster, PatternFly, and Ansible.
 
-This release is available now for Red Hat Enterprise Linux 8.4 (or similar) and CentOS Stream.
+This release is available now for Red Hat Enterprise Linux 8.5 (8.5 Beta) (or similar) and CentOS Stream.
 
 > **NOTE**
 >


### PR DESCRIPTION
Changes proposed in this pull request:

- oVirt 4.4.9 has requirements that can be satisfied only by RHEL 8.5 beta or newer

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola
