### PR TITLE
/var/tmp should not be smaller than 8 GB

### DIFF
--- a/source/documentation/common/prereqs/ref-Host_Storage_Requirements.adoc
+++ b/source/documentation/common/prereqs/ref-Host_Storage_Requirements.adoc
@@ -23,6 +23,6 @@ The minimum storage requirements for host installation are listed below. However
 * Anaconda reserves 20% of the thin pool size within the volume group for future metadata expansion. This is to prevent an out-of-the-box configuration from running out of space under normal usage conditions. Overprovisioning of thin pools during installation is also not supported.
 * *Minimum Total - 64 GiB*
 
-If you are also installing the {engine-appliance-name} for self-hosted engine installation, `/var/tmp` must be at least 5 GB.
+If you are also installing the {engine-appliance-name} for self-hosted engine installation, `/var/tmp` must be at least 8 GB.
 
 If you plan to use memory overcommitment, add enough swap space to provide virtual memory for all of virtual machines. See link:{URL_virt_product_docs}{URL_format}administration_guide/index#Memory_Optimization[Memory Optimization].


### PR DESCRIPTION
[ Bug fix]

Changes proposed in this pull request:

- /var/tmp should be larger than 8 GB the image is 6.8GB so there is not enough space on /var/tmp if its with the recommended 5 GB

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @mention yourself to sign)

This pull request needs review by: (please @mention the reviewer if relevant)
