### PR TITLE
BZ#1967772--Clarify statement about vMware OVAs

### DIFF
--- a/source/documentation/virtual_machine_management_guide/topics/Importing_an_OVA_file_from_a_host.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Importing_an_OVA_file_from_a_host.adoc
@@ -5,7 +5,7 @@ Import an Open Virtual Appliance (OVA) file into your {virt-product-fullname} en
 
 [IMPORTANT]
 ====
-Currently, only {virt-product-fullname} and VMware OVAs can be imported. KVM and Xen are not supported.
+Currently, only {virt-product-fullname} and OVAs created by VMware can be imported. KVM and Xen are not supported.
 
 The import process uses `virt-v2v`. Only virtual machines running operating systems compatible with `virt-v2v` can be successfully imported. For a current list of compatible operating systems, see link:https://access.redhat.com/articles/1351473[].
 ====


### PR DESCRIPTION
Bug fix

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1967772

Replaces the ambiguous "VMware OVAs" with the clearer "OVAs created by VMware" in a note. 

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @RichardHoch 

This pull request needs review by: Robert McSwain and @apinnick.  
