### PR TITLE
BZ1881864: [Docs] [Prereq] [Admin]  Image I/O Proxy replaced by ovirt-imageio

### DIFF
--- a/source/documentation/administration_guide/chap-Storage.adoc
+++ b/source/documentation/administration_guide/chap-Storage.adoc
@@ -129,7 +129,7 @@ include::topics/Importing_Templates_from_Imported_Data_Storage_Domains.adoc[]
 
 :context: storage_tasks
 
-include::topics/Uploading_Images_to_a_Data_Storage_Domain.adoc[]
+include::topics/Uploading_Images_to_a_Data_Storage_Domain.adoc[leveloffset=+3]
 
 include::topics/proc_Copy_image_to_ISO_domain.adoc[leveloffset=+3]
 

--- a/source/documentation/administration_guide/topics/Uploading_Images_to_a_Data_Storage_Domain.adoc
+++ b/source/documentation/administration_guide/topics/Uploading_Images_to_a_Data_Storage_Domain.adoc
@@ -1,5 +1,5 @@
 [id='Uploading_Images_to_a_Data_Storage_Domain_{context}']
-==== Uploading Images to a Data Storage Domain
+= Uploading Images to a Data Storage Domain
 
 You can upload virtual disk images and ISO images to your data storage domain in the Administration Portal or with the REST API.
 
@@ -16,15 +16,13 @@ ISO images can be attached to virtual machines as CDROMs or used to boot virtual
 
 The upload function uses HTML 5 APIs, which requires your environment to have the following:
 
-* Image I/O Proxy (`ovirt-imageio-proxy`), configured with `engine-setup`. See link:{URL_virt_product_docs}{URL_format}installing_{URL_product_virt}_as_a_standalone_manager_with_local_databases/index#Configuring_the_Red_Hat_Virtualization_Manager_install_RHVM[Configuring the {virt-product-fullname} {engine-name}] for details.
-
 * Certificate authority, imported into the web browser used to access the Administration Portal.
 +
 To import the certificate authority, browse to `https://_engine_address_/ovirt-engine/services/pki-resource?resource=ca-certificate&amp;format=X509-PEM-CA` and enable all the trust settings. Refer to the instructions to install the certificate authority in link:https://access.redhat.com/solutions/95103[Firefox], link:https://access.redhat.com/solutions/17864[Internet Explorer], or link:https://access.redhat.com/solutions/1168383[Google Chrome].
 
 * Browser that supports HTML 5, such as Firefox 35, Internet Explorer 10, Chrome 13, or later.
 
-*Uploading an Image to a Data Storage Domain*
+.Procedure
 
 . Click menu:Storage[Disks].
 . Select *Start* from the *Upload* menu.
@@ -34,17 +32,13 @@ To import the certificate authority, browse to `https://_engine_address_/ovirt-e
 +
 A progress bar indicates the status of the upload. You can pause, cancel, or resume uploads from the *Upload* menu.
 
-*Increasing the Upload Timeout Value*
+[TIP]
+====
+If the upload times out with the message, *Reason: timeout due to transfer inactivity*, increase the timeout value and restart the `ovirt-engine` service:
 
-. If the upload times out and you see the message, *Reason: timeout due to transfer inactivity*, increase the timeout value:
-+
 [options="nowrap" subs="normal"]
 ----
 # engine-config -s TransferImageClientInactivityTimeoutInSeconds=6000
-----
-. Restart the `ovirt-engine` service:
-+
-[options="nowrap" subs="normal"]
-----
 # systemctl restart ovirt-engine
 ----
+====

--- a/source/documentation/common/prereqs/ref-Database_Server_Firewall_Requirements.adoc
+++ b/source/documentation/common/prereqs/ref-Database_Server_Firewall_Requirements.adoc
@@ -15,11 +15,13 @@ Similarly, if you plan to access a local or remote Data Warehouse database from 
 Accessing the {engine-name} database from external systems is not supported.
 ====
 
+ifdef::rhv-doc[]
 [NOTE]
 ====
 A diagram of these firewall requirements is available at https://access.redhat.com/articles/3932211.
 You can use the IDs in the table to look up connections in the diagram.
 ====
+endif::[]
 
 .Database Server Firewall Requirements
 [options="header", cols="2,2,2,5,5,5,3", frame=all, grid=all]

--- a/source/documentation/common/prereqs/ref-Host_Firewall_Requirements.adoc
+++ b/source/documentation/common/prereqs/ref-Host_Firewall_Requirements.adoc
@@ -9,12 +9,14 @@
 
 To disable automatic firewall configuration when adding a new host, clear the *Automatically configure host firewall* check box under *Advanced Parameters*.
 
+ifdef::rhv-doc[]
 To customize the host firewall rules, see link:https://access.redhat.com/solutions/2772331[].
 [NOTE]
 ====
 A diagram of these firewall requirements is available at https://access.redhat.com/articles/3932211.
 You can use the IDs in the table to look up connections in the diagram.
 ====
+endif::[]
 
 .Virtualization Host Firewall Requirements
 [options="header", %autowidth, frame=all, grid=all]

--- a/source/documentation/common/prereqs/ref-Host_Firewall_Requirements.adoc
+++ b/source/documentation/common/prereqs/ref-Host_Firewall_Requirements.adoc
@@ -5,7 +5,7 @@
 // PPG
 // Install
 
-{enterprise-linux-host-fullname}s and {hypervisor-fullname}s ({hypervisor-shortname}) require a number of ports to be opened to allow network traffic through the system's firewall. The firewall rules are automatically configured by default when adding a new host to the {engine-name}, overwriting any pre-existing firewall configuration. 
+{enterprise-linux-host-fullname}s and {hypervisor-fullname}s ({hypervisor-shortname}) require a number of ports to be opened to allow network traffic through the system's firewall. The firewall rules are automatically configured by default when adding a new host to the {engine-name}, overwriting any pre-existing firewall configuration.
 
 To disable automatic firewall configuration when adding a new host, clear the *Automatically configure host firewall* check box under *Advanced Parameters*.
 
@@ -81,9 +81,9 @@ Client machines |{hypervisor-fullname}s
 
 {enterprise-linux-host-fullname}s |VDSM communications with the {engine-name} and other virtualization hosts.
 |Yes
-|H11 |54322 |TCP |{virt-product-fullname} {engine-name} (ImageIO Proxy server) |{hypervisor-fullname}s
+|H11 |54322 |TCP |{virt-product-fullname} {engine-name} `ovirt-imageio` service |{hypervisor-fullname}s
 
-{enterprise-linux-host-fullname}s |Required for communication with the ImageIO daemon (*ovirt-imageio-daemon*).
+{enterprise-linux-host-fullname}s |Required for communication with the `ovirt-imageo` service.
 |Yes
 |H12 |6081 |UDP |{hypervisor-fullname}s
 

--- a/source/documentation/common/prereqs/ref-Manager_Firewall_Requirements.adoc
+++ b/source/documentation/common/prereqs/ref-Manager_Firewall_Requirements.adoc
@@ -51,7 +51,7 @@ VM Portal clients |{virt-product-fullname} {engine-name} |Provides websocket pro
 
 {enterprise-linux-host-fullname}s |{virt-product-fullname} {engine-name} |If Kdump is enabled on the hosts, open this port for the fence_kdump listener on the {engine-name}. See link:{URL_virt_product_docs}{URL_format}administration_guide/index#sect-fence_kdump_Advanced_Configuration[fence_kdump Advanced Configuration]. `fence_kdump` doesn't provide a way to encrypt the connection. However, you can manually configure this port to block access from hosts that are not eligible.
 |No
-|M7 |54323 |TCP |Administration Portal clients |{virt-product-fullname} {engine-name} (ImageIO Proxy server) |Required for communication with the ImageIO Proxy (`ovirt-imageio-proxy`).
+|M7 |54323 |TCP |Administration Portal clients |{virt-product-fullname} {engine-name} (`ovirt-imageio` service) |Required for communication with the `ovirt-imageo` service.
 |Yes
 |M8 |6442 |TCP |{hypervisor-fullname}s
 

--- a/source/documentation/common/prereqs/ref-Manager_Firewall_Requirements.adoc
+++ b/source/documentation/common/prereqs/ref-Manager_Firewall_Requirements.adoc
@@ -11,11 +11,13 @@ The `engine-setup` script can configure the firewall automatically.
 
 The firewall configuration documented here assumes a default configuration.
 
+ifdef::rhv-doc[]
 [NOTE]
 ====
 A diagram of these firewall requirements is available at https://access.redhat.com/articles/3932211.
 You can use the IDs in the table to look up connections in the diagram.
 ====
+endif::[]
 
 .{virt-product-fullname} {engine-name} Firewall Requirements
 [options="header", cols="3,3,3,4,4,4,4", frame=all, grid=all]


### PR DESCRIPTION
Fixes BZ1881864: https://bugzilla.redhat.com/show_bug.cgi?id=1881864

Changes proposed in this pull request:

- Changing *ImageIO Proxy server* to *ovirt-imageio*

Previews:
https://ovirt.github.io/ovirt-site/previews/2682/documentation/installing_ovirt_as_a_self-hosted_engine_using_the_command_line/index.html#RHV-manager-firewall-requirements_SHE_cli_deploy
https://ovirt.github.io/ovirt-site/previews/2682/documentation/installing_ovirt_as_a_self-hosted_engine_using_the_command_line/index.html#host-firewall-requirements_SHE_cli_deploy
https://ovirt.github.io/ovirt-site/previews/2682/documentation/administration_guide/index.html#Uploading_Images_to_a_Data_Storage_Domain_storage_tasks

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @stoobie

This pull request needs review by: @nirs
