### PR TITLE
Revert "announce oVirt conference 2021"

### DIFF
--- a/source/index.haml
+++ b/source/index.haml
@@ -20,9 +20,6 @@ hide_metadata: true
 
 :markdown
 
-%div.banner
-  %a(href="https://blogs.ovirt.org/ovirt-2021-online-conference/")
-    %img#rome(src="images/banners/BannerConf2021.png" style="display:block; margin-left: auto; margin-right: auto; align-items: center; margin-bottom: 50px;")
 
 %section.intro
   .container


### PR DESCRIPTION
Changes proposed in this pull request:

This reverts commit 797c1b494945cbe764b2a94375e37702113aba78.

The conference is long time over and there's no need to keep it announced on home page.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @michalskrivanek 
