### PR TITLE
BZ#1822023 add note regarding non operational host in SHE restore

### DIFF
--- a/source/documentation/common/backup-restore/proc-Restoring_the_Backup_on_a_New_Self-hosted_Engine.adoc
+++ b/source/documentation/common/backup-restore/proc-Restoring_the_Backup_on_a_New_Self-hosted_Engine.adoc
@@ -90,13 +90,17 @@ The static IP address must belong to the same subnet as the host. For example, i
 . Enter a password for the `admin@internal` user to access the Administration Portal.
 +
 The script creates the virtual machine. This can take some time if the {engine-appliance-name} needs to be installed.
++
 [NOTE]
 ====
 If the host becomes non operational and the deployment fails (due to missing required network or similar problem), you can repeat the process, and answer _YES_ to the option _Pause the execution after adding this host to the engine?_. Pausing the process allows you to connect to the restored engine and manually review and remediate the configuration before proceeding with the deployment.
 ====
++
 ifdef::rhv-doc[]
++
 See also link:https://access.redhat.com/solutions/4088711[]
 endif::rhv-doc[]
+
 . Select the type of storage to use:
 
 * For NFS, enter the version, full address and path to the storage, and any mount options.

--- a/source/documentation/common/backup-restore/proc-Restoring_the_Backup_on_a_New_Self-hosted_Engine.adoc
+++ b/source/documentation/common/backup-restore/proc-Restoring_the_Backup_on_a_New_Self-hosted_Engine.adoc
@@ -90,7 +90,13 @@ The static IP address must belong to the same subnet as the host. For example, i
 . Enter a password for the `admin@internal` user to access the Administration Portal.
 +
 The script creates the virtual machine. This can take some time if the {engine-appliance-name} needs to be installed.
-
+[NOTE]
+====
+If the host becomes non operational and the deployment fails (due to missing required network or similar problem), you can repeat the process, and answer _YES_ to the option _Pause the execution after adding this host to the engine?_. Pausing the process allows you to connect to the restored engine and manually review and remediate the configuration before proceeding with the deployment.
+====
+ifdef::rhv-doc[]
+See also link:https://access.redhat.com/solutions/4088711[]
+endif::rhv-doc[]
 . Select the type of storage to use:
 
 * For NFS, enter the version, full address and path to the storage, and any mount options.


### PR DESCRIPTION
Fixes issue #1822023

Changes proposed in this pull request:
- "Migrating from a standalone manager to SHE" guide, section 6. "Restoring the Backup on a New Self-Hosted Engine" 
- add note regarding non operational host in SHE restore
- add link (RHV-docs only) to KCS article
Preview: https://ovirt.github.io/ovirt-site/previews/2680/documentation/migrating_from_a_standalone_manager_to_a_self-hosted_engine/index.html#Restoring_the_Backup_on_a_New_Self-hosted_Engine_migrating_to_SHE
I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @emarcusRH 
This pull request needs review by: (please @mention the reviewer if relevant)
