### PR TITLE
BZ#1968483 update to EAP 7.4 channel in installation and upgrade guides

### DIFF
--- a/source/documentation/common/install/proc-Enabling_the_Red_Hat_Virtualization_Manager_Repositories.adoc
+++ b/source/documentation/common/install/proc-Enabling_the_Red_Hat_Virtualization_Manager_Repositories.adoc
@@ -64,7 +64,7 @@ ifndef::remote_database_install,manual_database_install,migrate_SHE_DB,migrate_D
     --enable=rhel-8-for-x86_64-appstream-rpms \
     --enable=rhv-4.4-manager-for-rhel-8-x86_64-rpms \
     --enable=fast-datapath-for-rhel-8-x86_64-rpms \
-    --enable=jb-eap-7.3-for-rhel-8-x86_64-rpms
+    --enable=jb-eap-7.4-for-rhel-8-x86_64-rpms
 ----
 endif::remote_database_install,manual_database_install,migrate_SHE_DB,migrate_DWH_DB,install_DWH_remote,migrate_manager_db[]
 ifdef::remote_database_install,manual_database_install,migrate_DWH_DB,install_DWH_remote[]

--- a/source/documentation/common/install/snip-RHVM_repo_steps.adoc
+++ b/source/documentation/common/install/snip-RHVM_repo_steps.adoc
@@ -29,6 +29,6 @@
     --enable=rhel-8-for-x86_64-baseos-rpms \
     --enable=rhel-8-for-x86_64-appstream-rpms \
     --enable=rhv-4.4-manager-for-rhel-8-x86_64-rpms \
-    --enable=fast-datapath-for-rhel-8-x86_64-rpms \    
-    --enable=jb-eap-7.3-for-rhel-8-x86_64-rpms
+    --enable=fast-datapath-for-rhel-8-x86_64-rpms \
+    --enable=jb-eap-7.4-for-rhel-8-x86_64-rpms
 ----

--- a/source/documentation/common/upgrade/proc-Updating_the_Red_Hat_Virtualization_Manager.adoc
+++ b/source/documentation/common/upgrade/proc-Updating_the_Red_Hat_Virtualization_Manager.adoc
@@ -33,7 +33,7 @@ link:{URL_virt_product_docs}{URL_format}installing_{URL_product_virt}_as_a_stand
 +
 [NOTE]
 ====
-If you are upgrading from {virt-product-shortname} version 4.4.0 through 4.4.6 to {virt-product-shortname} version 4.4.7 or later, you must add the EAP 7.4 channel to the list of subscription repositories `jb-eap-7.4-for-rhel-8-x86_64-rpms`, and following the upgrade, remove the `jb-eap-7.3-for-rhel-8-x86_64-rpms` from the lisat of subscription repositories.
+If you are upgrading from {virt-product-shortname} version 4.4.0 through 4.4.8 to {virt-product-shortname} version 4.4.9 or later, you must add the EAP 7.4 channel to the list of subscription repositories `jb-eap-7.4-for-rhel-8-x86_64-rpms`, and following the upgrade, remove the `jb-eap-7.3-for-rhel-8-x86_64-rpms` from the lisat of subscription repositories.
 ====
 endif::SHE_minor_updates,migrating_to_SHE,minor_updates[]
 +

--- a/source/documentation/common/upgrade/proc-Updating_the_Red_Hat_Virtualization_Manager.adoc
+++ b/source/documentation/common/upgrade/proc-Updating_the_Red_Hat_Virtualization_Manager.adoc
@@ -30,6 +30,11 @@ link:{URL_customer-portal}{URL_docs}{URL_lang-locale}{URL_product_rhv}4.3/html-s
 endif::4-3_local_db,4-3_remote_db,4-3_SHE[]
 ifdef::SHE_minor_updates,migrating_to_SHE,minor_updates[]
 link:{URL_virt_product_docs}{URL_format}installing_{URL_product_virt}_as_a_standalone_manager_with_local_databases/index#Enabling_the_Red_Hat_Virtualization_Manager_Repositories_install_RHVM[Enabling the {virt-product-fullname} {engine-name} Repositories] for {virt-product-fullname} 4.4.
++
+[NOTE]
+====
+If you are upgrading from {virt-product-shortname} version 4.4.0 through 4.4.6 to {virt-product-shortname} version 4.4.7 or later, you must add the EAP 7.4 channel to the list of subscription repositories `jb-eap-7.4-for-rhel-8-x86_64-rpms`, and following the upgrade, remove the `jb-eap-7.3-for-rhel-8-x86_64-rpms` from the lisat of subscription repositories.
+====
 endif::SHE_minor_updates,migrating_to_SHE,minor_updates[]
 +
 Updates to the {virt-product-fullname} {engine-name} are released through the Content Delivery Network.


### PR DESCRIPTION
Fixes issue [BZ#1968384](https://bugzilla.redhat.com/show_bug.cgi?id=1968483)

** Do not release before: RHV 4.4.9 release

Changes proposed in this pull request:

- update EAP repository channel to 7.4

- add note in Upgrade guide regarding the EAP 7.4 requirement
 
- update repo listings in Release Notes and JAVA SDK document (downstream only docs) - see  [MR#2087](https://gitlab.cee.redhat.com/rhci-documentation/docs-Red_Hat_Enterprise_Virtualization/-/merge_requests/2087)

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @emarcusRH 

This pull request needs review by: @mwperina 
