### PR TITLE
Create links between oVirt on GH related pages

### DIFF
--- a/source/develop/dev-process/working-with-github.md
+++ b/source/develop/dev-process/working-with-github.md
@@ -119,3 +119,8 @@ $ gh repo sync
 ## Further reading
 
 Further details how to work with GitHub can be found in the [GitHub Docs](https://docs.github.com/en) or [GitHub CLI Manual](https://cli.github.com/manual/).
+
+
+# Administration of an oVirt project on GitHub
+
+Best practices for administration of an oVirt project on GitHub are described at [Migrating to GitHub](https://www.ovirt.org/develop/developer-guide/migrating_to_github.html).

--- a/source/develop/developer-guide/migrating_to_github.md
+++ b/source/develop/developer-guide/migrating_to_github.md
@@ -294,3 +294,8 @@ contact_links:
 For each repository, you can assign [labels](https://github.com/actions/labeler) to easily label things such as good first issues, bugs, documentation, tested labels, and more. Your repository labels can be found at: `https://github.com/oVirt/<your_project>/labels`
 
 There is also a GitHub Action you can use in your repository to [automatically label PRs](https://github.com/actions/labeler).
+
+
+# Developing code ob GitHub
+
+Best practices for developing an oVirt project on GitHub are described at [Working with oVirt on GitHub](https://www.ovirt.org/develop/dev-process/working-with-github.html).

--- a/source/develop/developer-guide/migrating_to_github.md
+++ b/source/develop/developer-guide/migrating_to_github.md
@@ -296,6 +296,6 @@ For each repository, you can assign [labels](https://github.com/actions/labeler)
 There is also a GitHub Action you can use in your repository to [automatically label PRs](https://github.com/actions/labeler).
 
 
-# Developing code ob GitHub
+# Developing code on GitHub
 
-Best practices for developing an oVirt project on GitHub are described at [Working with oVirt on GitHub](https://www.ovirt.org/develop/dev-process/working-with-github.html).
+You can find the best practices for developing an oVirt project on GitHub in [Working with oVirt on GitHub](https://www.ovirt.org/develop/dev-process/working-with-github.html).


### PR DESCRIPTION
Creates links between "Working with oVirt on GitHub" and "Migrating to
GitHub" pages.

Signed-off-by: Martin Perina <mperina@redhat.com>

Fixes issue # (delete if not relevant)

Changes proposed in this pull request:

-

-

-

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @mention yourself to sign)

This pull request needs review by: (please @mention the reviewer if relevant)
