### PR TITLE
Update stats URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -178,5 +178,5 @@ breadcrumbs:
 
 jekyll_analytics:
   Piwik:
-    url: stats.phx.ovirt.org
+    url: stats.ovirt.org
     siteId: '1'


### PR DESCRIPTION
The stats VM will be moved from PHX so changing the URL accordingly.

Note: Please do not merge until we complete the migration to avoid data loss.

Jira-ticket: https://issues.redhat.com/browse/CPDEVOPS-338
Signed-off-by: Evgheni Dereveanchin <ederevea@redhat.com>

Changes proposed in this pull request:

- change stats.phx.ovirt.org to stats.ovirt.org


I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @jekader 

This pull request needs review by: @sandrobonazzola 
