### PR TITLE
redirect page for console-client-resources

### DIFF
--- a/source/.htaccess
+++ b/source/.htaccess
@@ -384,6 +384,10 @@ RewriteRule ^(.*)$ /community/about.html [R=301,L]
 RewriteCond %{REQUEST_URI} /develop/release-management/process/making-an-release.html
 RewriteRule ^(.*)$ /develop/release-management/process/making-a-release.html [R=301,L]
 
+# https://www.ovirt.org/documentation/admin-guide/virt/console-client-resources/ -> https://www.ovirt.org/dropped/admin-guide/virt/console-client-resources.html
+RewriteCond %{REQUEST_URI} /documentation/admin-guide/virt/console-client-resources/
+RewriteRule ^(.*)$ /dropped/admin-guide/virt/console-client-resources.html [R=302,L]
+
 ##
 
 # add .html


### PR DESCRIPTION
[Bug fix]

Changes proposed in this pull request:

console-client-resources page is linked from the engine and from several
BZs and sites. Providing a redirect to the dropped page.
Using 302 instead of 301 as there's not yet a final decision on where
this content should be located within the site.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

