### PR TITLE
BZ1946201 - Added note regarding Auto migration and Migration compres…

### DIFF
--- a/source/documentation/virtual_machine_management_guide/chap-Administrative_Tasks.adoc
+++ b/source/documentation/virtual_machine_management_guide/chap-Administrative_Tasks.adoc
@@ -144,10 +144,10 @@ A virtual machine that is using a vGPU cannot be migrated to a different host.
 
 include::topics/Live_migration_prerequisites.adoc[]
 
+include::topics/Optimizing_Live_Migration.adoc[]
+
 // removed Optimizing live migration section - options no longer Existing
 // dcdacosta: added back Optimizing live migration since the values still apply on some versions. [See https://bugzilla.redhat.com/show_bug.cgi?id=1946201]
-//
-include::topics/Optimizing_Live_Migration.adoc[]
 
 include::topics/Guest_Agent_Hooks.adoc[]
 

--- a/source/documentation/virtual_machine_management_guide/chap-Administrative_Tasks.adoc
+++ b/source/documentation/virtual_machine_management_guide/chap-Administrative_Tasks.adoc
@@ -145,6 +145,9 @@ A virtual machine that is using a vGPU cannot be migrated to a different host.
 include::topics/Live_migration_prerequisites.adoc[]
 
 // removed Optimizing live migration section - options no longer Existing
+// dcdacosta: added back Optimizing live migration since the values still apply on some versions. [See https://bugzilla.redhat.com/show_bug.cgi?id=1946201]
+//
+include::topics/Optimizing_Live_Migration.adoc[]
 
 include::topics/Guest_Agent_Hooks.adoc[]
 

--- a/source/documentation/virtual_machine_management_guide/topics/Optimizing_Live_Migration.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Optimizing_Live_Migration.adoc
@@ -5,7 +5,7 @@ Live virtual machine migration can be a resource-intensive operation. To optimiz
 
 [NOTE]
 ====
-For cluster levels 4.3 or later, auto converge is enabled by default for all built-in migration policies, and migration compression is enabled by default for only the `Suspend workload if needed` migration policy. You can change these parameters by modifying the `MigrationPolicies` configuration value, and when adding a new migration policy.
+For cluster levels 4.3 or later, auto converge is enabled by default for all built-in migration policies, and migration compression is enabled by default for only the `Suspend workload if needed` migration policy. You can change these parameters when adding a new migration policy, or by modifying the `MigrationPolicies` configuration value.
 ====
 
 The *Auto Converge migrations* option allows you to set whether auto-convergence is used during live migration of virtual machines. Large virtual machines with high workloads can dirty memory more quickly than the transfer rate achieved during live migration, and prevent the migration from converging. Auto-convergence capabilities in QEMU allow you to force convergence of virtual machine migrations. QEMU automatically detects a lack of convergence and triggers a throttle-down of the vCPUs on the virtual machine.

--- a/source/documentation/virtual_machine_management_guide/topics/Optimizing_Live_Migration.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Optimizing_Live_Migration.adoc
@@ -5,6 +5,8 @@ Live virtual machine migration can be a resource-intensive operation. To optimiz
 
 [NOTE]
 ====
+The *Auto Converge migrations* and *Enable migration compression* options are available for cluster levels 4.2 or earlier.
+
 For cluster levels 4.3 or later, auto converge is enabled by default for all built-in migration policies, and migration compression is enabled by default for only the `Suspend workload if needed` migration policy. You can change these parameters when adding a new migration policy, or by modifying the `MigrationPolicies` configuration value.
 ====
 

--- a/source/documentation/virtual_machine_management_guide/topics/Optimizing_Live_Migration.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Optimizing_Live_Migration.adoc
@@ -17,7 +17,6 @@ The *Enable migration compression* option allows you to set whether migration co
 Both options are disabled globally by default.
 
 .Procedure
-. Configure the optimization settings at the global level:
 . Enable auto-convergence at the global level:
 +
 [options="nowrap" subs="normal"]

--- a/source/documentation/virtual_machine_management_guide/topics/Optimizing_Live_Migration.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Optimizing_Live_Migration.adoc
@@ -1,4 +1,4 @@
-[[Optimizing_Live_Migration]]
+[id="Optimizing_Live_Migration"]
 ==== Optimizing Live Migration
 
 Live virtual machine migration can be a resource-intensive operation. To optimize live migration, you can set the following two options globally for every virtual machine in an environment, for every virtual machine in a cluster, or for an individual virtual machine.
@@ -14,11 +14,9 @@ The *Enable migration compression* option allows you to set whether migration co
 
 Both options are disabled globally by default.
 
-
-*Configuring Auto-convergence and Migration Compression for Virtual Machine Migration*
-
+.Procedure
 . Configure the optimization settings at the global level:
-.. Enable auto-convergence at the global level:
+. Enable auto-convergence at the global level:
 +
 [options="nowrap" subs="normal"]
 ----

--- a/source/documentation/virtual_machine_management_guide/topics/Optimizing_Live_Migration.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Optimizing_Live_Migration.adoc
@@ -5,7 +5,7 @@ Live virtual machine migration can be a resource-intensive operation. To optimiz
 
 [NOTE]
 ====
-For cluster levels 4.3 or later, auto converge is enabled by default for all built-in policies, and migration compression is enabled by default for only the `Suspend workload if needed`. You can change these parameters by modifying the `MigrationPolicies` configuration value, and when adding a new migration policy.
+For cluster levels 4.3 or later, auto converge is enabled by default for all built-in migration policies, and migration compression is enabled by default for only the `Suspend workload if needed` migration policy. You can change these parameters by modifying the `MigrationPolicies` configuration value, and when adding a new migration policy.
 ====
 
 The *Auto Converge migrations* option allows you to set whether auto-convergence is used during live migration of virtual machines. Large virtual machines with high workloads can dirty memory more quickly than the transfer rate achieved during live migration, and prevent the migration from converging. Auto-convergence capabilities in QEMU allow you to force convergence of virtual machine migrations. QEMU automatically detects a lack of convergence and triggers a throttle-down of the vCPUs on the virtual machine.

--- a/source/documentation/virtual_machine_management_guide/topics/Optimizing_Live_Migration.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Optimizing_Live_Migration.adoc
@@ -1,0 +1,55 @@
+[[Optimizing_Live_Migration]]
+==== Optimizing Live Migration
+
+Live virtual machine migration can be a resource-intensive operation. To optimize live migration, you can set the following two options globally for every virtual machine in an environment, for every virtual machine in a cluster, or for an individual virtual machine.
+
+[NOTE]
+====
+For cluster levels 4.3 or later, auto converge is enabled by default for all built-in policies, and migration compression is enabled by default for only the `Suspend workload if needed`. You can change these parameters by modifying the `MigrationPolicies` configuration value, and when adding a new migration policy.
+====
+
+The *Auto Converge migrations* option allows you to set whether auto-convergence is used during live migration of virtual machines. Large virtual machines with high workloads can dirty memory more quickly than the transfer rate achieved during live migration, and prevent the migration from converging. Auto-convergence capabilities in QEMU allow you to force convergence of virtual machine migrations. QEMU automatically detects a lack of convergence and triggers a throttle-down of the vCPUs on the virtual machine.
+
+The *Enable migration compression* option allows you to set whether migration compression is used during live migration of the virtual machine. This feature uses Xor Binary Zero Run-Length-Encoding to reduce virtual machine downtime and total live migration time for virtual machines running memory write-intensive workloads or for any application with a sparse memory update pattern.
+
+Both options are disabled globally by default.
+
+
+*Configuring Auto-convergence and Migration Compression for Virtual Machine Migration*
+
+. Configure the optimization settings at the global level:
+.. Enable auto-convergence at the global level:
++
+[options="nowrap" subs="normal"]
+----
+# engine-config -s DefaultAutoConvergence=True
+----
++
+.. Enable migration compression at the global level:
++
+[options="nowrap" subs="normal"]
+----
+# engine-config -s DefaultMigrationCompression=True
+----
++
+.. Restart the *ovirt-engine* service to apply the changes:
++
+[options="nowrap" subs="normal"]
+----
+# systemctl restart ovirt-engine.service
+----
++
+. Configure the optimization settings for a cluster:
+.. Click menu:Compute[Clusters] and select a cluster.
+.. Click btn:[Edit].
+.. Click the *Migration Policy* tab.
+.. From the *Auto Converge migrations* list, select *Inherit from global setting*, *Auto Converge*, or *Don't Auto Converge*.
+.. From the *Enable migration compression* list, select *Inherit from global setting*, *Compress*, or *Don't Compress*.
+.. Click btn:[OK].
+. Configure the optimization settings at the virtual machine level:
+.. Click menu:Compute[Virtual Machines] and select a virtual machine.
+.. Click btn:[Edit].
+.. Click the *Host* tab.
+.. From the *Auto Converge migrations* list, select *Inherit from cluster setting*, *Auto Converge*, or *Don't Auto Converge*.
+.. From the *Enable migration compression* list, select *Inherit from cluster setting*, *Compress*, or *Don't Compress*.
+.. Click btn:[OK].


### PR DESCRIPTION
Fixes issue # https://bugzilla.redhat.com/show_bug.cgi?id=1946201

Changes proposed in this pull request:
- Added information that for cluster levels 4.3 or later, auto migration and compression are enabled by default

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @dcdacosta

This pull request needs review by: please @ahadas 

**Preview link:** https://ovirt.github.io/ovirt-site/previews/2663/documentation/virtual_machine_management_guide/index.html#Optimizing_Live_Migration