### PR TITLE
oVirt DevOps: point to right tracker

### DIFF
--- a/source/community/becoming-an-infrastructure-team-member.md
+++ b/source/community/becoming-an-infrastructure-team-member.md
@@ -16,7 +16,7 @@ This page describes the process for becoming a member of the Infrastructure team
 The Infrastructure team primarily uses three resources to get stuff done:
 
 * [The infra mailing list](https://lists.ovirt.org/archives/list/infra@ovirt.org/) for asynchronous communication
-* [oVirt infra Jira](https://ovirt-jira.atlassian.net/browse/OVIRT) for issue tracking
+* [CPE DevOps Jira](https://issues.redhat.com/projects/CPDEVOPS/summary) for issue tracking
 
 In general, the team hangs out on the general `#ovirt` IRC channel on OFTC (`irc.oftc.net`).
 
@@ -24,7 +24,7 @@ To start getting involved in the Infrastructure team, introduce yourself on the 
 Your self-introduction should include your name, relevant experience, and why you are interested in helping with oVirt infrastructure.
 
 In step 1, you should get familiar with
-* [the team goals](/develop/infra/infrastructure-documentation.html) 
+* [the team goals](/develop/infra/infrastructure-documentation.html)
 * [the team members](/develop/infra/infrastructure-team-administrators.html)
 * the skills we have
 * the infrastructure we use (such as [git](/develop/infra/infrastructure-git-repository.html) and [puppet](/develop/infra/infrastructure-puppet-details.html))

--- a/source/community/becoming-an-infrastructure-team-member.md
+++ b/source/community/becoming-an-infrastructure-team-member.md
@@ -16,7 +16,7 @@ This page describes the process for becoming a member of the Infrastructure team
 The Infrastructure team primarily uses three resources to get stuff done:
 
 * [The infra mailing list](https://lists.ovirt.org/archives/list/infra@ovirt.org/) for asynchronous communication
-* [CPE DevOps Jira](https://issues.redhat.com/projects/CPDEVOPS/summary) for issue tracking
+* [The infra ticketing system](https://issues.redhat.com/projects/CPDEVOPS/summary) for issue tracking
 
 In general, the team hangs out on the general `#ovirt` IRC channel on OFTC (`irc.oftc.net`).
 

--- a/source/develop/infra/infrastructure.md
+++ b/source/develop/infra/infrastructure.md
@@ -76,19 +76,19 @@ People who come to work on this project are *not* already experts, but they migh
 
 You can open a ticket on [the infra ticketing system](https://issues.redhat.com/projects/CPDEVOPS/summary).
 
-Please note that sending email infra-support@ovirt.org will automatically open a ticket on
-the deprecated [oVirt Jira Atlassina instance](https://ovirt-jira.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=OVIRT)
-which is not monitored anymore. Please don't use the infra-support@ovirt.org until it will be redirected
+Please note that sending an email to infra-support@ovirt.org will automatically open a ticket on
+the deprecated [oVirt Jira Atlassian instance](https://ovirt-jira.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=OVIRT)
+which is not monitored anymore. Please don't use the infra-support@ovirt.org until it is redirected
 to the new [infra ticketing system](https://issues.redhat.com/projects/CPDEVOPS/summary).
 
 ### Joining
 
-*   To gain access to systems - think of them as keys to doors - we match your skill and the trust you have built with the project. This is part of being a [meritocracy](/community/about/governance.html).
-*   Interested to join the Infrastructure Team ? [Click here](/community/becoming-an-infrastructure-team-member.html)
+*   To gain access to systems - think of them as keys to doors - we match your skill and the trust you have built with the project.
+*   Interested in joining the Infrastructure Team ? [Click here](/community/becoming-an-infrastructure-team-member.html)
 
 ### Communication
 
-The main thing is, come communicate with us if you have any questions, are interested in learning more, or what to participate in supporting oVirt infrastructure.
+The main thing is to communicate with us if you have any questions, are interested in learning more, or want to participate in supporting oVirt infrastructure.
 
 *   [Mailing list infra@ovirt.org](https://lists.ovirt.org/archives/list/infra@ovirt.org/)
 *   [IRC channel #ovirt on OFTC](irc://irc.oftc.net/#ovirt)
@@ -99,11 +99,11 @@ The main thing is, come communicate with us if you have any questions, are inter
 
 ### Decision process
 
-* The Infra team generally follows the principle that if it didn't get discussed on the [mailing list](https://lists.ovirt.org/archives/list/infra@ovirt.org/) it didn't really happen.
+* The Infra team generally follows the principle that if it wasn't discussed on the [mailing list](https://lists.ovirt.org/archives/list/infra@ovirt.org/) it didn't really happen.
 * This means all important or broad-reaching decisions are discussed and decided on the mailing list.
-* The team uses the same [collaborative decision process](https://blogs.apache.org/comdev/entry/how_apache_projects_use_consensus) that other oVirt teams use, with some lightweight elements added to move along minor votes.
+* The team uses the same [collaborative decision process](https://blogs.apache.org/comdev/entry/how_apache_projects_use_consensus) that other oVirt teams use, with some lightweight elements added to move along minor votes
   * +1 is a vote in favor of a proposition
-  * -1 is a vote against a proposition, must be accompanied with an explanation of the negative vote.
+  * -1 is a vote against a proposition, must be accompanied with an explanation of the negative vote
   * +/-0 is an abstention
   * 3 or more +1 votes are required for anything substantial, important, or far-reaching
   * 0 or more votes will pass a minor proposition - "If no one objects, it passes."

--- a/source/develop/infra/infrastructure.md
+++ b/source/develop/infra/infrastructure.md
@@ -74,7 +74,7 @@ People who come to work on this project are *not* already experts, but they migh
 
 ### Opening tickets to the Infra team
 
-*   Email infra-support@ovirt.org, this will automatically open a ticket on our [Jira instance](https://ovirt-jira.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=OVIRT). If you don't have a user, it will automatically send you a registration email and set you as a watcher on the ticket.
+*   Email infra-support@ovirt.org, this will automatically open a ticket on our [CPE DevOps Jira](https://issues.redhat.com/projects/CPDEVOPS/summary). If you don't have a user, it will automatically send you a registration email and set you as a watcher on the ticket.
 
 ### Joining
 

--- a/source/develop/infra/infrastructure.md
+++ b/source/develop/infra/infrastructure.md
@@ -74,7 +74,12 @@ People who come to work on this project are *not* already experts, but they migh
 
 ### Opening tickets to the Infra team
 
-*   Email infra-support@ovirt.org, this will automatically open a ticket on our [CPE DevOps Jira](https://issues.redhat.com/projects/CPDEVOPS/summary). If you don't have a user, it will automatically send you a registration email and set you as a watcher on the ticket.
+You can open a ticket on [the infra ticketing system](https://issues.redhat.com/projects/CPDEVOPS/summary).
+
+Please note that sending email infra-support@ovirt.org will automatically open a ticket on
+the deprecated [oVirt Jira Atlassina instance](https://ovirt-jira.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=OVIRT)
+which is not monitored anymore. Please don't use the infra-support@ovirt.org until it will be redirected
+to the new [infra ticketing system](https://issues.redhat.com/projects/CPDEVOPS/summary).
 
 ### Joining
 


### PR DESCRIPTION
Changes proposed in this pull request:

- the oVirt jira on atlassian server is not monitored anymore by the oVirt DevOps team. Updating the documentation pointing to the new Jira tracker. Issue: https://issues.redhat.com/browse/CPDEVOPS-327

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @jekader @marchukov 
