### PR TITLE
Fixed preview link

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -55,6 +55,7 @@ jobs:
     outputs:
       PR_ID: ${{steps.details.outputs.PR_ID}}
       PREVIEW_PATH: ${{steps.details.outputs.PREVIEW_PATH}}
+      PREVIEW_LINK: ${{steps.details.outputs.PREVIEW_LINK}}
       PREVIEW_LINK_PATH: ${{steps.details.outputs.PREVIEW_LINK_PATH}}
       PREVIEW_LINK_BASE: ${{steps.details.outputs.PREVIEW_LINK_BASE}}
     steps:


### PR DESCRIPTION
This change fixes the preview links in the final message after the preview build is complete.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @janosdebugs 

This pull request needs review by: @sandrobonazzola 
