### PR TITLE
4.4.9 requires RHEL 8.5 beta or newer

### DIFF
--- a/source/download/alternate_downloads.md
+++ b/source/download/alternate_downloads.md
@@ -26,8 +26,7 @@ Engine:
 - CentOS Stream
 
 Hosts:
-- Red Hat Enterprise Linux 8.4
-- CentOS Linux 8.4
+- Red Hat Enterprise Linux 8.5 beta (or similar)
 - oVirt Node (based on CentOS Stream)
 - CentOS Stream
 

--- a/source/download/index.md
+++ b/source/download/index.md
@@ -18,8 +18,7 @@ Engine:
 - CentOS Stream
 
 Hosts:
-- Red Hat Enterprise Linux 8.4
-- CentOS Linux 8.4
+- Red Hat Enterprise Linux 8.5 beta (or similar)
 - oVirt Node (based on CentOS Stream)
 - CentOS Stream
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Update download pages for 4.4.9 explicitly requiring 8.5 beta or newer for hosts

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 
