### PR TITLE
Drop 4.4.10 from next releases

### DIFF
--- a/source/develop/qa/index.md
+++ b/source/develop/qa/index.md
@@ -47,10 +47,6 @@ You can also join oVirt users mailing list, where quality assurance-related topi
 
 ## Next releases
 
-
-* 4.4.10:
-  - Tracker: [oVirt 4.4.10 release](https://bugzilla.redhat.com/buglist.cgi?quicksearch=target_milestone%3Aovirt-4.4.10)
-
 * 4.5.0:
   - Tracker: [oVirt 4.5.0 release](https://bugzilla.redhat.com/buglist.cgi?quicksearch=target_milestone%3Aovirt-4.5.0)
 


### PR DESCRIPTION
Changes proposed in this pull request:

- 4.4.10 has been released. Dropping from next releases

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

