### PR TITLE
BZ#1867911 update note regarding non operational state in restoring SHE backup

### DIFF
--- a/source/documentation/common/backup-restore/proc-Restoring_the_Backup_on_a_New_Self-hosted_Engine.adoc
+++ b/source/documentation/common/backup-restore/proc-Restoring_the_Backup_on_a_New_Self-hosted_Engine.adoc
@@ -93,7 +93,7 @@ The script creates the virtual machine. This can take some time if the {engine-a
 +
 [NOTE]
 ====
-If the host becomes non operational, due to a missing required network or a similar problem, deployment will pause and a message such as the following will be displayed:
+If the host becomes non operational, due to a missing required network or a similar problem, the deployment pauses and a message such as the following is displayed:
 ----
 [ INFO  ] You can now connect to https://<host name>:6900/ovirt-engine/ and check the status of this host and eventually remediate it, please continue only when the host is listed as 'up'
 [ INFO  ] TASK [ovirt.ovirt.hosted_engine_setup : include_tasks]
@@ -106,8 +106,8 @@ Pausing the process allows you to:
 
 * Connect to the Administration Portal using the provided URL.
 * Assess the situation, find out why the host is non operational, and fix whatever is needed.
-* For example, if this deployment was restored from a backup, and the backup included _required networks_ for the host cluster, you should set up the networks accordingly, attaching the relevant host NICs to these networks as needed.
-Once everything looks ok, and the host status is _Up_, remove the lock file presented in the message above, and deployment will continue.
+For example, if this deployment was restored from a backup, and the backup included _required networks_ for the host cluster, configure the networks, attaching the relevant host NICs to these networks.
+* Once everything looks OK, and the host status is _Up_, remove the lock file presented in the message above. The deployment continues.
 ====
 +
 ifdef::rhv-doc[]

--- a/source/documentation/common/backup-restore/proc-Restoring_the_Backup_on_a_New_Self-hosted_Engine.adoc
+++ b/source/documentation/common/backup-restore/proc-Restoring_the_Backup_on_a_New_Self-hosted_Engine.adoc
@@ -93,7 +93,16 @@ The script creates the virtual machine. This can take some time if the {engine-a
 +
 [NOTE]
 ====
-If the host becomes non operational and the deployment fails (due to missing required network or similar problem), you can repeat the process, and answer _YES_ to the option _Pause the execution after adding this host to the engine?_. Pausing the process allows you to connect to the restored engine and manually review and remediate the configuration before proceeding with the deployment.
+If the host becomes non operational and the deployment fails due to a missing required network or a similar problem, deployment will pause and a message such as the following will be displayed:
+----
+  [ INFO  ] You can now connect to https://<host name>:6900/ovirt-engine/ and check the status of this host and eventually remediate it, please continue only when the host is listed as 'up'
+  [ INFO  ] TASK [ovirt.ovirt.hosted_engine_setup : include_tasks]
+  [ INFO  ] ok: [localhost]
+  [ INFO  ] TASK [ovirt.ovirt.hosted_engine_setup : Create temporary lock file]
+  [ INFO  ] changed: [localhost]
+  [ INFO  ] TASK [ovirt.ovirt.hosted_engine_setup : Pause execution until /tmp/ansible.<random>_he_setup_lock is removed, delete it once ready to proceed]
+----
+Pausing the process allows you to connect to the restored engine and manually, and review and remediate the configuration before proceeding with the deployment.
 ====
 +
 ifdef::rhv-doc[]

--- a/source/documentation/common/backup-restore/proc-Restoring_the_Backup_on_a_New_Self-hosted_Engine.adoc
+++ b/source/documentation/common/backup-restore/proc-Restoring_the_Backup_on_a_New_Self-hosted_Engine.adoc
@@ -93,7 +93,7 @@ The script creates the virtual machine. This can take some time if the {engine-a
 +
 [NOTE]
 ====
-If the host becomes non operational and the deployment fails due to a missing required network or a similar problem, deployment will pause and a message such as the following will be displayed:
+If the host becomes non operational, due to a missing required network or a similar problem, deployment will pause and a message such as the following will be displayed:
 ----
 [ INFO  ] You can now connect to https://<host name>:6900/ovirt-engine/ and check the status of this host and eventually remediate it, please continue only when the host is listed as 'up'
 [ INFO  ] TASK [ovirt.ovirt.hosted_engine_setup : include_tasks]
@@ -102,7 +102,13 @@ If the host becomes non operational and the deployment fails due to a missing re
 [ INFO  ] changed: [localhost]
 [ INFO  ] TASK [ovirt.ovirt.hosted_engine_setup : Pause execution until /tmp/ansible.<random>_he_setup_lock is removed, delete it once ready to proceed]
 ----
-Pausing the process allows you to connect to the restored engine and manually, and review and remediate the configuration before proceeding with the deployment.
+Pausing the process allows you to:
+
+* Connect to the Administration Portal using the provided URL.
+* Assess the situation, find out why the host is non operational, and fix whatever is needed.
+* For example, if this deployment was restored from a backup, and the backup included _required networks_ for the host cluster, you should set up the networks accordingly, attaching the relevant host NICs to these networks as needed.
+Once everything looks ok, and the host status is _Up_, remove the lock file presented in the message above, and deployment will continue.
+* Connect to the restored engine manually, and review and remediate the configuration before proceeding with the deployment.
 ====
 +
 ifdef::rhv-doc[]

--- a/source/documentation/common/backup-restore/proc-Restoring_the_Backup_on_a_New_Self-hosted_Engine.adoc
+++ b/source/documentation/common/backup-restore/proc-Restoring_the_Backup_on_a_New_Self-hosted_Engine.adoc
@@ -95,12 +95,12 @@ The script creates the virtual machine. This can take some time if the {engine-a
 ====
 If the host becomes non operational and the deployment fails due to a missing required network or a similar problem, deployment will pause and a message such as the following will be displayed:
 ----
-  [ INFO  ] You can now connect to https://<host name>:6900/ovirt-engine/ and check the status of this host and eventually remediate it, please continue only when the host is listed as 'up'
-  [ INFO  ] TASK [ovirt.ovirt.hosted_engine_setup : include_tasks]
-  [ INFO  ] ok: [localhost]
-  [ INFO  ] TASK [ovirt.ovirt.hosted_engine_setup : Create temporary lock file]
-  [ INFO  ] changed: [localhost]
-  [ INFO  ] TASK [ovirt.ovirt.hosted_engine_setup : Pause execution until /tmp/ansible.<random>_he_setup_lock is removed, delete it once ready to proceed]
+[ INFO  ] You can now connect to https://<host name>:6900/ovirt-engine/ and check the status of this host and eventually remediate it, please continue only when the host is listed as 'up'
+[ INFO  ] TASK [ovirt.ovirt.hosted_engine_setup : include_tasks]
+[ INFO  ] ok: [localhost]
+[ INFO  ] TASK [ovirt.ovirt.hosted_engine_setup : Create temporary lock file]
+[ INFO  ] changed: [localhost]
+[ INFO  ] TASK [ovirt.ovirt.hosted_engine_setup : Pause execution until /tmp/ansible.<random>_he_setup_lock is removed, delete it once ready to proceed]
 ----
 Pausing the process allows you to connect to the restored engine and manually, and review and remediate the configuration before proceeding with the deployment.
 ====

--- a/source/documentation/common/backup-restore/proc-Restoring_the_Backup_on_a_New_Self-hosted_Engine.adoc
+++ b/source/documentation/common/backup-restore/proc-Restoring_the_Backup_on_a_New_Self-hosted_Engine.adoc
@@ -108,7 +108,6 @@ Pausing the process allows you to:
 * Assess the situation, find out why the host is non operational, and fix whatever is needed.
 * For example, if this deployment was restored from a backup, and the backup included _required networks_ for the host cluster, you should set up the networks accordingly, attaching the relevant host NICs to these networks as needed.
 Once everything looks ok, and the host status is _Up_, remove the lock file presented in the message above, and deployment will continue.
-* Connect to the restored engine manually, and review and remediate the configuration before proceeding with the deployment.
 ====
 +
 ifdef::rhv-doc[]


### PR DESCRIPTION
Fixes issue # | [<BZ#1867911>(https://bugzilla.redhat.com/show_bug.cgi?id=1867911)

Changes proposed in this pull request:

-modify note regarding non operational state in restoring SHE backup
Previews: 
https://ovirt.github.io/ovirt-site/previews/2702/documentation/administration_guide/index.html#Backing_up_and_Restoring_a_Self-hosted_Engine
https://ovirt.github.io/ovirt-site/previews/2702/documentation/migrating_from_a_standalone_manager_to_a_self-hosted_engine/index.html#Restoring_the_Backup_on_a_New_Self-hosted_Engine_migrating_to_SHE

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): ( @emarcusRH )

This pull request needs review by: (please @didib )
