### PR TITLE
migrating_to_github: require CI +1

### DIFF
--- a/source/develop/developer-guide/migrating_to_github.md
+++ b/source/develop/developer-guide/migrating_to_github.md
@@ -201,11 +201,10 @@ jobs:
 
 # Require "CI +1" for merging
 
-Once your GitHub Action is working, you can require it to pass in order to be able to merge the patch, similarly to "CI +1" used in Gerrit.
-For enabling it go to `https://github.com/oVirt/<your_project>/settings`.
+Once your GitHub Action is working, you can require it to pass in order to be able to merge the patch, similarly to "CI +1" used in Gerrit. For enabling it go to `https://github.com/oVirt/<your_project>/settings`.
 
 Within the `Branches` section:
-- edit the protection rule you setup for protected branches
-  - enable `Require status checks to pass before merging` ;
-  - enable `Require branches to be up to date before merging` ;
-  - Within the search tool `Search for status checks in the last week for this repository` search for the jobs required to pass (e.g. `build-el9` and `build-el8` from above).
+- Edit the protection rule you setup for protected branches
+  - Enable `Require status checks to pass before merging`
+  - Enable `Require branches to be up to date before merging`
+  - Within the search tool `Search for status checks in the last week for this repository` search for the jobs required to pass (e.g. `build-el9` and `build-el8` from above)

--- a/source/develop/developer-guide/migrating_to_github.md
+++ b/source/develop/developer-guide/migrating_to_github.md
@@ -198,3 +198,14 @@ jobs:
         name: artifacts
         path: exported-artifacts/
 ```
+
+# Require "CI +1" for merging
+
+Once your GitHub Action is working, you can require it to pass in order to be able to merge the patch, similarly to "CI +1" used in Gerrit.
+For enabling it go to `https://github.com/oVirt/<your_project>/settings`.
+
+Within the `Branches` section:
+- edit the protection rule you setup for protected branches
+  - enable `Require status checks to pass before merging` ;
+  - enable `Require branches to be up to date before merging` ;
+  - Within the search tool `Search for status checks in the last week for this repository` search for the jobs required to pass (e.g. `build-el9` and `build-el8` from above).


### PR DESCRIPTION
Fixes issue # (delete if not relevant)

Changes proposed in this pull request:

- Add instructions for requiring CI to pass before merging

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @sanjacodes 
