### PR TITLE
Added permissions key to grant permissions to repos

### DIFF
--- a/.github/workflows/dashpanel.yml
+++ b/.github/workflows/dashpanel.yml
@@ -1,4 +1,6 @@
 name: Dashpanel
+permissions:
+  contents: write
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,4 +1,8 @@
 name: "Preview build"
+permissions:
+  issues: write
+  pull-requests: write
+  contents: write
 on:
   pull_request:
 jobs:

--- a/.github/workflows/remove-preview.yml
+++ b/.github/workflows/remove-preview.yml
@@ -1,4 +1,8 @@
 name: Remove preview
+permissions:
+  issues: write
+  pull-requests: write
+  contents: write
 on:
   pull_request:
     types:


### PR DESCRIPTION
Changes proposed in this pull request:

- This change adds the permissions key to make sure the ovirt-site repo retains permissions after org-wide enforcement for GHA policies.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @janosdebugs 

This pull request needs review by: @michalskrivanek 
