### PR TITLE
Add missing step from configuring tz doc

### DIFF
--- a/source/documentation/virtual_machine_management_guide/topics/Configuring_Time_Zones.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Configuring_Time_Zones.adoc
@@ -14,8 +14,12 @@ Do not change values that come directly from the operating system or the {engine
 . Create an override file in `/etc/ovirt-engine/conf/`. The file name must begin with a value greater than `00`, so that the file appears after `/etc/ovirt-engine/conf/00-timezone.properties`, and ends with the extension, `.properties`.
 +
 For example, `10-timezone.properties` overrides the default file, `00-timezone.properties`. The last file in the file list has precedence over earlier files.
-+
 . Add new time zones to that file. Be sure each key is a valid General time zone from the link:https://en.wikipedia.org/wiki/Tz_database[time zone database] and the value is a valid Windows time zone:
 +
 General:: Time zones used for non-Windows operating system types, must follow the standard time zone format for example, `Etc/GMT` or `Asia/Jerusalem`.
 Windows:: Time zones specifically supported on link:https://docs.microsoft.com/en-us/previous-versions/windows/embedded/ms912391(v=winembedded.11)?redirectedfrom=MSDN[Windows] for example, `GMT Standard Time` or `Israel Standard Time`.
+. Restart the `ovirt-engine` service:
++
+[options="nowrap" subs="normal"]
+----
+# systemctl restart ovirt-engine


### PR DESCRIPTION
Add restart the engine step that was missing
to configuring tz document.

This pull request needs review by: @ahadas @dcdacosta @sandrobonazzola 
