### PR TITLE
BZ1979811: Clarify Ansible scope

### DIFF
--- a/source/documentation/administration_guide/chap-Automating_RHV_Configuration_using_Ansible.adoc
+++ b/source/documentation/administration_guide/chap-Automating_RHV_Configuration_using_Ansible.adoc
@@ -1,22 +1,15 @@
 [[chap-Automating_RHV_Configuration_using_Ansible]]
 == Automating Configuration Tasks using Ansible
 
-Ansible is an automation tool used to configure systems, deploy software, and perform rolling updates. Ansible includes support for {virt-product-fullname}, and Ansible modules are available to allow you to automate post-installation tasks such as data center setup and configuration, managing users, or virtual machine operations.
+Ansible is an automation tool used to configure systems, deploy software, and perform rolling updates. {virt-product-fullname} includes a limited version of Ansible to automate {virt-product-shortname} post-installation tasks such as data center setup and configuration, managing users, and virtual machine operations.
 
-Ansible provides an easier method of automating {virt-product-fullname} configuration compared to REST APIs and SDKs, and allows you to integrate with other Ansible modules. For more information about the Ansible modules available for {virt-product-fullname}, see the link:https://cloud.redhat.com/ansible/automation-hub/redhat/rhv/docs[oVirt Ansible Collection] in the Red Hat Ansible Automation Hub documentation.
+Ansible provides an easier method of automating {virt-product-fullname} configuration compared to REST APIs and SDKs, and you can integrate with other Ansible modules. For more information about the Ansible modules available for {virt-product-fullname}, see the link:https://cloud.redhat.com/ansible/automation-hub/redhat/rhv/docs[oVirt Ansible Collection] in the Red Hat Ansible Automation Hub documentation.
 
 [NOTE]
 ====
 Ansible Tower is a graphically enabled framework accessible through a web interface and REST APIs for Ansible. If you want support for Ansible Tower, then you must have an Ansible Tower license, which is not part of the {virt-product-fullname} subscription.
 ====
-Ansible is shipped with {virt-product-fullname}. To install Ansible, run the following command on the {engine-name} machine:
-
-[options="nowrap" subs="normal"]
-----
-# dnf install ansible
-----
 
 See the link:http://docs.ansible.com/[Ansible Documentation] for alternate installation instructions, and information about using Ansible.
-
 
 include::topics/oVirt_Ansible_Collection.adoc[]

--- a/source/documentation/administration_guide/chap-Automating_RHV_Configuration_using_Ansible.adoc
+++ b/source/documentation/administration_guide/chap-Automating_RHV_Configuration_using_Ansible.adoc
@@ -10,6 +10,6 @@ Ansible provides an easier method of automating {virt-product-fullname} configur
 Ansible Tower is a graphically enabled framework accessible through a web interface and REST APIs for Ansible. If you want support for Ansible Tower, then you must have an Ansible Tower license, which is not part of the {virt-product-fullname} subscription.
 ====
 
-See the link:http://docs.ansible.com/[Ansible Documentation] for alternate installation instructions, and information about using Ansible.
+See the link:http://docs.ansible.com/[Ansible documentation] for alternate installation instructions, and information about using Ansible.
 
 include::topics/oVirt_Ansible_Collection.adoc[]


### PR DESCRIPTION
Bug fix

This PR addresses https://bugzilla.redhat.com/show_bug.cgi?id=1979811)

Changes proposed in this pull request:
- Changed verbiage to indicate that the version of Ansible included with oVirt/RHV is limited, not the full product.

Preview: https://ovirt.github.io/ovirt-site/previews/2637/documentation/administration_guide/index.html#chap-Automating_RHV_Configuration_using_Ansible

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @stoobie 
This pull request needs review by: @michalskrivanek 