### PR TITLE
external scheduler proxy: mark as dropped in 4.5

### DIFF
--- a/source/develop/release-management/features/sla/external-scheduling-proxy.md
+++ b/source/develop/release-management/features/sla/external-scheduling-proxy.md
@@ -8,6 +8,15 @@ authors:
 
 # External Scheduler Proxy
 
+> IMPORTANT: The oVirt Scheduler Proxy project has been dropped from oVirt starting with oVirt 4.5 release.
+> The oVirt Scheduler Proxy project development has been discontinued.
+>
+> See also:
+> - https://bugzilla.redhat.com/show_bug.cgi?id=2028192
+>
+> Keeping the following section only for reference.
+
+
 ## Summary
 
 ## Owner

--- a/source/develop/release-management/features/sla/ovirtschedulerapi.md
+++ b/source/develop/release-management/features/sla/ovirtschedulerapi.md
@@ -10,6 +10,15 @@ authors:
 
 # oVirt Scheduler API
 
+> IMPORTANT: The oVirt Scheduler Proxy project has been dropped from oVirt starting with oVirt 4.5 release.
+> The oVirt Scheduler Proxy project development has been discontinued.
+>
+> See also:
+> - https://bugzilla.redhat.com/show_bug.cgi?id=2028192
+>
+> Keeping the following section only for reference.
+
+
 ## Summary
 
 High level design can be found in the following page: [Features/oVirtScheduler](/develop/release-management/features/sla/ovirtscheduler.html)

--- a/source/develop/sla/external-scheduler-samples.md
+++ b/source/develop/sla/external-scheduler-samples.md
@@ -8,6 +8,15 @@ authors:
 
 # External Scheduler Samples
 
+> IMPORTANT: The oVirt Scheduler Proxy project has been dropped from oVirt starting with oVirt 4.5 release.
+> The oVirt Scheduler Proxy project development has been discontinued.
+>
+> See also:
+> - https://bugzilla.redhat.com/show_bug.cgi?id=2028192
+>
+> Keeping the following section only for reference.
+
+
 ## Introduction
 
 When running or migrating VMs the external scheduler proxy is used to introduce user written logic in to the selection process of hosts . The user can effect the selection process In two ways

--- a/source/develop/sla/host-memory-balance.md
+++ b/source/develop/sla/host-memory-balance.md
@@ -3,6 +3,16 @@ title: Host Memory balance
 authors: nslomian
 ---
 
+> IMPORTANT: The oVirt Scheduler Proxy project has been dropped from oVirt starting with oVirt 4.5 release.
+> The oVirt Scheduler Proxy project development has been discontinued.
+>
+> See also:
+> - https://bugzilla.redhat.com/show_bug.cgi?id=2028192
+>
+> Keeping the following section only for reference.
+
+
+
 # Host Memory balance
 
 This external load balancer will move a VM from a host that has less free memory than the specified amount:


### PR DESCRIPTION
Changes proposed in this pull request:

- Marked sections related to oVirt Scheduler Proxy as project discontinued starting from version 4.5

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @stoobie @michalskrivanek @ahadas @MarSik 
