### PR TITLE
BZ2036835 - Update advanced virtualization to virt:rhel

### DIFF
--- a/source/documentation/common/install/snip-Enable_virt_module.adoc
+++ b/source/documentation/common/install/snip-Enable_virt_module.adoc
@@ -14,15 +14,22 @@
 ----
 # dnf module enable virt:8.3
 ----
-* For {virt-product-shortname} 4.4.6 or later:
+* For {virt-product-shortname} 4.4.6 to 4.4.8:
 +
 [source,terminal]
 +
 ----
 # dnf module enable virt:av
 ----
+* For {virt-product-shortname} 4.4.9 and later:
++
+[options="nowrap" subs="normal"]
++
+----
+# dnf module enable virt:rhel
+----
 +
 [NOTE]
 ====
-Starting with {enterprise-linux-shortname} 8.4, only one Advanced Virtualization stream is used, `rhel:av`.
+ Starting in {enterprise-linux-shortname} the Advanced virtualization packages will use the standard `virt:rhel` module. For {enterprise-linux-shortname} 8.4 and 8.5, only one Advanced Virtualization stream is used, `rhel:av`. 
 ====

--- a/source/documentation/common/install/snip-Enable_virt_module.adoc
+++ b/source/documentation/common/install/snip-Enable_virt_module.adoc
@@ -14,14 +14,14 @@
 ----
 # dnf module enable virt:8.3
 ----
-* For {virt-product-shortname} 4.4.6 to 4.4.8:
+* For {virt-product-shortname} 4.4.6 to 4.4.9:
 +
 [source,terminal]
 +
 ----
 # dnf module enable virt:av
 ----
-* For {virt-product-shortname} 4.4.9 and later:
+* For {virt-product-shortname} 4.4.10 and later:
 +
 [options="nowrap" subs="normal"]
 +
@@ -31,5 +31,5 @@
 +
 [NOTE]
 ====
-Starting in {enterprise-linux-shortname} the Advanced virtualization packages will use the standard `virt:rhel` module. For {enterprise-linux-shortname} 8.4 and 8.5, only one Advanced Virtualization stream is used, `rhel:av`.
+Starting with {enterprise-linux-shortname} 8.6 the Advanced virtualization packages will use the standard `virt:rhel` module. For {enterprise-linux-shortname} 8.4 and 8.5, only one Advanced Virtualization stream is used, `rhel:av`.
 ====

--- a/source/documentation/common/install/snip-Enable_virt_module.adoc
+++ b/source/documentation/common/install/snip-Enable_virt_module.adoc
@@ -28,8 +28,8 @@
 ----
 # dnf module enable virt:rhel
 ----
-+
+
 [NOTE]
 ====
- Starting in {enterprise-linux-shortname} the Advanced virtualization packages will use the standard `virt:rhel` module. For {enterprise-linux-shortname} 8.4 and 8.5, only one Advanced Virtualization stream is used, `rhel:av`. 
+ Starting in {enterprise-linux-shortname} the Advanced virtualization packages will use the standard `virt:rhel` module. For {enterprise-linux-shortname} 8.4 and 8.5, only one Advanced Virtualization stream is used, `rhel:av`.
 ====

--- a/source/documentation/common/install/snip-Enable_virt_module.adoc
+++ b/source/documentation/common/install/snip-Enable_virt_module.adoc
@@ -28,8 +28,8 @@
 ----
 # dnf module enable virt:rhel
 ----
-
++
 [NOTE]
 ====
- Starting in {enterprise-linux-shortname} the Advanced virtualization packages will use the standard `virt:rhel` module. For {enterprise-linux-shortname} 8.4 and 8.5, only one Advanced Virtualization stream is used, `rhel:av`.
+Starting in {enterprise-linux-shortname} the Advanced virtualization packages will use the standard `virt:rhel` module. For {enterprise-linux-shortname} 8.4 and 8.5, only one Advanced Virtualization stream is used, `rhel:av`.
 ====

--- a/source/documentation/common/install/snip-Enable_virt_module.adoc
+++ b/source/documentation/common/install/snip-Enable_virt_module.adoc
@@ -14,14 +14,19 @@
 ----
 # dnf module enable virt:8.3
 ----
-* For {virt-product-shortname} 4.4.6 to 4.4.9:
+* For {virt-product-shortname} 4.4.6 to 4.4.10:
 +
 [source,terminal]
 +
 ----
 # dnf module enable virt:av
 ----
-* For {virt-product-shortname} 4.4.10 and later:
+ifdef::rhv-doc[]
+* For {virt-product-shortname} 4.4 SP1 and later:
+endif::rhv-doc[]
+ifdef::ovirt-doc[]
+* For {virt-product-shortname} 4.5 and later:
+endif::ovirt-doc[]
 +
 [options="nowrap" subs="normal"]
 +


### PR DESCRIPTION
Fixes issue https://bugzilla.redhat.com/show_bug.cgi?id=2036835

Changes proposed in this pull request:

- Use virt:rhel module instead of virt:av in RHEL 8.6+ to get advanced virtualization packages

Changes can be verified using the following preview links:

1. https://ovirt.github.io/ovirt-site/previews/2740/documentation/installing_ovirt_as_a_self-hosted_engine_using_the_command_line/index.html#proc_Manually_installing_the_appliance_install_RHVM
2. https://ovirt.github.io/ovirt-site/previews/2740/documentation/upgrade_guide/index.html#Manually_Updating_Hosts_minor_updates
3. https://ovirt.github.io/ovirt-site/previews/2740/documentation/administration_guide/index.html#Updating_a_host_between_minor_releases

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (@dcdacosta)

This pull request needs review by: (@mwperina)
