### PR TITLE
Add oVirt dashpanel

### DIFF
--- a/.github/workflows/dashpanel.yml
+++ b/.github/workflows/dashpanel.yml
@@ -1,0 +1,32 @@
+name: Dashpanel
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '8 0 * * *'
+
+jobs:
+  build:
+    name: Dashpanel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Dashpanel
+        uses: haveyoudebuggedit/dashpanel@main
+        with:
+          orgnames: ovirt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: |
+          set -euo pipefail
+          mv dashpanel-*.md source/community
+          git config user.name "oVirt Dashpanel"
+          git config user.email noreply@github.com
+          git add source/community/dashpanel-*.md
+          if ! git diff-index --quiet HEAD --; then
+            git commit -m "Updating Dashpanel for oVirt"
+            git push --set-upstream origin master
+          else
+            echo -e "No changes found."
+          fi

--- a/source/community/index.md
+++ b/source/community/index.md
@@ -50,6 +50,7 @@ Before getting started, please read our [community etiquette guidelines](/commun
 
 If you'd like to contribute code to oVirt, visit the [Developer section](/develop/) of the site for guidelines. All of our projects use git. Most are hosted at [https://gerrit.ovirt.org/](https://gerrit.ovirt.org/), and the rest are hosted at [https://github.com/oVirt](https://github.com/oVirt/).
 
+We also have an [overview](https://github.com/oVirt/ovirt-site/blob/master/source/community/dashpanel-ovirt.md) of all open issues and PRs for oVirt on GitHub.
 
 ## Testing
 


### PR DESCRIPTION
Adds a [dashpanel](https://github.com/marketplace/actions/dashpanel) for oVirt that:

* Runs each day at 00:08 (can also be triggered manually)
* Produces a file called `dashpanel-ovirt.md` that lists all public oVirt repositories that have open issues and/or PRs
* Commits the output file into source/community
* Links to the .md file directly on the Community main page (we can change this later if we find we need it, the output file would then need a preamble to be used correctly by the site builder)

Successfully tested on a test repository.