### PR TITLE
fixing compilation sync errors - remove illegal code block param

### DIFF
--- a/source/documentation/common/collateral_files/legal-notice.adoc
+++ b/source/documentation/common/collateral_files/legal-notice.adoc
@@ -1,7 +1,7 @@
 [appendix]
 [id="legal-notice"]
 = Legal notice
-include::common/collateral_files/attributes.adoc[]
+include::attributes.adoc[]
 
 [.lead]
 Copyright © 2021 Red Hat, Inc.

--- a/source/documentation/common/upgrade/proc-Upgrading_hypervisor_preserve_gluster_storage.adoc
+++ b/source/documentation/common/upgrade/proc-Upgrading_hypervisor_preserve_gluster_storage.adoc
@@ -109,7 +109,6 @@ Example:
 +
 .. Edit the backup inventory file with correct details.
 +
-[code, subs="attributes"]
 ----
   Common variables
   backup_dir ->  Absolute path to directory that contains the extracted contents of the backup archive


### PR DESCRIPTION
Fixes issue  sync problems in downstream/Pantheon compilation due to illegal code block parameter

Changes proposed in this pull request:  remove [code, 

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @emarcusRH )

This pull request needs review by: (please @stoobie mention the reviewer if relevant)
