### PR TITLE
Terminology and formatting fix

### DIFF
--- a/source/documentation/administration_guide/topics/proc-adding-kubevirt-openshift-as-an-external-provider.adoc
+++ b/source/documentation/administration_guide/topics/proc-adding-kubevirt-openshift-as-an-external-provider.adoc
@@ -34,9 +34,12 @@ NOTE: This capability is known as _OpenShift Virtualization_.
 
 . Click the name of new cluster you just created. This cluster name, *kubevirt* for example, is based on the name of the provider. This action opens the cluster details view.
 
-. Click the *Hosts* tab to verify that the {container-platform} status of the worker nodes is up.
+. Click the *Hosts* tab to verify that the status of the {container-platform} worker nodes is `up`.
 +
-NOTE: Even if they are running, the status of the master nodes is down because they cannot host virtual machines.
+[NOTE]
+====
+The status of the control plane nodes is `down`, even if they are running, because they cannot host virtual machines.
+====
 
 . Use menu:Compute[Virtual Machines] to deploy a virtual machine to the new cluster.
 


### PR DESCRIPTION
Bug fix

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=2048444. 

1. Replaces the phrase "master nodes" with the phrase "control plane nodes" in accordance with OpenShift documentation standards. 

2. Fixes formatting of the note in the verification steps.

Preview: https://ovirt.github.io/ovirt-site/previews/2724/documentation/administration_guide/index.html#proc-adding-kubevirt-openshift-as-an-external-provider_external_providers

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @RichardHoch 

This pull request needs review by @apinnick 
