### PR TITLE
1702011.1 Fixing typos, indicating that community only applies to SNMPv2

### DIFF
--- a/source/documentation/administration_guide/topics/ref-Sample-SNMPv3-traps-configuration-file.adoc
+++ b/source/documentation/administration_guide/topics/ref-Sample-SNMPv3-traps-configuration-file.adoc
@@ -1,6 +1,5 @@
 [id="SNMPv3-traps-configuration-file"]
 = Sample SNMP configuration file
-// :icons: font
 
 This sample configuration file is based on settings in `ovirt-engine-notifier.conf`. A dedicated SNMP configuration file, such as this one, overrides the settings in `ovirt-engine-notifier.conf`.
 
@@ -10,9 +9,7 @@ Copy the default SNMP settings from the events notification daemon configuration
 ====
 
 ./etc/ovirt-engine/notifier/notifier.conf.d/20-snmp.conf
-//[options="nowrap" subs="normal"]
-//[source,perl,subs="+quotes,+macros"]
-//[source,perl,subs="verbatim,+macros"]
+
 [source,perl,subs="+quotes"]
 ----
 SNMP_MANAGERS="manager1.example.com manager2.example.com:162" <1>

--- a/source/documentation/administration_guide/topics/ref-Sample-SNMPv3-traps-configuration-file.adoc
+++ b/source/documentation/administration_guide/topics/ref-Sample-SNMPv3-traps-configuration-file.adoc
@@ -1,8 +1,8 @@
 [id="SNMPv3-traps-configuration-file"]
-= Sample SNMP version 3 configuration file
-:icons: font
+= Sample SNMP configuration file
+// :icons: font
 
-This sample configuration file is based on settings in `ovirt-engine-notifier.conf`.
+This sample configuration file is based on settings in `ovirt-engine-notifier.conf`. A dedicated SNMP configuration file, such as this one, overrides the settings in `ovirt-engine-notifier.conf`.
 
 [TIP]
 ====
@@ -30,7 +30,7 @@ SNMP_SECURITY_LEVEL=3 <12>
 ----
 
 <1> The IP addresses or fully qualified domain names of machines that will act as the SNMP managers. Entries must be separated by a space and can contain a port number. For example, `manager1.example.com manager2.example.com:164`
-<1> Default SNMP Community String (SNMP version 2 only).
+<1> (SNMP version 2 only) Default SNMP Community String.
 <1> SNMP Trap Object Identifier for outgoing notifications. iso(1) org(3) dod(6) internet(1) private(4) enterprises(1) redhat(2312) ovirt(13) engine(1) notifier(1)
 +
 [NOTE]
@@ -39,10 +39,10 @@ Changing the default will prevent generated traps from complying with OVIRT-MIB.
 ====
 <1> The algorithm used to determine the triggers for and recipients of SNMP notifications.
 <1> SNMP Version. SNMP version 2 and version 3 traps are supported. 2 = SNMPv2, 3 = SNMPv3.
-<1> The engine id used for SNMPv3 traps.
-<1> The user name used for SNMPv3 traps.
-<1> The SNMPv3 auth protocol. Supported values are MD5 and SHA. Required when `SNMP_SECURITY_LEVEL` is set to 2 (`AUTH_NOPRIV`) or 3 (`AUTH_PRIV`).
-<1> The SNMPv3 auth passphrase. Required when `SNMP_SECURITY_LEVEL` is set to 2 (`AUTH_NOPRIV`) or 3 (`AUTH_PRIV`).
-<1> The SNMPv3 privacy protocol. Supported values are AES128, AES192 and AES256. Be aware that AES192 and AES256 are not defined in RFC3826, so verify that your SNMP server supports those protocols before enabling them. Required when `SNMP_SECURITY_LEVEL` is set to 3 (`AUTH_PRIV`).
-<1> The SNMPv3 privacy passphrase. Required when `SNMP_SECURITY_LEVEL` is set to 3 (`AUTH_PRIV`).
-<1> The SNMPv3 security level. 1 = `NOAUTH_NOPRIV`, 2 = `AUTH_NOPRIV`, 3 = `AUTH_PRIV`.
+<1> (SNMP version 3 only) The engine id used for SNMP traps.
+<1> (SNMP version 3 only) The user name used for SNMP traps.
+<1> (SNMP version 3 only) The SNMP auth protocol. Supported values are MD5 and SHA. Required when `SNMP_SECURITY_LEVEL` is set to 2 (`AUTH_NOPRIV`) or 3 (`AUTH_PRIV`).
+<1> (SNMP version 3 only) The SNMP auth passphrase. Required when `SNMP_SECURITY_LEVEL` is set to 2 (`AUTH_NOPRIV`) or 3 (`AUTH_PRIV`).
+<1> (SNMP version 3 only) The SNMP privacy protocol. Supported values are AES128, AES192 and AES256. Be aware that AES192 and AES256 are not defined in RFC3826, so verify that your SNMP server supports those protocols before enabling them. Required when `SNMP_SECURITY_LEVEL` is set to 3 (`AUTH_PRIV`).
+<1> (SNMP version 3 only) The SNMP privacy passphrase. Required when `SNMP_SECURITY_LEVEL` is set to 3 (`AUTH_PRIV`).
+<1> (SNMP version 3 only) The SNMP security level. 1 = `NOAUTH_NOPRIV`, 2 = `AUTH_NOPRIV`, 3 = `AUTH_PRIV`.

--- a/source/documentation/administration_guide/topics/ref-Sample-SNMPv3-traps-configuration-file.adoc
+++ b/source/documentation/administration_guide/topics/ref-Sample-SNMPv3-traps-configuration-file.adoc
@@ -11,7 +11,9 @@ Copy the default SNMP settings from the events notification daemon configuration
 
 ./etc/ovirt-engine/notifier/notifier.conf.d/20-snmp.conf
 //[options="nowrap" subs="normal"]
-[source,perl]
+//[source,perl,subs="+quotes,+macros"]
+//[source,perl,subs="verbatim,+macros"]
+[source,perl,subs="+quotes"]
 ----
 SNMP_MANAGERS="manager1.example.com manager2.example.com:162" <1>
 SNMP_COMMUNITY=public <2>
@@ -19,16 +21,16 @@ SNMP_OID=1.3.6.1.4.1.2312.13.1.1 <3>
 FILTER="include:*(snmp:)" <4>
 SNMP_VERSION=3 <5>
 SNMP_ENGINE_ID="80:00:00:00:01:02:05:05" <6>
-SNMP_USERNAME=ovirtengine> <7>
+SNMP_USERNAME=_<username>_ <7>
 SNMP_AUTH_PROTOCOL=MD5 <8>
-SNMP_AUTH_PASSPHRASE=<__authpass__> <9>
+SNMP_AUTH_PASSPHRASE=_<authpass>_ <9>
 SNMP_PRIVACY_PROTOCOL=AES128 <10>
-SNMP_PRIVACY_PASSPHRASE=<__privpass__> <11>
+SNMP_PRIVACY_PASSPHRASE=_<privpass>_ <11>
 SNMP_SECURITY_LEVEL=3 <12>
 ----
 
 <1> The IP addresses or fully qualified domain names of machines that will act as the SNMP managers. Entries must be separated by a space and can contain a port number. For example, `manager1.example.com manager2.example.com:164`
-<1> Default SNMP Community String.
+<1> Default SNMP Community String (SNMP version 2 only).
 <1> SNMP Trap Object Identifier for outgoing notifications. iso(1) org(3) dod(6) internet(1) private(4) enterprises(1) redhat(2312) ovirt(13) engine(1) notifier(1)
 +
 [NOTE]


### PR DESCRIPTION
 Bug fix: Typos in SNMP topics, from BZ170211.

Changes proposed in this pull request:

- Fixed typos and missing italics in user-replacebale text formatting

- Added text indicating the SNMP community only applies to version 2.

Preview:
https://ovirt.github.io/ovirt-site/previews/2701/documentation/administration_guide/index.html#SNMPv3-traps-configuration-file

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @stoobie
