### PR TITLE
BZ2054905 - Updated Copyright date to 2022 and included legal notices…

### DIFF
--- a/source/documentation/administration_guide/index.adoc
+++ b/source/documentation/administration_guide/index.adoc
@@ -29,4 +29,4 @@ include::appe-System_Accounts.adoc[]
 [appendix]
 == Legal notice
 
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}administration_guide/[Red Hat Virtualization {vernum_rhv} Administration Guide]. Copyright © 2021 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}administration_guide/[Red Hat Virtualization {vernum_rhv} Administration Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].

--- a/source/documentation/administration_guide/index.adoc
+++ b/source/documentation/administration_guide/index.adoc
@@ -2,6 +2,9 @@
 include::common/collateral_files/attributes.adoc[]
 = Administration Guide
 
+:context: admin_guide
+:admin_guide:
+
 // Make sure Jekyll displays a guide title
 [discrete]
 = Administration Guide
@@ -26,7 +29,5 @@ include::appe-Branding.adoc[]
 
 include::appe-System_Accounts.adoc[]
 
-[appendix]
-== Legal notice
-
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}administration_guide/[Red Hat Virtualization {vernum_rhv} Administration Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+:admin_guide:
+include::common/collateral_files/legal-notice_ovirt.adoc[]

--- a/source/documentation/assembly-Setting_up_a_gpu_on_a_vm/master.adoc
+++ b/source/documentation/assembly-Setting_up_a_gpu_on_a_vm/master.adoc
@@ -12,5 +12,7 @@ You can use a host with a compatible graphics processing unit (GPU) to run virtu
 include::assembly_managing-nvidia-vgpu-devices.adoc[]
 //include::common/assemblies/assembly_managing-intel-vgpu-devices.adoc[leveloffset=+1]
 
+include::common/collateral_files/legal-notice.adoc[]
+
 :GPU_setup_on_vm_standalone_doc!:
 :context!: GPU_setup_on_vm_standalone_doc

--- a/source/documentation/common/collateral_files/legal-notice.adoc
+++ b/source/documentation/common/collateral_files/legal-notice.adoc
@@ -4,7 +4,7 @@
 include::attributes.adoc[]
 
 [.lead]
-Copyright © 2021 Red Hat, Inc.
+Copyright © 2022 Red Hat, Inc.
 
 Licensed under the (link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution–ShareAlike 4.0 International License]). Derived from documentation for the (link:https://ovirt.org[oVirt Project]). If you distribute this document or an adaptation of it, you must provide the URL for the original version.
 

--- a/source/documentation/common/collateral_files/legal-notice_ovirt.adoc
+++ b/source/documentation/common/collateral_files/legal-notice_ovirt.adoc
@@ -11,7 +11,7 @@ Certain portions of this text first appeared in link:{URL_downstream_virt_produc
 endif::DWH[]
 ifdef::disaster_recovery[]
 Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}disaster_recovery_guide/index[Red Hat Virtualization {vernum_rhv} Disaster Recovery Guide].
-endif::
+endif::disaster_recovery[]
 ifdef::VM_portal[]
 Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}introduction_to_the_vm_portal/index[Red Hat Virtualization {vernum_rhv} Introduction to the VM Portal].
 endif::VM_portal[]

--- a/source/documentation/common/collateral_files/legal-notice_ovirt.adoc
+++ b/source/documentation/common/collateral_files/legal-notice_ovirt.adoc
@@ -1,0 +1,51 @@
+[appendix]
+[id="legal-notice"]
+= Legal notice
+include::attributes.adoc[]
+
+ifdef::admin_guide[]
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}administration_guide/[Red Hat Virtualization {vernum_rhv} Administration Guide].
+endif::admin_guide[]
+ifdef::DWH[]
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}data_warehouse_guide/index[Red Hat Virtualization {vernum_rhv} Data Warehouse Guide].
+endif::DWH[]
+ifdef::disaster_recovery[]
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}disaster_recovery_guide/index[Red Hat Virtualization {vernum_rhv} Disaster Recovery Guide].
+endif::
+ifdef::VM_portal[]
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}introduction_to_the_vm_portal/index[Red Hat Virtualization {vernum_rhv} Introduction to the VM Portal].
+endif::VM_portal[]
+ifdef::RHV_planning[]
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}planning_and_prerequisites_guide/index[Red Hat Virtualization {vernum_rhv} Planning and Prerequisites].
+endif::RHV_planning[]
+ifdef::product_guide[]
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}product_guide/index[Red Hat Virtualization {vernum_rhv} Product Guide].
+endif::product_guide[]
+ifdef::pythonSDK[]
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}python_sdk_guide/index[Red Hat Virtualization {vernum_rhv} Python SDK Guide].
+endif::pythonSDK[]
+ifdef::restAPI[]
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}rest_api_guide/index[Red Hat Virtualization {vernum_rhv} REST API  Guide].
+endif::restAPI[]
+ifdef::techref[]
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}technical_reference/index[Red Hat Virtualization {vernum_rhv} Technical Reference].
+endif::techref[]
+ifdef::SHE_cli_deploy[]
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}installing_red_hat_virtualization_as_a_self-hosted_engine_using_the_command_line/[Red Hat Virtualization {vernum_rhv} Installing Red Hat Virtualization as a self-hosted engine using the command line].
+endif::SHE_cli_deploy[]
+ifdef::SM_localDB_deploy[]
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}installing_red_hat_virtualization_as_a_standalone_manager_with_local_databases/[Red Hat Virtualization {vernum_rhv} Installing Red Hat Virtualization as a standalone Manager with local databases].
+endif::SM_localDB_deploy[]
+ifdef::SM_remoteDB_deploy[]
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}installing_red_hat_virtualization_as_a_standalone_manager_with_remote_databases/[Red Hat Virtualization {vernum_rhv} Installing Red Hat Virtualization as a standalone Manager with remote databases].
+endif::SM_remoteDB_deploy[]
+ifdef::migrating_to_SHE[]
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}migrating_from_a_standalone_manager_to_a_self-hosted_engine/[Red Hat Virtualization {vernum_rhv} Migrating from a standalone Manager to a self-hosted engine].
+endif::migrating_to_SHE[]
+ifdef::upgrade[]
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}upgrade_guide/index[Red Hat Virtualization {vernum_rhv} Upgrade Guide].
+endif::upgrade[]
+ifdef::vmm[]
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}virtual_machine_management_guide/index[Red Hat Virtualization {vernum_rhv} Virtual Machine Management Guide].
+endif::vmm[]
+Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].

--- a/source/documentation/data_warehouse_guide/index.adoc
+++ b/source/documentation/data_warehouse_guide/index.adoc
@@ -15,7 +15,4 @@ include::chap-Installing_and_Configuring_Data_Warehouse.adoc[leveloffset=+1]
 
 include::chap-About_History_Database.adoc[]
 
-[appendix]
-== Legal notice
-
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}data_warehouse_guide/index[Red Hat Virtualization {vernum_rhv} Data Warehouse Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+include::common/collateral_files/legal-notice_ovirt.adoc[]

--- a/source/documentation/data_warehouse_guide/index.adoc
+++ b/source/documentation/data_warehouse_guide/index.adoc
@@ -18,4 +18,4 @@ include::chap-About_History_Database.adoc[]
 [appendix]
 == Legal notice
 
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}data_warehouse_guide/index[Red Hat Virtualization {vernum_rhv} Data Warehouse Guide]. Copyright © 2021 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}data_warehouse_guide/index[Red Hat Virtualization {vernum_rhv} Data Warehouse Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].

--- a/source/documentation/disaster_recovery_guide/index.adoc
+++ b/source/documentation/disaster_recovery_guide/index.adoc
@@ -4,6 +4,7 @@ include::common/collateral_files/attributes.adoc[]
 :imagesdir: images
 :toclevels: 4
 
+
 // Make sure Jekyll displays a guide title
 [discrete]
 = Disaster Recovery Guide
@@ -17,7 +18,5 @@ include::reference/rfr_MappingFileAttributes.adoc[leveloffset=+1]
 [appendix]
 include::reference/rfr_TestingAP.adoc[leveloffset=+1]
 
-[appendix]
-== Legal notice
-
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}disaster_recovery_guide/index[Red Hat Virtualization {vernum_rhv} Disaster Recovery Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+:disaster_recovery:
+include::common/collateral_files/legal-notice_ovirt.adoc[]

--- a/source/documentation/disaster_recovery_guide/index.adoc
+++ b/source/documentation/disaster_recovery_guide/index.adoc
@@ -20,4 +20,4 @@ include::reference/rfr_TestingAP.adoc[leveloffset=+1]
 [appendix]
 == Legal notice
 
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}disaster_recovery_guide/index[Red Hat Virtualization {vernum_rhv} Disaster Recovery Guide]. Copyright © 2021 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}disaster_recovery_guide/index[Red Hat Virtualization {vernum_rhv} Disaster Recovery Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].

--- a/source/documentation/doc-Hardware_Considerations_for_Implementing_SR-IOV/master.adoc
+++ b/source/documentation/doc-Hardware_Considerations_for_Implementing_SR-IOV/master.adoc
@@ -10,3 +10,5 @@ include::common/sriov/conc-Hardware_Considerations.adoc[]
 [id='Additional_Considerations']
 == Additional Hardware Considerations for Using Device Assignment
 include::common/sriov/conc-Additional_Considerations_Device_Assignment.adoc[]
+
+include::common/collateral_files/legal-notice.adoc[]

--- a/source/documentation/doc-Introduction_to_the_VM_Portal/index.adoc
+++ b/source/documentation/doc-Introduction_to_the_VM_Portal/index.adoc
@@ -13,7 +13,4 @@ include::chap-Accessing_the_VM_Portal.adoc[leveloffset=+1]
 
 include::chap-Managing_virtual_machines.adoc[]
 
-[appendix]
-== Legal notice
-
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}disaster_recovery_guide/index[Red Hat Virtualization {vernum_rhv} Disaster Recovery Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+include::common/collateral_files/legal-notice_ovirt.adoc[]

--- a/source/documentation/doc-Introduction_to_the_VM_Portal/index.adoc
+++ b/source/documentation/doc-Introduction_to_the_VM_Portal/index.adoc
@@ -16,4 +16,4 @@ include::chap-Managing_virtual_machines.adoc[]
 [appendix]
 == Legal notice
 
-Certain portions of this text first appeared in the link:{URL_downstream_virt_product_docs}introduction_to_the_vm_portal/[Red Hat Virtualization 4.3 Introduction to the VM Portal]. Copyright © 2019 Red Hat, Inc. Licensed under a link:http://creativecommons.org/licenses/by-sa/3.0/[Creative Commons Attribution-ShareAlike 3.0 Unported License].
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}disaster_recovery_guide/index[Red Hat Virtualization {vernum_rhv} Disaster Recovery Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].

--- a/source/documentation/doc-Introduction_to_the_VM_Portal/master.adoc
+++ b/source/documentation/doc-Introduction_to_the_VM_Portal/master.adoc
@@ -8,3 +8,5 @@ include::common/collateral_files/attributes.adoc[]
 include::chap-Accessing_the_VM_Portal.adoc[leveloffset=+1]
 
 include::chap-Managing_virtual_machines.adoc[]
+
+include::common/collateral_files/legal-notice.adoc[]

--- a/source/documentation/doc-Planning_and_Prerequisites_Guide/index.adoc
+++ b/source/documentation/doc-Planning_and_Prerequisites_Guide/index.adoc
@@ -21,7 +21,4 @@ include::asm-Considerations.adoc[]
 
 include::asm-Recommendations.adoc[]
 
-[appendix]
-== Legal notice
-
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}disaster_recovery_guide/index[Red Hat Virtualization {vernum_rhv} Disaster Recovery Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+include::common/collateral_files/legal-notice_ovirt.adoc[]

--- a/source/documentation/doc-Planning_and_Prerequisites_Guide/index.adoc
+++ b/source/documentation/doc-Planning_and_Prerequisites_Guide/index.adoc
@@ -20,3 +20,8 @@ include::common/prereqs/asm-Requirements.adoc[leveloffset=+1]
 include::asm-Considerations.adoc[]
 
 include::asm-Recommendations.adoc[]
+
+[appendix]
+== Legal notice
+
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}disaster_recovery_guide/index[Red Hat Virtualization {vernum_rhv} Disaster Recovery Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].

--- a/source/documentation/doc-Planning_and_Prerequisites_Guide/master.adoc
+++ b/source/documentation/doc-Planning_and_Prerequisites_Guide/master.adoc
@@ -21,3 +21,5 @@ include::common/prereqs/asm-Requirements.adoc[leveloffset=+1]
 include::asm-Considerations.adoc[]
 
 include::asm-Recommendations.adoc[]
+
+include::common/collateral_files/legal-notice.adoc[]

--- a/source/documentation/doc-Product_Guide/index.adoc
+++ b/source/documentation/doc-Product_Guide/index.adoc
@@ -9,3 +9,8 @@ include::asm-Components.adoc[]
 include::asm-Installation.adoc[leveloffset=+1]
 
 include::asm-AccessingRHV.adoc[]
+
+[appendix]
+== Legal notice
+
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}disaster_recovery_guide/index[Red Hat Virtualization {vernum_rhv} Disaster Recovery Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].

--- a/source/documentation/doc-Product_Guide/index.adoc
+++ b/source/documentation/doc-Product_Guide/index.adoc
@@ -2,6 +2,8 @@
 include::common/collateral_files/attributes.adoc[]
 = Product Guide
 
+:product_guide:
+
 include::asm-Introduction.adoc[leveloffset=+1]
 
 include::asm-Components.adoc[]
@@ -10,7 +12,4 @@ include::asm-Installation.adoc[leveloffset=+1]
 
 include::asm-AccessingRHV.adoc[]
 
-[appendix]
-== Legal notice
-
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}disaster_recovery_guide/index[Red Hat Virtualization {vernum_rhv} Disaster Recovery Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+include::common/collateral_files/legal-notice_ovirt.adoc[]

--- a/source/documentation/doc-Product_Guide/master.adoc
+++ b/source/documentation/doc-Product_Guide/master.adoc
@@ -9,3 +9,5 @@ include::asm-Components.adoc[]
 include::asm-Installation.adoc[leveloffset=+1]
 
 include::asm-AccessingRHV.adoc[]
+
+include::common/collateral_files/legal-notice.adoc[]

--- a/source/documentation/doc-Python_SDK_Guide/index.adoc
+++ b/source/documentation/doc-Python_SDK_Guide/index.adoc
@@ -8,3 +8,8 @@ include::chap-Overview.adoc[]
 include::chap-Using_the_Software_Development_Kit.adoc[]
 
 include::chap-Python_Examples.adoc[]
+
+[appendix]
+== Legal notice
+
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}disaster_recovery_guide/index[Red Hat Virtualization {vernum_rhv} Disaster Recovery Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].

--- a/source/documentation/doc-Python_SDK_Guide/index.adoc
+++ b/source/documentation/doc-Python_SDK_Guide/index.adoc
@@ -3,13 +3,12 @@ include::common/collateral_files/attributes.adoc[]
 = Python SDK Guide
 :imagesdir: images
 
+:pythonSDK:
+
 include::chap-Overview.adoc[]
 
 include::chap-Using_the_Software_Development_Kit.adoc[]
 
 include::chap-Python_Examples.adoc[]
 
-[appendix]
-== Legal notice
-
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}disaster_recovery_guide/index[Red Hat Virtualization {vernum_rhv} Disaster Recovery Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+include::common/collateral_files/legal-notice_ovirt.adoc[]

--- a/source/documentation/doc-Python_SDK_Guide/master.adoc
+++ b/source/documentation/doc-Python_SDK_Guide/master.adoc
@@ -8,3 +8,5 @@ include::chap-Overview.adoc[]
 include::chap-Using_the_Software_Development_Kit.adoc[]
 
 include::chap-Python_Examples.adoc[]
+
+include::common/collateral_files/legal-notice.adoc[]

--- a/source/documentation/doc-REST_API_Guide/index.adoc
+++ b/source/documentation/doc-REST_API_Guide/index.adoc
@@ -5,3 +5,8 @@ include::common/collateral_files/attributes.adoc[]
 :product-name: oVirt
 
 include::model.adoc[]
+
+[appendix]
+== Legal notice
+
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}disaster_recovery_guide/index[Red Hat Virtualization {vernum_rhv} Disaster Recovery Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].

--- a/source/documentation/doc-REST_API_Guide/index.adoc
+++ b/source/documentation/doc-REST_API_Guide/index.adoc
@@ -6,7 +6,6 @@ include::common/collateral_files/attributes.adoc[]
 
 include::model.adoc[]
 
-[appendix]
-== Legal notice
+:restAPI:
 
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}disaster_recovery_guide/index[Red Hat Virtualization {vernum_rhv} Disaster Recovery Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+include::common/collateral_files/legal-notice_ovirt.adoc[]

--- a/source/documentation/doc-REST_API_Guide/master.adoc
+++ b/source/documentation/doc-REST_API_Guide/master.adoc
@@ -6,3 +6,5 @@ include::common/collateral_files/attributes.adoc[]
 :product-name: Red Hat Virtualization
 
 include::model.adoc[]
+
+include::common/collateral_files/legal-notice.adoc[]

--- a/source/documentation/doc-Release_Notes/master.adoc
+++ b/source/documentation/doc-Release_Notes/master.adoc
@@ -14,3 +14,5 @@ include::chap-Tech_Preview_and_Deprecated_Features.adoc[leveloffset=+1]
 include::chap-Compatibility_levels.adoc[]
 
 include::chap-Release_Notes.adoc[]
+
+include::common/collateral_files/legal-notice.adoc[]

--- a/source/documentation/doc-Technical_Notes/master.adoc
+++ b/source/documentation/doc-Technical_Notes/master.adoc
@@ -19,3 +19,5 @@ include::RHSA-20205179-04.adoc[leveloffset=+1]
 include::RHBA-20210312-02.adoc[leveloffset=+1]
 include::RHSA-20211169-06.adoc[leveloffset=+1]
 include::RHSA-20214626-06.adoc[leveloffset=+1]
+
+include::common/collateral_files/legal-notice.adoc[]

--- a/source/documentation/doc-Technical_Reference/index.adoc
+++ b/source/documentation/doc-Technical_Reference/index.adoc
@@ -2,6 +2,8 @@ include::common/collateral_files/attributes.adoc[]
 = Technical Reference
 :imagesdir: images
 
+:techref:
+
 include::chap-Introduction.adoc[]
 
 include::chap-Storage.adoc[]
@@ -26,7 +28,4 @@ include::appe-Event_Codes.adoc[]
 
 include::appe-Timezones.adoc[]
 
-[appendix]
-== Legal notice
-
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}disaster_recovery_guide/index[Red Hat Virtualization {vernum_rhv} Disaster Recovery Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+include::common/collateral_files/legal-notice_ovirt.adoc[]

--- a/source/documentation/doc-Technical_Reference/index.adoc
+++ b/source/documentation/doc-Technical_Reference/index.adoc
@@ -25,3 +25,8 @@ include::appe-Enumerated_Value_Translation.adoc[]
 include::appe-Event_Codes.adoc[]
 
 include::appe-Timezones.adoc[]
+
+[appendix]
+== Legal notice
+
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}disaster_recovery_guide/index[Red Hat Virtualization {vernum_rhv} Disaster Recovery Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].

--- a/source/documentation/doc-Technical_Reference/master.adoc
+++ b/source/documentation/doc-Technical_Reference/master.adoc
@@ -26,3 +26,5 @@ include::appe-Enumerated_Value_Translation.adoc[]
 include::appe-Event_Codes.adoc[]
 
 include::appe-Timezones.adoc[]
+
+include::common/collateral_files/legal-notice.adoc[]

--- a/source/documentation/installing_ovirt_as_a_self-hosted_engine_using_the_command_line/index.adoc
+++ b/source/documentation/installing_ovirt_as_a_self-hosted_engine_using_the_command_line/index.adoc
@@ -140,4 +140,4 @@ ifndef::parent-context[:!context:]
 [appendix]
 == Legal notice
 
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}installing_red_hat_virtualization_as_a_self-hosted_engine_using_the_command_line/[Red Hat Virtualization {vernum_rhv} Installing Red Hat Virtualization as a self-hosted engine using the command line]. Copyright © 2021 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}installing_red_hat_virtualization_as_a_self-hosted_engine_using_the_command_line/[Red Hat Virtualization {vernum_rhv} Installing Red Hat Virtualization as a self-hosted engine using the command line]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].

--- a/source/documentation/installing_ovirt_as_a_self-hosted_engine_using_the_command_line/index.adoc
+++ b/source/documentation/installing_ovirt_as_a_self-hosted_engine_using_the_command_line/index.adoc
@@ -137,7 +137,7 @@ include::common/install/proc-Preventing_Kernel_Modules_from_Loading_Automaticall
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]
-[appendix]
-== Legal notice
 
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}installing_red_hat_virtualization_as_a_self-hosted_engine_using_the_command_line/[Red Hat Virtualization {vernum_rhv} Installing Red Hat Virtualization as a self-hosted engine using the command line]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+//adding context back
+:context: SHE_cli_deploy
+include::common/collateral_files/legal-notice_ovirt.adoc[]

--- a/source/documentation/installing_ovirt_as_a_standalone_manager_with_local_databases/index.adoc
+++ b/source/documentation/installing_ovirt_as_a_standalone_manager_with_local_databases/index.adoc
@@ -117,7 +117,7 @@ include::common/install/proc-Preventing_Kernel_Modules_from_Loading_Automaticall
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]
 
-[appendix]
-== Legal notice
+//adding context back
+:context: SM_localDB_deploy
 
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}installing_red_hat_virtualization_as_a_standalone_manager_with_local_databases/[Red Hat Virtualization {vernum_rhv} Installing Red Hat Virtualization as a standalone Manager with local databases]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+include::common/collateral_files/legal-notice_ovirt.adoc[]

--- a/source/documentation/installing_ovirt_as_a_standalone_manager_with_local_databases/index.adoc
+++ b/source/documentation/installing_ovirt_as_a_standalone_manager_with_local_databases/index.adoc
@@ -120,4 +120,4 @@ ifndef::parent-context[:!context:]
 [appendix]
 == Legal notice
 
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}installing_red_hat_virtualization_as_a_standalone_manager_with_local_databases/[Red Hat Virtualization {vernum_rhv} Installing Red Hat Virtualization as a standalone Manager with local databases]. Copyright © 2021 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}installing_red_hat_virtualization_as_a_standalone_manager_with_local_databases/[Red Hat Virtualization {vernum_rhv} Installing Red Hat Virtualization as a standalone Manager with local databases]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].

--- a/source/documentation/installing_ovirt_as_a_standalone_manager_with_remote_databases/index.adoc
+++ b/source/documentation/installing_ovirt_as_a_standalone_manager_with_remote_databases/index.adoc
@@ -120,4 +120,4 @@ ifndef::parent-context[:!context:]
 
 == Legal notice
 
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}installing_red_hat_virtualization_as_a_standalone_manager_with_remote_databases/[Red Hat Virtualization {vernum_rhv} Installing Red Hat Virtualization as a standalone Manager with remote databases]. Copyright © 2021 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}installing_red_hat_virtualization_as_a_standalone_manager_with_remote_databases/[Red Hat Virtualization {vernum_rhv} Installing Red Hat Virtualization as a standalone Manager with remote databases]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].

--- a/source/documentation/installing_ovirt_as_a_standalone_manager_with_remote_databases/index.adoc
+++ b/source/documentation/installing_ovirt_as_a_standalone_manager_with_remote_databases/index.adoc
@@ -118,6 +118,6 @@ include::common/install/proc-Preventing_Kernel_Modules_from_Loading_Automaticall
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]
 
-== Legal notice
-
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}installing_red_hat_virtualization_as_a_standalone_manager_with_remote_databases/[Red Hat Virtualization {vernum_rhv} Installing Red Hat Virtualization as a standalone Manager with remote databases]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+//adding context back
+:context: SM_remoteDB_deploy
+include::common/collateral_files/legal-notice_ovirt.adoc[]

--- a/source/documentation/introduction_to_the_vm_portal/index.adoc
+++ b/source/documentation/introduction_to_the_vm_portal/index.adoc
@@ -13,7 +13,4 @@ include::chap-Accessing_the_VM_Portal.adoc[leveloffset=+1]
 
 include::chap-Managing_virtual_machines.adoc[]
 
-[appendix]
-== Legal notice
-
-Certain portions of this text first appeared in the link:{URL_downstream_virt_product_docs}introduction_to_the_vm_portal/[Red Hat Virtualization 4.3 Introduction to the VM Portal]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+include::common/collateral_files/legal-notice_ovirt.adoc[]

--- a/source/documentation/introduction_to_the_vm_portal/index.adoc
+++ b/source/documentation/introduction_to_the_vm_portal/index.adoc
@@ -16,4 +16,4 @@ include::chap-Managing_virtual_machines.adoc[]
 [appendix]
 == Legal notice
 
-Certain portions of this text first appeared in the link:{URL_downstream_virt_product_docs}introduction_to_the_vm_portal/[Red Hat Virtualization 4.3 Introduction to the VM Portal]. Copyright © 2021 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+Certain portions of this text first appeared in the link:{URL_downstream_virt_product_docs}introduction_to_the_vm_portal/[Red Hat Virtualization 4.3 Introduction to the VM Portal]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].

--- a/source/documentation/migrating_from_a_standalone_manager_to_a_self-hosted_engine/index.adoc
+++ b/source/documentation/migrating_from_a_standalone_manager_to_a_self-hosted_engine/index.adoc
@@ -104,6 +104,5 @@ include::common/install/proc-Preventing_Kernel_Modules_from_Loading_Automaticall
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]
 
-== Legal notice
-
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}migrating_from_a_standalone_manager_to_a_self-hosted_engine/[Red Hat Virtualization {vernum_rhv} Migrating from a standalone Manager to a self-hosted engine]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+:context: migrating_to_SHE
+include::common/collateral_files/legal-notice_ovirt.adoc[]

--- a/source/documentation/migrating_from_a_standalone_manager_to_a_self-hosted_engine/index.adoc
+++ b/source/documentation/migrating_from_a_standalone_manager_to_a_self-hosted_engine/index.adoc
@@ -104,5 +104,5 @@ include::common/install/proc-Preventing_Kernel_Modules_from_Loading_Automaticall
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]
 
-:context: migrating_to_SHE
+:migrating_to_SHE:
 include::common/collateral_files/legal-notice_ovirt.adoc[]

--- a/source/documentation/migrating_from_a_standalone_manager_to_a_self-hosted_engine/index.adoc
+++ b/source/documentation/migrating_from_a_standalone_manager_to_a_self-hosted_engine/index.adoc
@@ -106,4 +106,4 @@ ifndef::parent-context[:!context:]
 
 == Legal notice
 
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}migrating_from_a_standalone_manager_to_a_self-hosted_engine/[Red Hat Virtualization {vernum_rhv} Migrating from a standalone Manager to a self-hosted engine]. Copyright © 2021 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}migrating_from_a_standalone_manager_to_a_self-hosted_engine/[Red Hat Virtualization {vernum_rhv} Migrating from a standalone Manager to a self-hosted engine]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].

--- a/source/documentation/upgrade_guide/index.adoc
+++ b/source/documentation/upgrade_guide/index.adoc
@@ -87,4 +87,4 @@ include::topics/installing_virtual_product_hypervisors_from_local_repository.ado
 
 == Legal notice
 
-Certain portions of this text first appeared in the link:{URL_downstream_virt_product_docs}upgrade_guide/index[Red Hat Virtualization {vernum_rhv} Upgrade Guide]. Copyright © 2021 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+Certain portions of this text first appeared in the link:{URL_downstream_virt_product_docs}upgrade_guide/index[Red Hat Virtualization {vernum_rhv} Upgrade Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].

--- a/source/documentation/upgrade_guide/index.adoc
+++ b/source/documentation/upgrade_guide/index.adoc
@@ -85,6 +85,4 @@ include::topics/installing_virtual_product_hypervisors_from_local_repository.ado
 
 :appendices!:
 
-== Legal notice
-
-Certain portions of this text first appeared in the link:{URL_downstream_virt_product_docs}upgrade_guide/index[Red Hat Virtualization {vernum_rhv} Upgrade Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+include::common/collateral_files/legal-notice_ovirt.adoc[]

--- a/source/documentation/upgrade_guide/master.adoc
+++ b/source/documentation/upgrade_guide/master.adoc
@@ -65,13 +65,12 @@ include::topics/Updating_the_Local_Repository_for_an_Offline_Red_Hat_Virtualizat
 [appendix]
 include::topics/installing_virtual_product_hypervisors_from_local_repository.adoc[leveloffset=+1]
 
-include::common/collateral_files/legal-notice.adoc[]
-
-
 === Additional resources
 
 * See xref:Updating_the_Red_Hat_Virtualization_Manager_minor_updates[Updating the {virt-product-fullname} {engine-name}] for information on updating the {engine-name} between minor versions.
 * See xref:Red_Hat_Virtualization_Upgrade_Overview[{virt-product-fullname} Upgrade Overview] for information on upgrading between major versions.
+
+include::common/collateral_files/legal-notice.adoc[]
 
 :context!: appendices
 :appendices!:

--- a/source/documentation/virtual_machine_management_guide/index.adoc
+++ b/source/documentation/virtual_machine_management_guide/index.adoc
@@ -27,4 +27,4 @@ include::appe-virt_sysprep_operations.adoc[]
 [appendix]
 == Legal notice
 
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}virtual_machine_management_guide/index[Red Hat Virtualization {vernum_rhv} Virtual Machine Management Guide]. Copyright © 2021 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}virtual_machine_management_guide/index[Red Hat Virtualization {vernum_rhv} Virtual Machine Management Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].

--- a/source/documentation/virtual_machine_management_guide/index.adoc
+++ b/source/documentation/virtual_machine_management_guide/index.adoc
@@ -3,6 +3,8 @@ include::common/collateral_files/attributes.adoc[]
 = Virtual Machine Management Guide
 
 // Make sure Jekyll displays a guide title
+:vmm: 
+
 [discrete]
 = Virtual Machine Management Guide
 
@@ -24,7 +26,4 @@ include::appe-Reference_Settings_in_Administration_Portal_and_User_Portal_Window
 
 include::appe-virt_sysprep_operations.adoc[]
 
-[appendix]
-== Legal notice
-
-Certain portions of this text first appeared in link:{URL_downstream_virt_product_docs}virtual_machine_management_guide/index[Red Hat Virtualization {vernum_rhv} Virtual Machine Management Guide]. Copyright © 2022 Red Hat, Inc. Licensed under a link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0 Unported License].
+include::common/collateral_files/legal-notice_ovirt.adoc[]


### PR DESCRIPTION
… where missing from some docs

Bug Fix

Fixes issue https://bugzilla.redhat.com/show_bug.cgi?id=2054905

Changes proposed in this pull request:
- Updated the copyright in the legal notices from 2021 to 2022
- Included the legal notices in the Planning and Prerequisites and Intro to VM Portal Guides because it was missing.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @dcdacosta 
This pull request needs review by: @apinnick 