### PR TITLE
fix-issue2688 Removed ovirt-documentation from CODEOWNERS file.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,3 @@
 # See https://help.github.com/articles/about-code-owners/ for more info on this file
 
 /source/release/ @oVirt/ovirt-release-engineering
-/source/documentation/ @oVirt/ovirt-documentation


### PR DESCRIPTION
Fixes issue #2688

Changes proposed in this pull request:

- Removed ovirt-documentation from CODEOWNERS file.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @stoobie 

This pull request needs review by: @sandrobonazzola @oVirt/ovirt-documentation 
