### PR TITLE
removing link to cockpit installation file

### DIFF
--- a/source/documentation/index.haml
+++ b/source/documentation/index.haml
@@ -21,7 +21,6 @@ hide_metadata: true
   .col-md-6.listNotAsUL
     :markdown
       ### oVirt User Documentation
-      - [Installing oVirt as a self-hosted engine using the Cockpit web interface](/documentation/installing_ovirt_as_a_self-hosted_engine_using_the_cockpit_web_interface/index.html)
       - [Installing oVirt as a self-hosted engine using the command line](/documentation/installing_ovirt_as_a_self-hosted_engine_using_the_command_line/index.html)
       - [Installing oVirt as a standalone Manager with local databases](/documentation/installing_ovirt_as_a_standalone_manager_with_local_databases/index.html)
       - [Installing oVirt as a standalone Manager with remote databases](/documentation/installing_ovirt_as_a_standalone_manager_with_remote_databases/index.html)


### PR DESCRIPTION
Fixes issue [BZ#2020448](https://bugzilla.redhat.com/show_bug.cgi?id=2020448)

Milestone: RHV 4.4.9 release

Changes proposed in this pull request:

- Remove link to "Installing SHE using Cockpit" in the index.haml for the oVirt site 

I confirm that this pull request was submitted according to the contribution guidelines: (@emarcusRH )

This pull request needs review by: (please @sandrobonazzola )
