### PR TITLE
github migrating doc: Update the upload rpm action

### DIFF
--- a/source/develop/developer-guide/migrating_to_github.md
+++ b/source/develop/developer-guide/migrating_to_github.md
@@ -157,10 +157,9 @@ jobs:
           yum --downloadonly install -y exported-artifacts/*noarch.rpm
           yum --downloadonly install -y ovirt-engine ovirt-engine-setup-plugin-websocket-proxy
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: ovirt/upload-rpms-action@v2
       with:
-        name: artifacts
-        path: exported-artifacts/
+        directory: test-artifacts
 
 
   build-el9:
@@ -205,10 +204,9 @@ jobs:
           yum --downloadonly install -y exported-artifacts/*noarch.rpm
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: ovirt/upload-rpms-action@v2
       with:
-        name: artifacts
-        path: exported-artifacts/
+        directory: test-artifacts
 ```
 
 # Require "CI +1" for merging


### PR DESCRIPTION
Update the github action example to use upload-rpms-action[1]
that takes a directory, creates an RPM repository if needed 
and uploads the resulting RPM repository.

[1] https://github.com/oVirt/upload-rpms-action

This pull request needs review by: @tinez @almusil 