### PR TITLE
BZ#1867062 add prerequisite for VMs to be set to cluster compatibility level 4.3

### DIFF
--- a/source/documentation/common/upgrade/proc-Upgrading_the_Manager_to_4-4.adoc
+++ b/source/documentation/common/upgrade/proc-Upgrading_the_Manager_to_4-4.adoc
@@ -26,8 +26,8 @@ You can only restore backups to environments of the same minor release as that o
 
 .Prerequisites
 
-* All data centers and clusters in the environment must have the cluster compatibility level set to version 4.2 or 4.3 before you start the procedure.
-* All virtual machines in the environment must have the cluster compatibility level set to version 4.3 before you start the procedure.
+* All data centers and clusters in the environment must have the cluster compatibility level set to version 4.2 or 4.3.
+* All virtual machines in the environment must have the cluster compatibility level set to version 4.3.
 ifdef::SHE_upgrade[]
 * Make note of the MAC address of the self-hosted engine if you are using DHCP and want to use the same IP address. The deploy script prompts you for this information.
 * During the deployment you need to provide a new storage domain for the {engine-name} machine. The deployment script renames the 4.3 storage domain and retains its data to enable disaster recovery.

--- a/source/documentation/common/upgrade/proc-Upgrading_the_Manager_to_4-4.adoc
+++ b/source/documentation/common/upgrade/proc-Upgrading_the_Manager_to_4-4.adoc
@@ -27,6 +27,7 @@ You can only restore backups to environments of the same minor release as that o
 .Prerequisites
 
 * All data centers and clusters in the environment must have the cluster compatibility level set to version 4.2 or 4.3 before you start the procedure.
+* All virtual machines in the environment must have the cluster compatibility level set to version 4.3 before you start the procedure.
 ifdef::SHE_upgrade[]
 * Make note of the MAC address of the self-hosted engine if you are using DHCP and want to use the same IP address. The deploy script prompts you for this information.
 * During the deployment you need to provide a new storage domain for the {engine-name} machine. The deployment script renames the 4.3 storage domain and retains its data to enable disaster recovery.


### PR DESCRIPTION
Fixes issue #1867062

Changes proposed in this pull request:

-add prerequisite for upgrading Manager 4.3 > 4.4: all VMs must have cluster compatibility level 4.3
Preview is here: https://ovirt.github.io/ovirt-site/previews/2677/documentation/upgrade_guide/index.html#Upgrading_the_Manager_to_4-4_4-3_SHE

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @emarcusRH )

This pull request needs review by: (please @RichardHoch )
