### PR TITLE
Fixed formatting issue in Configuring Time Zone topic

### DIFF
--- a/source/documentation/virtual_machine_management_guide/topics/Configuring_Time_Zones.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Configuring_Time_Zones.adoc
@@ -18,8 +18,9 @@ For example, `10-timezone.properties` overrides the default file, `00-timezone.p
 +
 General:: Time zones used for non-Windows operating system types, must follow the standard time zone format for example, `Etc/GMT` or `Asia/Jerusalem`.
 Windows:: Time zones specifically supported on link:https://docs.microsoft.com/en-us/previous-versions/windows/embedded/ms912391(v=winembedded.11)?redirectedfrom=MSDN[Windows] for example, `GMT Standard Time` or `Israel Standard Time`.
-. Restart the `ovirt-engine` service:
+. Restart the `{engine-package}` service:
 +
 [options="nowrap" subs="normal"]
 ----
 # systemctl restart ovirt-engine
+----


### PR DESCRIPTION
Fixes formatting issue in Configuring Time Zones topic
Changes proposed in this pull request:
- Added closing ---- for the example in Step 3
- Used the {engine-package} attribute in Step 3 so the term resolves correctly for both upstream and downstream

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (@dcdacosta)

This pull request needs review by: (please @emarcusRH)

**Direct link to preview of changes:**
https://ovirt.github.io/ovirt-site/previews/2679/documentation/virtual_machine_management_guide/index.html#Configuring_timezones


