### PR TITLE
BZ2014790: [Docs] [DisasterRecovery] highlight that failovers cannot occur if the SPM is the point of failure if Power Management is not configured

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ source/.jekyll-metadata
 
 # ignore docs index.html: index.adoc is used instead
 source/documentation/*/index.html
+source/documentation/*/build/

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,6 @@ source/.jekyll-metadata
 /.dockerid
 /.gem-docker
 
-# ignore docs index.html: index.adoc is used instead
+# Ignore files generated for local previews of documentation
 source/documentation/*/index.html
 source/documentation/*/build/

--- a/source/documentation/administration_guide/topics/Manually_fencing_or_isolating_a_nonresponsive_host.adoc
+++ b/source/documentation/administration_guide/topics/Manually_fencing_or_isolating_a_nonresponsive_host.adoc
@@ -5,11 +5,11 @@ If a host unpredictably goes into a non-responsive state, for example, due to a 
 
 [WARNING]
 ====
-Do not use the *Confirm host has been rebooted* option unless you have manually rebooted the host. Using this option while the host is still running can lead to a virtual machine image corruption.
+Do not select *Confirm 'Host has been Rebooted'* unless you have manually rebooted the host. Using this option while the host is still running can lead to a virtual machine image corruption.
 ====
 
 
-*Manually fencing or isolating a non-responsive host*
+.Procedure
 
 . In the Administration Portal, click menu:Compute[Hosts] and confirm the host's status is `Non Responsive`.
 . Manually reboot the host. This could mean physically entering the lab and rebooting the host.

--- a/source/documentation/disaster_recovery_guide/assembly/asm_ActiveActiveDR.adoc
+++ b/source/documentation/disaster_recovery_guide/assembly/asm_ActiveActiveDR.adoc
@@ -1,11 +1,9 @@
 [[active_active]]
-== Active-Active Disaster Recovery
+= Active-Active Disaster Recovery
 :cptdir: ../concept
 :taskdir: ../task
 
-This chapter provides instructions to configure {virt-product-fullname} for disaster recovery using the active-active disaster recovery solution.
-
-include::{cptdir}/cpt_OverviewActiveActive.adoc[]
-include::{cptdir}/cpt_NetworkConsiderationsAA.adoc[]
-include::{cptdir}/cpt_StorageConsiderationsAA.adoc[]
-include::{taskdir}/task_ConfigureStretchCluster.adoc[]
+include::{cptdir}/cpt_OverviewActiveActive.adoc[leveloffset=+1]
+include::{cptdir}/cpt_NetworkConsiderationsAA.adoc[leveloffset=+1]
+include::{cptdir}/cpt_StorageConsiderationsAA.adoc[leveloffset=+1]
+include::{taskdir}/task_ConfigureStretchCluster.adoc[leveloffset=+1]

--- a/source/documentation/disaster_recovery_guide/assembly/asm_ActivePassiveDR.adoc
+++ b/source/documentation/disaster_recovery_guide/assembly/asm_ActivePassiveDR.adoc
@@ -1,14 +1,12 @@
 [[active_passive]]
-== Active-Passive Disaster Recovery
+= Active-Passive Disaster Recovery
 :cptdir: ../concept
 :taskdir: ../task
 
-This chapter provides instructions to configure {virt-product-fullname} for disaster recovery using the active-passive disaster recovery solution.
-
-include::{cptdir}/cpt_OverviewActivePassive.adoc[]
-include::{cptdir}/cpt_NetworkConsiderationsAP.adoc[]
-include::{cptdir}/cpt_StorageConsiderationsAP.adoc[]
-include::{taskdir}/task_CreateAnsiblePlaybooks.adoc[]
-include::{taskdir}/task_ExecuteFailover.adoc[]
-include::{taskdir}/task_Clean.adoc[]
-include::{taskdir}/task_ExecuteFailback.adoc[]
+include::{cptdir}/cpt_OverviewActivePassive.adoc[leveloffset=+1]
+include::{cptdir}/cpt_NetworkConsiderationsAP.adoc[leveloffset=+1]
+include::{cptdir}/cpt_StorageConsiderationsAP.adoc[leveloffset=+1]
+include::{taskdir}/task_CreateAnsiblePlaybooks.adoc[leveloffset=+1]
+include::{taskdir}/task_ExecuteFailover.adoc[leveloffset=+1]
+include::{taskdir}/task_Clean.adoc[leveloffset=+1]
+include::{taskdir}/task_ExecuteFailback.adoc[leveloffset=+1]

--- a/source/documentation/disaster_recovery_guide/concept/cpt_DisasterRecoverySolutions.adoc
+++ b/source/documentation/disaster_recovery_guide/concept/cpt_DisasterRecoverySolutions.adoc
@@ -1,14 +1,14 @@
 [[disaster_recovery_solutions]]
 
-== Disaster Recovery Solutions
+= Disaster Recovery Solutions
 
-{virt-product-fullname} (RHV) supports two types of disaster recovery solutions to ensure that environments can recover when a site outage occurs. Both solutions support two sites, and both require replicated storage.
+{virt-product-fullname} supports two types of disaster recovery solutions to ensure that environments can recover when a site outage occurs. Both solutions support two sites, and both require replicated storage.
 
-*Active-Active Disaster Recovery*:
+.Active-Active Disaster Recovery
 
-This solution is implemented using a stretch cluster configuration. This means that there is a single RHV environment with a cluster that contains hosts capable of running the required virtual machines in the primary and secondary site. Virtual machines automatically migrate to hosts in the secondary site if an outage occurs. However, the environment must meet latency and networking requirements. See <<active_active_overview>> for more information.
+This solution is implemented using a stretch cluster configuration. This means that there is a single {virt-product-shortname} environment with a cluster that contains hosts capable of running the required virtual machines in the primary and secondary site. Virtual machines automatically migrate to hosts in the secondary site if an outage occurs. However, the environment must meet latency and networking requirements. See xref:active_active_overview[Active-Active Overview] for more information.
 
 
-*Active-Passive Disaster Recovery*:
+.Active-Passive Disaster Recovery
 
-Also referred to as site-to-site failover, this disaster recovery solution is implemented by configuring two seperate RHV environments: the active primary environment, and the passive secondary (backup) environment. Failover and failback between sites must be manually executed, and is managed by Ansible. See <<active_passive_overview>> for more information.
+Also referred to as site-to-site failover, this disaster recovery solution is implemented by configuring two separate RHV environments: the active primary environment, and the passive secondary (backup) environment. Failover and failback between sites must be manually executed, and is managed by Ansible. See xref:active_passive_overview[Active-Passive Overview] for more information.

--- a/source/documentation/disaster_recovery_guide/concept/cpt_DisasterRecoverySolutions.adoc
+++ b/source/documentation/disaster_recovery_guide/concept/cpt_DisasterRecoverySolutions.adoc
@@ -11,4 +11,4 @@ This solution is implemented using a stretch cluster configuration. This means t
 
 .Active-Passive Disaster Recovery
 
-Also referred to as site-to-site failover, this disaster recovery solution is implemented by configuring two separate RHV environments: the active primary environment, and the passive secondary (backup) environment. Failover and failback between sites must be manually executed, and is managed by Ansible. See xref:active_passive_overview[Active-Passive Overview] for more information.
+Also referred to as site-to-site failover, this disaster recovery solution is implemented by configuring two separate {virt-product-shortname} environments: the active primary environment, and the passive secondary (backup) environment. Failover and failback between sites must be manually executed, and is managed by Ansible. See xref:active_passive_overview[Active-Passive Overview] for more information.

--- a/source/documentation/disaster_recovery_guide/concept/cpt_NetworkConsiderationsAA.adoc
+++ b/source/documentation/disaster_recovery_guide/concept/cpt_NetworkConsiderationsAA.adoc
@@ -1,6 +1,6 @@
 [[network_considerations]]
-==== Network Considerations
+= Network Considerations
 
-All hosts in the cluster must be on the same broadcast domain over an L2 network. This means that connectivity between the two sites needs to be L2.
+All hosts in the cluster must be on the same broadcast domain over an L2 network. So connectivity between the two sites must be L2.
 
-The maximum latency requirements between the sites across the L2 network differs for the two setups. The standalone {engine-name} environment requires a maximum latency of 100ms, while the self-hosted engine environment requires a maximum latency of 7ms.
+The maximum latency requirements between the sites across the L2 network differ for the two setups. The standalone {engine-name} environment requires a maximum latency of 100ms, while the self-hosted engine environment requires a maximum latency of 7ms.

--- a/source/documentation/disaster_recovery_guide/concept/cpt_NetworkConsiderationsAP.adoc
+++ b/source/documentation/disaster_recovery_guide/concept/cpt_NetworkConsiderationsAP.adoc
@@ -1,5 +1,5 @@
 [[network_considerations_active_passive]]
-==== Network Considerations
+= Network Considerations
 
 You must ensure that the same general connectivity exists in the primary and secondary sites.
 

--- a/source/documentation/disaster_recovery_guide/concept/cpt_OverviewActiveActive.adoc
+++ b/source/documentation/disaster_recovery_guide/concept/cpt_OverviewActiveActive.adoc
@@ -1,16 +1,16 @@
 [[active_active_overview]]
-=== Active-Active Overview
+= Active-Active Overview
 
-{virt-product-fullname} supports an active-active disaster recovery failover configuration that can span two sites. Both sites are active, and if the primary site becomes unavailable, the {virt-product-fullname} environment will continue to operate in the secondary site to ensure business continuity.
+The active-active disaster recovery failover configuration can span two sites. Both sites are active, and if the primary site becomes unavailable, the {virt-product-fullname} environment continues to operate in the secondary site to ensure business continuity.
 
-The active-active failover is achieved by configuring a stretch cluster where hosts capable of running the virtual machines are located in the primary and secondary site. All the hosts belong to the same {virt-product-fullname} cluster.
+The active-active failover configuration includes a stretch cluster in which hosts capable of running the virtual machines are located in both the primary and secondary sites. All the hosts belong to the same {virt-product-fullname} cluster.
 
-You require replicated storage that is writeable on both sites to allow virtual machines to migrate between sites and continue running on the site’s storage.
+This configuration requires replicated storage that is writeable on both sites so virtual machines can migrate between the two sites and continue running on both sites' storage.
 
 .Stretch Cluster Configuration
 image::StretchCluster.png[]
 
-Virtual machines will migrate to the secondary site if the primary site becomes unavailable. The virtual machines will automatically failback to the primary site when the site becomes available and the storage is replicated in both sites.
+Virtual machines migrate to the secondary site if the primary site becomes unavailable. The virtual machines automatically failback to the primary site when the site becomes available and the storage is replicated in both sites.
 
 .Failed Over Stretch Cluster
 image::StretchClusterFailover.png[]

--- a/source/documentation/disaster_recovery_guide/concept/cpt_OverviewActivePassive.adoc
+++ b/source/documentation/disaster_recovery_guide/concept/cpt_OverviewActivePassive.adoc
@@ -1,5 +1,5 @@
 [[active_passive_overview]]
-=== Active-Passive Overview
+= Active-Passive Overview
 
 {virt-product-fullname} supports an active-passive disaster recovery solution that can span two sites. If the primary site becomes unavailable, the {virt-product-fullname} environment can be forced to fail over to the secondary (backup) site.
 
@@ -17,7 +17,7 @@ You must ensure that the secondary environment has enough resources to run the f
 Storage domains that contain virtual machine disks and templates in the primary site must be replicated. These replicated storage domains must not be attached to the secondary site.
 ====
 
-The failover and failback process must be executed manually. To do this you need to create Ansible playbooks to map entities between the sites, and to manage the failover and failback processes. The mapping file instructs the {virt-product-fullname} components where to fail over or fail back to on the target site.
+The failover and failback process must be executed manually. To do this you must create Ansible playbooks to map entities between the sites, and to manage the failover and failback processes. The mapping file instructs the {virt-product-fullname} components where to fail over or fail back to on the target site.
 
 The following diagram describes an active-passive setup where the machine running Red Hat Ansible Engine is highly available, and has access to the `oVirt.disaster-recovery` Ansible role, configured playbooks, and mapping file. The storage domains that store the virtual machine disks in Site A is replicated. Site B has no virtual machines or attached storage domains.
 
@@ -30,4 +30,4 @@ When the environment fails over to Site B, the storage domains are first attache
 .Failover to Backup Site
 image::SiteToSiteFailover.png[]
 
-You will need to manually fail back to the primary site (Site A) when it is running again.
+You must manually fail back to the primary site (Site A) when it is running again.

--- a/source/documentation/disaster_recovery_guide/concept/cpt_StorageConsiderationsAA.adoc
+++ b/source/documentation/disaster_recovery_guide/concept/cpt_StorageConsiderationsAA.adoc
@@ -1,8 +1,15 @@
 [[storage_considerations_active_active]]
 = Storage Considerations
 
-The storage domain for {virt-product-fullname} can be made of either block devices (SAN - iSCSI or FCP) or a file system (NAS - NFS, GlusterFS, or other POSIX compliant file systems). For more information about {virt-product-fullname} storage see link:{URL_virt_product_docs}{URL_format}administration_guide/index#chap-Storage[Storage] in the _Administration Guide_.
+The storage domain for {virt-product-fullname} can comprise either block devices (SAN - iSCSI or FCP) or a file system (NAS - NFS, GlusterFS, or other POSIX compliant file systems). For more information about {virt-product-fullname} storage see link:{URL_virt_product_docs}{URL_format}administration_guide/index#chap-Storage[Storage] in the _Administration Guide_.
 
 The sites require synchronously replicated storage that is writeable on both sites with shared layer 2 (L2) network connectivity. The replicated storage is required to allow virtual machines to migrate between sites and continue running on the site’s storage. All storage replication options supported by {enterprise-linux} 7 and later can be used in the stretch cluster.
 
-IMPORTANT: If you have a custom multipath configuration that is recommended by the storage vendor, see the instructions and important limitations in link:{URL_virt_product_docs}{URL_format}installing_{URL_product_virt}_as_a_self-hosted_engine_using_the_command_line/index#proc-Customizing_Multipath_Configurations_for_SAN_Vendors_SHE_cli_deploy[Customizing Multipath Configurations for SAN Vendors].
+[IMPORTANT]
+====
+If you have a custom multipath configuration that is recommended by the storage vendor, see the instructions and important limitations in link:{URL_virt_product_docs}{URL_format}installing_{URL_product_virt}_as_a_self-hosted_engine_using_the_command_line/index#proc-Customizing_Multipath_Configurations_for_SAN_Vendors_SHE_cli_deploy[Customizing Multipath Configurations for SAN Vendors].
+====
+
+Set the SPM role on a host at the primary site to have precedence. To do so, configure SPM priority as high in the primary site hosts and SPM priority as low on secondary site hosts. Doing so prepares for recovery if you have a primary site failure that impacts network devices inside the primary site, preventing the fencing device for the SPM host from being reachable, such as power loss.
+
+If you do not take this precaution, in such a scenario virtual machines do a failover, but operations that require the SPM role in place cannot be executed, including adding new disks, extending existing disks, and exporting virtual machines. You must declare *Confirm host has been rebooted* for the SPM host.

--- a/source/documentation/disaster_recovery_guide/concept/cpt_StorageConsiderationsAA.adoc
+++ b/source/documentation/disaster_recovery_guide/concept/cpt_StorageConsiderationsAA.adoc
@@ -1,7 +1,7 @@
 [[storage_considerations_active_active]]
 = Storage Considerations
 
-The storage domain for {virt-product-fullname} can comprise either block devices (SAN - iSCSI or FCP) or a file system (NAS - NFS, GlusterFS, or other POSIX compliant file systems). For more information about {virt-product-fullname} storage see link:{URL_virt_product_docs}{URL_format}administration_guide/index#chap-Storage[Storage] in the _Administration Guide_.
+The storage domain for {virt-product-fullname} can comprise either block devices (SAN - iSCSI or FCP) or a file system (NAS - NFS, GlusterFS, or other POSIX compliant file systems). For more information about {virt-product-fullname} storage, see link:{URL_virt_product_docs}{URL_format}administration_guide/index#chap-Storage[Storage] in the _Administration Guide_.
 
 The sites require synchronously replicated storage that is writeable on both sites with shared layer 2 (L2) network connectivity. The replicated storage is required to allow virtual machines to migrate between sites and continue running on the site’s storage. All storage replication options supported by {enterprise-linux} 7 and later can be used in the stretch cluster.
 

--- a/source/documentation/disaster_recovery_guide/concept/cpt_StorageConsiderationsAA.adoc
+++ b/source/documentation/disaster_recovery_guide/concept/cpt_StorageConsiderationsAA.adoc
@@ -1,5 +1,5 @@
 [[storage_considerations_active_active]]
-==== Storage Considerations
+= Storage Considerations
 
 The storage domain for {virt-product-fullname} can be made of either block devices (SAN - iSCSI or FCP) or a file system (NAS - NFS, GlusterFS, or other POSIX compliant file systems). For more information about {virt-product-fullname} storage see link:{URL_virt_product_docs}{URL_format}administration_guide/index#chap-Storage[Storage] in the _Administration Guide_.
 

--- a/source/documentation/disaster_recovery_guide/concept/cpt_StorageConsiderationsAA.adoc
+++ b/source/documentation/disaster_recovery_guide/concept/cpt_StorageConsiderationsAA.adoc
@@ -10,6 +10,11 @@ The sites require synchronously replicated storage that is writeable on both sit
 If you have a custom multipath configuration that is recommended by the storage vendor, see the instructions and important limitations in link:{URL_virt_product_docs}{URL_format}installing_{URL_product_virt}_as_a_self-hosted_engine_using_the_command_line/index#proc-Customizing_Multipath_Configurations_for_SAN_Vendors_SHE_cli_deploy[Customizing Multipath Configurations for SAN Vendors].
 ====
 
-Set the SPM role on a host at the primary site to have precedence. To do so, configure SPM priority as high in the primary site hosts and SPM priority as low on secondary site hosts. Doing so prepares for recovery if you have a primary site failure that impacts network devices inside the primary site, preventing the fencing device for the SPM host from being reachable, such as power loss.
+Set the SPM role on a host at the primary site to have precedence. To do so, configure SPM priority as high in the primary site hosts and SPM priority as low on secondary site hosts. If you have a primary site failure that impacts network devices inside the primary site, preventing the fencing device for the SPM host from being reachable, such as power loss, the hosts in the seconday site are not able to take over the SPM role.
 
-If you do not take this precaution, in such a scenario virtual machines do a failover, but operations that require the SPM role in place cannot be executed, including adding new disks, extending existing disks, and exporting virtual machines. You must declare *Confirm host has been rebooted* for the SPM host.
+In such a scenario virtual machines do a failover, but operations that require the SPM role in place cannot be executed, including adding new disks, extending existing disks, and exporting virtual machines.
+
+To restore full functionality, detect the actual nature of the disaster and after fixing the root cause and rebooting the SPM host, select *Confirm 'Host has been Rebooted'* for the SPM host.
+
+.Additional resources
+link:{URL_virt_product_docs}{URL_format}administration_guide/index#Manually_fencing_or_isolating_a_nonresponsive_host[Manually Fencing or Isolating a Non-Responsive Host] in the _Administration Guide_.

--- a/source/documentation/disaster_recovery_guide/concept/cpt_StorageConsiderationsAP.adoc
+++ b/source/documentation/disaster_recovery_guide/concept/cpt_StorageConsiderationsAP.adoc
@@ -1,9 +1,12 @@
 [[storage_considerations_active-passive]]
-==== Storage Considerations
+= Storage Considerations
 
-The storage domain for {virt-product-fullname} can be made of either block devices (SAN - iSCSI or FCP) or a file system (NAS - NFS, GlusterFS, or other POSIX compliant file systems). For more information about {virt-product-fullname} storage see link:{URL_virt_product_docs}{URL_format}administration_guide/index#chap-Storage[Storage] in the _Administration Guide_. 
+The storage domain for {virt-product-fullname} can comprise either block devices (SAN - iSCSI or FCP) or a file system (NAS - NFS, GlusterFS, or other POSIX compliant file systems). For more information about {virt-product-fullname} storage see link:{URL_virt_product_docs}{URL_format}administration_guide/index#chap-Storage[Storage] in the _Administration Guide_.
 
-IMPORTANT: Local storage domains are unsupported for disaster recovery.
+[IMPORTANT]
+====
+Local storage domains are unsupported for disaster recovery.
+====
 
 A primary and secondary storage replica is required. The primary storage domain’s block devices or shares that contain virtual machine disks or templates must be replicated. The secondary storage must not be attached to any data center, and will be added to the backup site’s data center during failover.
 

--- a/source/documentation/disaster_recovery_guide/concept/cpt_StorageConsiderationsAP.adoc
+++ b/source/documentation/disaster_recovery_guide/concept/cpt_StorageConsiderationsAP.adoc
@@ -13,7 +13,3 @@ A primary and secondary storage replica is required. The primary storage domainâ
 If you are implementing disaster recovery using a self-hosted engine, ensure that the  storage domain used by the {engine-name} virtual machine does not contain virtual machine disks because in such a case the storage domain will not be failed over.
 
 All storage solutions that have replication options that are supported by {enterprise-linux} 7 and later can be used.
-
-Set the SPM role on a host at the primary site to have precedence. To do so, configure SPM priority as high in the primary site hosts and SPM priority as low on secondary site hosts. Doing so prepares for recovery if you have a primary site failure that impacts network devices inside the primary site, preventing the fencing device for the SPM host from being reachable, such as power loss.
-
-If you do not take this precaution, in such a scenario virtual machines do a failover, but operations that require the SPM role in place cannot be executed, including adding new disks, extending existing disks, and exporting virtual machines. You must declare *Confirm host has been rebooted* for the SPM host.

--- a/source/documentation/disaster_recovery_guide/concept/cpt_StorageConsiderationsAP.adoc
+++ b/source/documentation/disaster_recovery_guide/concept/cpt_StorageConsiderationsAP.adoc
@@ -10,6 +10,6 @@ Local storage domains are unsupported for disaster recovery.
 
 A primary and secondary storage replica is required. The primary storage domain’s block devices or shares that contain virtual machine disks or templates must be replicated. The secondary storage must not be attached to any data center, and will be added to the backup site’s data center during failover.
 
-If you are implementing disaster recovery using a self-hosted engine, ensure that the  storage domain used by the {engine-name} virtual machine does not contain virtual machine disks because in such a case the storage domain will not be failed over.
+If you are implementing disaster recovery using a self-hosted engine, ensure that the storage domain used by the {engine-name} virtual machine does not contain virtual machine disks because in such a case the storage domain will not be failed over.
 
 All storage solutions that have replication options that are supported by {enterprise-linux} 7 and later can be used.

--- a/source/documentation/disaster_recovery_guide/concept/cpt_StorageConsiderationsAP.adoc
+++ b/source/documentation/disaster_recovery_guide/concept/cpt_StorageConsiderationsAP.adoc
@@ -10,6 +10,10 @@ Local storage domains are unsupported for disaster recovery.
 
 A primary and secondary storage replica is required. The primary storage domain’s block devices or shares that contain virtual machine disks or templates must be replicated. The secondary storage must not be attached to any data center, and will be added to the backup site’s data center during failover.
 
-If you are implementing disaster recovery using self-hosted engine, ensure that the  storage domain used by the self-hosted engine {engine-name} virtual machine does not contain virtual machine disks because the storage domain will not be failed over.
+If you are implementing disaster recovery using a self-hosted engine, ensure that the  storage domain used by the {engine-name} virtual machine does not contain virtual machine disks because in such a case the storage domain will not be failed over.
 
 All storage solutions that have replication options that are supported by {enterprise-linux} 7 and later can be used.
+
+Set the SPM role on a host at the primary site to have precedence. To do so, configure SPM priority as high in the primary site hosts and SPM priority as low on secondary site hosts. Doing so prepares for recovery if you have a primary site failure that impacts network devices inside the primary site, preventing the fencing device for the SPM host from being reachable, such as power loss.
+
+If you do not take this precaution, in such a scenario virtual machines do a failover, but operations that require the SPM role in place cannot be executed, including adding new disks, extending existing disks, and exporting virtual machines. You must declare *Confirm host has been rebooted* for the SPM host.

--- a/source/documentation/disaster_recovery_guide/concept/cpt_StretchPrerequisites.adoc
+++ b/source/documentation/disaster_recovery_guide/concept/cpt_StretchPrerequisites.adoc
@@ -1,4 +1,4 @@
-*Prerequisites*:
+.Prerequisites
 
 * A writable storage server in both sites with L2 network connectivity.
 * Real-time storage replication service to duplicate the storage.

--- a/source/documentation/disaster_recovery_guide/index.adoc
+++ b/source/documentation/disaster_recovery_guide/index.adoc
@@ -8,14 +8,14 @@ include::common/collateral_files/attributes.adoc[]
 [discrete]
 = Disaster Recovery Guide
 
-include::concept/cpt_DisasterRecoverySolutions.adoc[]
-include::assembly/asm_ActiveActiveDR.adoc[]
-include::assembly/asm_ActivePassiveDR.adoc[]
+include::concept/cpt_DisasterRecoverySolutions.adoc[leveloffset=+1]
+include::assembly/asm_ActiveActiveDR.adoc[leveloffset=+1]
+include::assembly/asm_ActivePassiveDR.adoc[leveloffset=+1]
 
 [appendix]
-include::reference/rfr_MappingFileAttributes.adoc[]
+include::reference/rfr_MappingFileAttributes.adoc[leveloffset=+1]
 [appendix]
-include::reference/rfr_TestingAP.adoc[]
+include::reference/rfr_TestingAP.adoc[leveloffset=+1]
 
 [appendix]
 == Legal notice

--- a/source/documentation/disaster_recovery_guide/master.adoc
+++ b/source/documentation/disaster_recovery_guide/master.adoc
@@ -4,13 +4,13 @@ include::common/collateral_files/attributes.adoc[]
 :imagesdir: images
 :toclevels: 4
 
-include::concept/cpt_DisasterRecoverySolutions.adoc[]
-include::assembly/asm_ActiveActiveDR.adoc[]
-include::assembly/asm_ActivePassiveDR.adoc[]
+include::concept/cpt_DisasterRecoverySolutions.adoc[leveloffset=+1]
+include::assembly/asm_ActiveActiveDR.adoc[leveloffset=+1]
+include::assembly/asm_ActivePassiveDR.adoc[leveloffset=+1]
 
 [appendix]
-include::reference/rfr_MappingFileAttributes.adoc[]
+include::reference/rfr_MappingFileAttributes.adoc[leveloffset=+1]
 [appendix]
-include::reference/rfr_TestingAP.adoc[]
+include::reference/rfr_TestingAP.adoc[leveloffset=+1]
 
 include::common/collateral_files/legal-notice.adoc[]

--- a/source/documentation/disaster_recovery_guide/reference/ref_UsingOvirtDrScript.adoc
+++ b/source/documentation/disaster_recovery_guide/reference/ref_UsingOvirtDrScript.adoc
@@ -1,14 +1,16 @@
 [[Using-ovirt-dr-script]]
-==== Using the `ovirt-dr` Script for Ansible Tasks
+= The `ovirt-dr` Script for Ansible Tasks
 
-The `ovirt-dr` script is located in */usr/share/ansible/roles/oVirt.disaster-recovery/files*. This script simplifies the following Ansible tasks:
+The `ovirt-dr` script simplifies the following Ansible tasks:
 
 * Generating a `var` mapping file of the primary and secondary sites for failover and fallback
 * Validating the `var` mapping file
 * Executing failover on a target site
 * Executing failback from a target site to a source site
 
-*Usage*
+This script is located in `/usr/share/ansible/roles/oVirt.disaster-recovery/files`
+
+.Usage
 
 [options="nowrap" subs="normal"]
 ----

--- a/source/documentation/disaster_recovery_guide/reference/rfr_MappingFileAttributes.adoc
+++ b/source/documentation/disaster_recovery_guide/reference/rfr_MappingFileAttributes.adoc
@@ -1,5 +1,5 @@
 [[mapping_file_attributes]]
-== Mapping File Attributes
+= Mapping File Attributes
 
 The following table describes the attributes in the mapping file that is used to fail over and fail back between the two sites in an active-passive disaster recovery solution.
 

--- a/source/documentation/disaster_recovery_guide/reference/rfr_TestingAP.adoc
+++ b/source/documentation/disaster_recovery_guide/reference/rfr_TestingAP.adoc
@@ -1,5 +1,5 @@
 [[testing_active_passive]]
-== Testing the Active-Passive Configuration
+= Testing the Active-Passive Configuration
 :refdir: ../reference
 
 You must test your disaster recovery solution after configuring it. This section provides multiple options to test the active-passive disaster recovery configuration.
@@ -13,8 +13,8 @@ You must test your disaster recovery solution after configuring it. This section
 Ensure that you completed all the steps to configure your active-passive configuration before running any of these tests.
 ====
 
-include::{refdir}/rfr_discreet_failover.adoc[]
+include::{refdir}/rfr_discreet_failover.adoc[leveloffset=+1]
 
-include::{refdir}/rfr_discreet_failover_failback.adoc[]
+include::{refdir}/rfr_discreet_failover_failback.adoc[leveloffset=+1]
 
-include::{refdir}/rfr_non_discreet_failover_failback.adoc[]
+include::{refdir}/rfr_non_discreet_failover_failback.adoc[leveloffset=+1]

--- a/source/documentation/disaster_recovery_guide/reference/rfr_discreet_failover.adoc
+++ b/source/documentation/disaster_recovery_guide/reference/rfr_discreet_failover.adoc
@@ -1,7 +1,7 @@
 [[discreet_failover]]
 = Discreet Failover Test
 
-This test simulates a failover while the primary site and all its storage domains remain active, allowing users to continue working in the primary site. For this to happen you must disable replication between the primary storage domains and the replicated (secondary) storage domains. During this test the primary site will be unaware of the failover activities on the secondary site.
+This test simulates a failover while the primary site and all its storage domains remain active, allowing users to continue working in the primary site. To enable this scenario, you must disable replication between the primary storage domains and the replicated (secondary) storage domains. During this test the primary site is unaware of the failover activities on the secondary site.
 
 This test will not allow you to test the failback functionality.
 

--- a/source/documentation/disaster_recovery_guide/reference/rfr_discreet_failover.adoc
+++ b/source/documentation/disaster_recovery_guide/reference/rfr_discreet_failover.adoc
@@ -1,7 +1,7 @@
 [[discreet_failover]]
-=== Discreet Failover Test
+= Discreet Failover Test
 
-This test simulates a failover while the primary site and all its storage domains remain active, allowing users to continue working in the primary site. For this to happen you will need to disable replication between the primary storage domains and the replicated (secondary) storage domains. During this test the primary site will be unaware of the failover activities on the secondary site.
+This test simulates a failover while the primary site and all its storage domains remain active, allowing users to continue working in the primary site. For this to happen you must disable replication between the primary storage domains and the replicated (secondary) storage domains. During this test the primary site will be unaware of the failover activities on the secondary site.
 
 This test will not allow you to test the failback functionality.
 

--- a/source/documentation/disaster_recovery_guide/reference/rfr_discreet_failover_failback.adoc
+++ b/source/documentation/disaster_recovery_guide/reference/rfr_discreet_failover_failback.adoc
@@ -1,5 +1,5 @@
 [[discreet_failover_failback]]
-=== Discreet Failover and Failback Test
+= Discreet Failover and Failback Test
 
 For this test you must define testable storage domains that will be used specifically for testing the failover and failback. These storage domains must be replicated so that the replicated storage can be attached to the secondary site. This allows you to test the failover while users continue to work in the primary site.
 

--- a/source/documentation/disaster_recovery_guide/reference/rfr_non_discreet_failover_failback.adoc
+++ b/source/documentation/disaster_recovery_guide/reference/rfr_non_discreet_failover_failback.adoc
@@ -1,11 +1,11 @@
 [[non_discreet_failover_failback]]
-=== Full Failover and Failback test
+= Full Failover and Failback test
 
 This test performs a full failover and failback between the primary and secondary site. You can simulate the disaster by shutting down the primary site's hosts or by adding firewall rules to block writing to the storage domains.
 
 For more information about failing over the environment, cleaning the environment, and performing the failback, see <<execute_failover>>, <<clean>>, and <<execute_failback>>.
 
-.Procedure: Failover test:
+.Procedure: Failover test
 
 . Disable storage replication between the primary and replicated storage domains and ensure that all replicated storage domains are in read/write mode.
 . Run the command to fail over to the secondary site:
@@ -16,7 +16,7 @@ For more information about failing over the environment, cleaning the environmen
 ----
 . Verify that all relevant storage domains, virtual machines, and templates are registered and running successfully.
 
-.Procedure: Failback test:
+.Procedure: Failback test
 
 . Synchronize replication between the secondary site’s storage domains and the primary site’s storage domains. The secondary site’s storage domains must be in read/write mode and the primary site’s storage domains must be in read-only mode.
 . Run the command to clean the primary site and remove all inactive storage domains and related virtual machines and templates:

--- a/source/documentation/disaster_recovery_guide/task/task_Clean.adoc
+++ b/source/documentation/disaster_recovery_guide/task/task_Clean.adoc
@@ -13,7 +13,7 @@ This example uses the `dr-cleanup.yml` playbook created earlier to clean the env
 .Procedure
 
 . Clean up the primary site with the following command:
-
++
 [options="nowrap" subs="normal"]
 ----
 # ansible-playbook dr-cleanup.yml --tags "clean_engine"

--- a/source/documentation/disaster_recovery_guide/task/task_Clean.adoc
+++ b/source/documentation/disaster_recovery_guide/task/task_Clean.adoc
@@ -1,22 +1,22 @@
 [[clean]]
-=== Clean the Primary Site
+= Cleaning the Primary Site
 
 After you fail over, you must clean the environment in the primary site before failing back to it:
 
 * Reboot all hosts in the primary site.
 * Ensure the secondary site's storage domains are in read/write mode and the primary site's storage domains are in read only mode.
-* Synchronize the replication from the secondary site's storage domains to the primary site's storage domains.  
+* Synchronize the replication from the secondary site's storage domains to the primary site's storage domains.
 * Clean the primary site of all storage domains to be imported. This can be done manually in the {engine-name}, or by creating and running an Ansible playbook. See link:{URL_virt_product_docs}{URL_format}administration_guide/index#Detaching_a_storage_domain[Detaching a Storage Domain] in the _Administration Guide_ for manual instructions, or <<create_cleanup>> for information to create the Ansible playbook.
 
 This example uses the `dr-cleanup.yml` playbook created earlier to clean the environment.
 
-*Cleaning the primary site:*
+.Procedure
 
-Clean up the primary site with the following command:
+. Clean up the primary site with the following command:
 
 [options="nowrap" subs="normal"]
 ----
 # ansible-playbook dr-cleanup.yml --tags "clean_engine"
 ----
 
-You can now failback the environment to the primary site. See <<execute_failback>> for more information.
+. You can now failback the environment to the primary site. See xref:execute_failback[] for more information.

--- a/source/documentation/disaster_recovery_guide/task/task_CommonStepsConfigureStretchCluster.adoc
+++ b/source/documentation/disaster_recovery_guide/task/task_CommonStepsConfigureStretchCluster.adoc
@@ -1,6 +1,6 @@
 . Configure the SPM priority to be higher on all hosts in the primary site to ensure SPM failover to the secondary site occurs only when all hosts in the primary site are unavailable. See link:{URL_virt_product_docs}{URL_format}administration_guide/index#SPM_Priority[SPM Priority] in the _Administration Guide_.
 
-. Configure all virtual machines that need to failover as highly available, and ensure that the virtual machine has a lease on the target storage domain. See link:{URL_virt_product_docs}{URL_format}virtual_machine_management_guide/index#Configuring_a_highly_available_virtual_machine[Configuring a Highly Available Virtual Machine] in the _Virtual Machine Management Guide_.
+. Configure all virtual machines that must failover as highly available, and ensure that the virtual machine has a lease on the target storage domain. See link:{URL_virt_product_docs}{URL_format}virtual_machine_management_guide/index#Configuring_a_highly_available_virtual_machine[Configuring a Highly Available Virtual Machine] in the _Virtual Machine Management Guide_.
 
 . Configure virtual machine to host soft affinity and define the behavior you expect from the affinity group. See  link:{URL_virt_product_docs}{URL_format}virtual_machine_management_guide/index#sect-Affinity_Groups[Affinity Groups] in the _Virtual Machine Management Guide_ and link:{URL_virt_product_docs}{URL_format}administration_guide/index#sect-Scheduling_Policies[Scheduling Policies] in the _Administration Guide_.
 

--- a/source/documentation/disaster_recovery_guide/task/task_ConfigureStretchCluster.adoc
+++ b/source/documentation/disaster_recovery_guide/task/task_ConfigureStretchCluster.adoc
@@ -1,15 +1,15 @@
 [[configure_she_stretch_cluster]]
-=== Configure a Self-hosted Engine Stretch Cluster Environment
+= Configuring a Self-hosted Engine Stretch Cluster Environment
 
 This procedure provides instructions to configure a stretch cluster using a self-hosted engine deployment.
 
 include::{cptdir}/cpt_StretchPrerequisites.adoc[]
 
-*Limitations*:
+.Limitations
 
 * Maximum 7ms latency between sites.
 
-*Configuring the Self-hosted Engine Stretch Cluster*
+.Configuring the Self-hosted Engine Stretch Cluster
 
 . Deploy the self-hosted engine. See link:{URL_virt_product_docs}{URL_format}installing_{URL_product_virt}_as_a_self-hosted_engine_using_the_command_line[Installing {virt-product-fullname} as a self-hosted engine using the command line].
 
@@ -20,13 +20,13 @@ include::{cptdir}/cpt_StretchPrerequisites.adoc[]
 include::{taskdir}/task_CommonStepsConfigureStretchCluster.adoc[]
 
 [[configure_standalone_manager_stretch_cluster]]
-=== Configure a Standalone {engine-name} Stretch Cluster Environment
+= Configuring a Standalone {engine-name} Stretch Cluster Environment
 
 This procedure provides instructions to configure a stretch cluster using a standalone {engine-name} deployment.
 
 include::{cptdir}/cpt_StretchPrerequisites.adoc[]
 
-*Limitations*:
+.Limitations
 
 * Maximum 100ms latency between sites.
 
@@ -42,7 +42,7 @@ The standalone {engine-name} is only highly available when managed externally. F
 * In a public cloud.
 ====
 
-*Configuring the Standalone {engine-name} Stretch Cluster*
+.Procedure
 
 . Install and configure the {virt-product-fullname} {engine-name}. See link:{URL_virt_product_docs}{URL_format}installing_{URL_product_virt}_as_a_standalone_manager_with_local_databases/index#[_Installing {virt-product-fullname} as a standalone {engine-name} with local databases_].
 

--- a/source/documentation/disaster_recovery_guide/task/task_CreateAnsiblePlaybooks.adoc
+++ b/source/documentation/disaster_recovery_guide/task/task_CreateAnsiblePlaybooks.adoc
@@ -16,9 +16,10 @@ Ansible is used to initiate and manage the disaster recovery failover and failba
 [NOTE]
 ====
 The replicated storage that contains virtual machines and templates must not be attached to the secondary site.
+====
+
 * The `oVirt.disaster-recovery` package must be installed on the highly available Red Hat Ansible Engine machine that will automate the failover and failback.
 * The machine running Red Hat Ansible Engine must be able to use SSH to connect to the {engine-name} in the primary and secondary site.
-====
 
 It is also recommended to create environment properties that exist in the primary site, such as affinity groups, affinity labels, users, on the secondary site.
 

--- a/source/documentation/disaster_recovery_guide/task/task_CreateAnsiblePlaybooks.adoc
+++ b/source/documentation/disaster_recovery_guide/task/task_CreateAnsiblePlaybooks.adoc
@@ -1,7 +1,7 @@
 [[create_ansible_playbooks]]
-=== Create the Required Ansible Playbooks
+= Create the Required Ansible Playbooks
 
-Ansible is used to initiate and manage the disaster recovery failover and failback. You therefore need to create Ansible playbooks to facilitate this. For more information about creating Ansible playbooks, see the link:http://docs.ansible.com/ansible/latest/playbooks.html[Ansible documentation].
+Ansible is used to initiate and manage the disaster recovery failover and failback. You therefore must create Ansible playbooks to facilitate this. For more information about creating Ansible playbooks, see the link:http://docs.ansible.com/ansible/latest/playbooks.html[Ansible documentation].
 
 *Prerequisites*:
 
@@ -13,9 +13,12 @@ Ansible is used to initiate and manage the disaster recovery failover and failba
 ** Networks with the same general connectivity as the primary site.
 * Replicated storage. See <<storage_considerations_active-passive>> for more information.
 +
-NOTE: The replicated storage that contains virtual machines and templates must not be attached to the secondary site.
+[NOTE]
+====
+The replicated storage that contains virtual machines and templates must not be attached to the secondary site.
 * The `oVirt.disaster-recovery` package must be installed on the highly available Red Hat Ansible Engine machine that will automate the failover and failback.
 * The machine running Red Hat Ansible Engine must be able to use SSH to connect to the {engine-name} in the primary and secondary site.
+====
 
 It is also recommended to create environment properties that exist in the primary site, such as affinity groups, affinity labels, users, on the secondary site.
 
@@ -33,7 +36,7 @@ Create the playbooks and associated files in `/usr/share/ansible/roles/oVirt.dis
 
 You can test the configuration using one or more of the testing procedures in <<testing_active_passive>>.
 
-include::{taskdir}/task_UsingOvirtDrScript.adoc[]
-include::{taskdir}/task_GenerateMapping.adoc[]
-include::{taskdir}/task_CreateFailoverFailbackPlaybooks.adoc[]
-include::{taskdir}/task_CreateCleanupPlaybook.adoc[]
+include::../reference/ref_UsingOvirtDrScript.adoc[leveloffset=+1]
+include::{taskdir}/task_GenerateMapping.adoc[leveloffset=+1]
+include::{taskdir}/task_CreateFailoverFailbackPlaybooks.adoc[leveloffset=+1]
+include::{taskdir}/task_CreateCleanupPlaybook.adoc[leveloffset=+1]

--- a/source/documentation/disaster_recovery_guide/task/task_CreateAnsiblePlaybooks.adoc
+++ b/source/documentation/disaster_recovery_guide/task/task_CreateAnsiblePlaybooks.adoc
@@ -1,9 +1,9 @@
 [[create_ansible_playbooks]]
 = Create the Required Ansible Playbooks
 
-Ansible is used to initiate and manage the disaster recovery failover and failback. You therefore must create Ansible playbooks to facilitate this. For more information about creating Ansible playbooks, see the link:http://docs.ansible.com/ansible/latest/playbooks.html[Ansible documentation].
+Ansible is used to initiate and manage the disaster recovery failover and failback. So you must create Ansible playbooks to facilitate this. For more information about creating Ansible playbooks, see the link:http://docs.ansible.com/ansible/latest/playbooks.html[Ansible documentation].
 
-*Prerequisites*:
+.Prerequisites
 
 * Fully functioning {virt-product-fullname} environment in the primary site.
 * A backup environment in the secondary site with the same data center and cluster compatibility level as the primary environment. The backup environment must have:
@@ -23,7 +23,10 @@ The replicated storage that contains virtual machines and templates must not be 
 
 It is also recommended to create environment properties that exist in the primary site, such as affinity groups, affinity labels, users, on the secondary site.
 
-NOTE: The default behaviour of the Ansible playbooks can be configured in the `/usr/share/ansible/roles/oVirt.disaster-recovery/defaults/main.yml` file.
+[NOTE]
+====
+The default behaviour of the Ansible playbooks can be configured in the `/usr/share/ansible/roles/oVirt.disaster-recovery/defaults/main.yml` file.
+====
 
 The following playbooks must be created:
 

--- a/source/documentation/disaster_recovery_guide/task/task_CreateCleanupPlaybook.adoc
+++ b/source/documentation/disaster_recovery_guide/task/task_CreateCleanupPlaybook.adoc
@@ -1,7 +1,7 @@
 [[create_cleanup]]
 = Create the Playbook to Clean the Primary Site
 
-Before you failback to the primary site, you must ensure that the primary site is cleaned of all storage domains to be imported. You can do so manually on the {engine-name}, or optionally you can create an Ansible playbook to do it for you.
+Before you fail back to the primary site, you must ensure that the primary site is cleaned of all storage domains to be imported. You can do so manually on the {engine-name}, or optionally you can create an Ansible playbook to do it for you.
 
 The Ansible playbook to clean the primary site is named `dr-cleanup.yml` in this example, and it uses the mapping file created in <<generate_mapping>>:
 [options="nowrap" subs="normal"]

--- a/source/documentation/disaster_recovery_guide/task/task_CreateCleanupPlaybook.adoc
+++ b/source/documentation/disaster_recovery_guide/task/task_CreateCleanupPlaybook.adoc
@@ -1,7 +1,7 @@
 [[create_cleanup]]
 = Create the Playbook to Clean the Primary Site
 
-Before you failback to the primary site, you must ensure that the primary site is cleaned of all storage domains to be imported. You can do this manually on the {engine-name}, or optionally you can create an Ansible playbook to do it for you.
+Before you failback to the primary site, you must ensure that the primary site is cleaned of all storage domains to be imported. You can do so manually on the {engine-name}, or optionally you can create an Ansible playbook to do it for you.
 
 The Ansible playbook to clean the primary site is named `dr-cleanup.yml` in this example, and it uses the mapping file created in <<generate_mapping>>:
 [options="nowrap" subs="normal"]

--- a/source/documentation/disaster_recovery_guide/task/task_CreateCleanupPlaybook.adoc
+++ b/source/documentation/disaster_recovery_guide/task/task_CreateCleanupPlaybook.adoc
@@ -1,12 +1,12 @@
 [[create_cleanup]]
-==== Create the Playbook to Clean the Primary Site
+= Create the Playbook to Clean the Primary Site
 
-Before you failback to the primary site, you need to ensure that the primary site is cleaned of all storage domains to be imported. This can be performed manually on the {engine-name}, or optionally you can create an Ansible playbook to perform it for you.
+Before you failback to the primary site, you must ensure that the primary site is cleaned of all storage domains to be imported. You can do this manually on the {engine-name}, or optionally you can create an Ansible playbook to do it for you.
 
 The Ansible playbook to clean the primary site is named `dr-cleanup.yml` in this example, and it uses the mapping file created in <<generate_mapping>>:
 [options="nowrap" subs="normal"]
 ----
---- 
+---
 - name: clean RHV
   hosts: localhost
   connection: local

--- a/source/documentation/disaster_recovery_guide/task/task_CreateFailoverFailbackPlaybooks.adoc
+++ b/source/documentation/disaster_recovery_guide/task/task_CreateFailoverFailbackPlaybooks.adoc
@@ -1,5 +1,5 @@
 [[create_failover_failback]]
-==== Create the Failover and Failback Playbooks
+= Create the Failover and Failback Playbooks
 
 Ensure that you have the mapping file that you created and configured, in this case `disaster_recovery_vars.yml`, because this must be added to the playbooks.
 
@@ -22,7 +22,7 @@ dr_sites_primary_password: primary_password
 dr_sites_secondary_password: secondary_password
 ----
 
-NOTE: For extra security you can encrypt the password file. However, you will need to use the `--ask-vault-pass` parameter when running the playbook. See _Using Ansible Roles to Configure {virt-product-fullname}_ in the link:{URL_virt_product_docs}{URL_format}administration_guide/index#Using_Ansible_Roles[Administration Guide] for more information.
+NOTE: For extra security you can encrypt the password file. However, you must use the `--ask-vault-pass` parameter when running the playbook. See _Using Ansible Roles to Configure {virt-product-fullname}_ in the link:{URL_virt_product_docs}{URL_format}administration_guide/index#Using_Ansible_Roles[Administration Guide] for more information.
 
 In these examples the Ansible playbooks to fail over and fail back are named `dr-rhv-failover.yml` and  `dr-rhv-failback.yml`.
 

--- a/source/documentation/disaster_recovery_guide/task/task_CreateFailoverFailbackPlaybooks.adoc
+++ b/source/documentation/disaster_recovery_guide/task/task_CreateFailoverFailbackPlaybooks.adoc
@@ -22,7 +22,10 @@ dr_sites_primary_password: primary_password
 dr_sites_secondary_password: secondary_password
 ----
 
-NOTE: For extra security you can encrypt the password file. However, you must use the `--ask-vault-pass` parameter when running the playbook. See _Using Ansible Roles to Configure {virt-product-fullname}_ in the link:{URL_virt_product_docs}{URL_format}administration_guide/index#Using_Ansible_Roles[Administration Guide] for more information.
+[NOTE]
+====
+For extra security you can encrypt the password file. However, you must use the `--ask-vault-pass` parameter when running the playbook. See _Using Ansible Roles to Configure {virt-product-fullname}_ in the link:{URL_virt_product_docs}{URL_format}administration_guide/index#Using_Ansible_Roles[Administration Guide] for more information.
+====
 
 In these examples the Ansible playbooks to fail over and fail back are named `dr-rhv-failover.yml` and  `dr-rhv-failback.yml`.
 

--- a/source/documentation/disaster_recovery_guide/task/task_ExecuteFailback.adoc
+++ b/source/documentation/disaster_recovery_guide/task/task_ExecuteFailback.adoc
@@ -1,9 +1,9 @@
 [[execute_failback]]
-=== Execute a Failback
+= Executing a Failback
 
 Once you fail over, you can fail back to the primary site when it is active and you have performed the necessary steps to clean the environment.
 
-*Prerequisites*:
+.Prerequisites
 
 * The environment in the primary site is running and has been cleaned, see <<clean>> for more information.
 * The environment in the secondary site is running, and has active storage domains.
@@ -13,7 +13,7 @@ Once you fail over, you can fail back to the primary site when it is active and 
 
 This example uses the `dr-rhv-failback.yml` playbook created earlier.
 
-*Executing a failback*:
+.Procedure
 
 . Run the failback playbook with the following command:
 +

--- a/source/documentation/disaster_recovery_guide/task/task_ExecuteFailover.adoc
+++ b/source/documentation/disaster_recovery_guide/task/task_ExecuteFailover.adoc
@@ -1,7 +1,7 @@
 [[execute_failover]]
-=== Execute a Failover
+= Executing a Failover
 
-*Prerequisites*:
+.Prerequisites
 
 * The {engine-name} and hosts in the secondary site are running.
 * Replicated storage domains are in read/write mode.
@@ -10,17 +10,20 @@
 ** The `oVirt.disaster-recovery` package.
 ** The mapping file and required failover playbook.
 
-IMPORTANT: Sanlock must release all storage locks from the replicated storage domains before the failover process starts.
+[IMPORTANT]
+====
+Sanlock must release all storage locks from the replicated storage domains before the failover process starts.
 These locks should be released automatically approximately 80 seconds after the disaster occurs.
+====
 
 This example uses the `dr-rhv-failover.yml` playbook created earlier.
 
-*Executing a failover*:
+.Procedure
 
-Run the failover playbook with the following command:
+. Run the failover playbook with the following command:
 [options="nowrap" subs="normal"]
 ----
 # ansible-playbook dr-rhv-failover.yml --tags "fail_over"
 ----
 
-When the primary site becomes active, ensure that you clean the environment before failing back. See <<clean>> for more information.
+. When the primary site becomes active, ensure that you clean the environment before failing back. See xref:clean[] for more information.

--- a/source/documentation/disaster_recovery_guide/task/task_ExecuteFailover.adoc
+++ b/source/documentation/disaster_recovery_guide/task/task_ExecuteFailover.adoc
@@ -21,6 +21,7 @@ This example uses the `dr-rhv-failover.yml` playbook created earlier.
 .Procedure
 
 . Run the failover playbook with the following command:
++
 [options="nowrap" subs="normal"]
 ----
 # ansible-playbook dr-rhv-failover.yml --tags "fail_over"

--- a/source/documentation/disaster_recovery_guide/task/task_GenerateMapping.adoc
+++ b/source/documentation/disaster_recovery_guide/task/task_GenerateMapping.adoc
@@ -1,13 +1,15 @@
 [[generate_mapping]]
-==== Create the Playbook to Generate the Mapping File
+= Creating the Playbook to Generate the Mapping File
 
-The Ansible playbook used to generate the mapping file will prepopulate the file with the target (primary) site’s entities. You then need to manually add the backup site’s entities, such as IP addresses, cluster, affinity groups, affinity label, external LUN disks, authorization domains, roles, and vNIC profiles, to the file.
+The Ansible playbook used to generate the mapping file will prepopulate the file with the target (primary) site’s entities. You then must manually add the backup site’s entities, such as IP addresses, cluster, affinity groups, affinity label, external LUN disks, authorization domains, roles, and vNIC profiles, to the file.
 
-IMPORTANT: The mapping file generation will fail if you have any virtual machine disks on the self-hosted engine’s storage domain. Also, the mapping file will not contain an attribute for this storage domain because it must not be failed over.
-
+[IMPORTANT]
+====
+The mapping file generation will fail if you have any virtual machine disks on the self-hosted engine’s storage domain. Also, the mapping file will not contain an attribute for this storage domain because it must not be failed over.
+====
 In this example the Ansible playbook is named `dr-rhv-setup.yml`, and is executed on the {engine-name} machine in the primary site.
 
-*Creating the mapping file*:
+.Procedure
 
 . Create an Ansible playbook to generate the mapping file. For example:
 +
@@ -29,7 +31,10 @@ In this example the Ansible playbook is named `dr-rhv-setup.yml`, and is execute
     - oVirt.disaster-recovery
 ----
 +
-NOTE: For extra security you can encrypt your {engine-name} password in a `.yml` file. See link:{URL_virt_product_docs}{URL_format}administration_guide/index[Using Ansible Roles to Configure {virt-product-fullname}] in the _Administration Guide_ for more information.
+[NOTE]
+====
+For extra security you can encrypt your {engine-name} password in a `.yml` file. See link:{URL_virt_product_docs}{URL_format}administration_guide/index[Using Ansible Roles to Configure {virt-product-fullname}] in the _Administration Guide_ for more information.
+====
 
 . Run the Ansible command to generate the mapping file. The primary site’s configuration will be prepopulated.
 +

--- a/source/documentation/disaster_recovery_guide/task/task_GenerateMapping.adoc
+++ b/source/documentation/disaster_recovery_guide/task/task_GenerateMapping.adoc
@@ -33,7 +33,7 @@ In this example the Ansible playbook is named `dr-rhv-setup.yml`, and is execute
 +
 [NOTE]
 ====
-For extra security you can encrypt your {engine-name} password in a `.yml` file. See link:{URL_virt_product_docs}{URL_format}administration_guide/index[Using Ansible Roles to Configure {virt-product-fullname}] in the _Administration Guide_ for more information.
+For extra security, you can encrypt your {engine-name} password in a `.yml` file. See link:{URL_virt_product_docs}{URL_format}administration_guide/index[Using Ansible Roles to Configure {virt-product-fullname}] in the _Administration Guide_ for more information.
 ====
 
 . Run the Ansible command to generate the mapping file. The primary site’s configuration will be prepopulated.


### PR DESCRIPTION
Bug fix

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2014790

Changes proposed in this pull request:
- Updated topics on Storage consideration as per https://bugzilla.redhat.com/show_bug.cgi?id=2014790#c1:
  - https://github.com/oVirt/ovirt-site/pull/2653/files#diff-f07c76203bba9d6afcb62d5b09264276dd2e011fc6b39b98057025ccf5d4415e 
  - https://github.com/oVirt/ovirt-site/pull/2653/files#diff-840c2951c1ffae1691ee0fa5bf02f1e75fb24f0aeefde0abeeafc7e1dd8c3e86
- Lots of other editing fixes, not connected to technical content.

Preview
https://ovirt.github.io/ovirt-site/previews/2653/documentation/disaster_recovery_guide/index.html#storage_considerations_active_active

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @stoobie 
This pull request needs review by: @sleviim 