### PR TITLE
BZ1919809 - Added new FIPS Mode property for clusters

### DIFF
--- a/source/documentation/administration_guide/topics/Cluster_General_Settings_Explained.adoc
+++ b/source/documentation/administration_guide/topics/Cluster_General_Settings_Explained.adoc
@@ -23,13 +23,13 @@ On existing clusters, the management network can only be changed using the *Mana
 
 * *ppc64*: For IBM POWER CPU types.
 
-|*CPU Type* |The oldest CPU family in the cluster. For a list of CPU types, see link:{URL_downstream_virt_product_docs}planning_and_prerequisites_guide/index#CPU_Requirements_RHV_planning[CPU Requirements] in the _Planning and Prerequisites Guide_. You cannot change this cannot after creating the cluster without significant disruption. Set CPU type to the oldest CPU model in the cluster. Only features present in all models can be used. For both Intel and AMD CPU types, the listed CPU models are in logical order from the oldest to the newest.
+|*CPU Type* |The oldest CPU family in the cluster. For a list of CPU types, see link:{URL_downstream_virt_product_docs}planning_and_prerequisites_guide/index#CPU_Requirements_RHV_planning[CPU Requirements] in the _Planning and Prerequisites Guide_. You cannot change this after creating the cluster without significant disruption. Set CPU type to the oldest CPU model in the cluster. Only features present in all models can be used. For both Intel and AMD CPU types, the listed CPU models are in logical order from the oldest to the newest.
 |*Chipset/Firmware Type* a|This setting is only available if the *CPU Architecture* of the cluster is set to *x86_64*. This setting specifies the chipset and firmware type. Options are:
 
-* *Auto Detect*: This setting automatically detects the chipset and firmware type. When *Auto Detect* is selected, the chipset and firmware are determined by the first host up in the cluster
+* *Auto Detect*: This setting automatically detects the chipset and firmware type. When *Auto Detect* is selected, the chipset and firmware are determined by the first host up in the cluster.
 * *I440FX Chipset with BIOS*: Specifies the chipset to I440FX with a firmware type of BIOS.
-* *Q35 Chipset with BIOS*: Specifies the Q35 chipset with a firmware type of BIOS without UEFI (Default for clusters with compatibility version 4.4)
-* *Q35 Chipset with UEFI* Specifies the Q35 chipset with a firmware type of BIOS with UEFI
+* *Q35 Chipset with BIOS*: Specifies the Q35 chipset with a firmware type of BIOS without UEFI (Default for clusters with compatibility version 4.4).
+* *Q35 Chipset with UEFI* Specifies the Q35 chipset with a firmware type of BIOS with UEFI.
 * *Q35 Chipset with UEFI SecureBoot* Specifies the Q35 chipset with a firmware type of UEFI with SecureBoot, which authenticates the digital signatures of the boot loader.
 
 For more information, see link:{URL_virt_product_docs}{URL_format}administration_guide/index#About_UEFI_Q35-cluster_opt_settings[UEFI and the Q35 chipset] in the _Administration Guide_.
@@ -60,7 +60,7 @@ The following options are required for each host in the cluster that is being im
 
 * *Hostname*: Enter the IP or fully qualified domain name of the Gluster host server.
 
-* *Host ssh public key (PEM)*: {virt-product-fullname} {engine-name} fetches the host's ssh public key, to ensure you are connecting with the correct host.
+* *Host ssh public key (PEM)*: {virt-product-fullname} {engine-name} fetches the host's SSH public key, to ensure you are connecting with the correct host.
 
 * *Password*: Enter the root password required for communicating with the host.
 

--- a/source/documentation/administration_guide/topics/Cluster_General_Settings_Explained.adoc
+++ b/source/documentation/administration_guide/topics/Cluster_General_Settings_Explained.adoc
@@ -26,21 +26,21 @@ On existing clusters, the management network can only be changed using the *Mana
 |*CPU Type* |The oldest CPU family in the cluster. For a list of CPU types, see link:{URL_downstream_virt_product_docs}planning_and_prerequisites_guide/index#CPU_Requirements_RHV_planning[CPU Requirements] in the _Planning and Prerequisites Guide_. You cannot change this cannot after creating the cluster without significant disruption. Set CPU type to the oldest CPU model in the cluster. Only features present in all models can be used. For both Intel and AMD CPU types, the listed CPU models are in logical order from the oldest to the newest.
 |*Chipset/Firmware Type* a|This setting is only available if the *CPU Architecture* of the cluster is set to *x86_64*. This setting specifies the chipset and firmware type. Options are:
 
-* *Auto Detect*: This setting automatically detects the chipset and firmware type.
-* *I440FX Chipset with BIOS*: Specifies the chipset to I440FX with a firmware type of legacy BIOS.
-* *Q35 Chipset with Legacy BIOS*: Specifies the Q35 chipset with a firmware type of legacy BIOS without UEFI (Default for clusters with compatibility version 4.4)
-* *Q35 Chipset with UEFI BIOS* Specifies the Q35 chipset with a firmware type of legacy BIOS with UEFI
-* *Q35 Chipset with SecureBoot* Specifies the Q35 chipset with a firmware type of UEFI with SecureBoot, which authenticates the digital signatures of the boot loader.
+* *Auto Detect*: This setting automatically detects the chipset and firmware type. When *Auto Detect* is selected, the chipset and firmware are determined by the first host up in the cluster
+* *I440FX Chipset with BIOS*: Specifies the chipset to I440FX with a firmware type of BIOS.
+* *Q35 Chipset with BIOS*: Specifies the Q35 chipset with a firmware type of BIOS without UEFI (Default for clusters with compatibility version 4.4)
+* *Q35 Chipset with UEFI* Specifies the Q35 chipset with a firmware type of BIOS with UEFI
+* *Q35 Chipset with UEFI SecureBoot* Specifies the Q35 chipset with a firmware type of UEFI with SecureBoot, which authenticates the digital signatures of the boot loader.
 
 For more information, see link:{URL_virt_product_docs}{URL_format}administration_guide/index#About_UEFI_Q35-cluster_opt_settings[UEFI and the Q35 chipset] in the _Administration Guide_.
-|*Change Existing VMs/Templates from 1440fx to Q35 Chipset with Bios* |Select this check box to change  existing workloads when the cluster's chipset changes from I440FX to Q35.
+|*Change Existing VMs/Templates from 1440fx to Q35 Chipset with Bios* |Select this check box to change existing workloads when the cluster's chipset changes from I440FX to Q35.
 |*FIPS Mode* a|The FIPS mode used by the cluster. All hosts in the cluster must run the FIPS mode you specify or they will become non-operational.
 
 * *Auto Detect*: This setting automatically detects whether FIPS mode is enabled or disabled. When *Auto Detect* is selected, the FIPS mode is determined by the first host up in the cluster.
 
-* *Disabled*: This setting disables FIPS mode on the cluster.
+* *Disabled*: This setting disables FIPS on the cluster.
 
-* *Enabled*:  This setting enables FIPS mode on the cluster.
+* *Enabled*:  This setting enables FIPS on the cluster.
 
 |*Compatibility Version* |The version of {virt-product-fullname}. You will not be able to select a version earlier than the version specified for the data center.
 |*Switch Type* |The type of switch used by the cluster. *Linux Bridge* is the standard {virt-product-fullname} switch. *OVS* provides support for Open vSwitch networking features.

--- a/source/documentation/administration_guide/topics/Cluster_General_Settings_Explained.adoc
+++ b/source/documentation/administration_guide/topics/Cluster_General_Settings_Explained.adoc
@@ -24,6 +24,16 @@ On existing clusters, the management network can only be changed using the *Mana
 * *ppc64*: For IBM POWER CPU types.
 
 |*CPU Type* |The oldest CPU family in the cluster. For a list of CPU types, see link:{URL_downstream_virt_product_docs}planning_and_prerequisites_guide/index#CPU_Requirements_RHV_planning[CPU Requirements] in the _Planning and Prerequisites Guide_. You cannot change this cannot after creating the cluster without significant disruption. Set CPU type to the oldest CPU model in the cluster. Only features present in all models can be used. For both Intel and AMD CPU types, the listed CPU models are in logical order from the oldest to the newest.
+|*Chipset/Firmware Type* a|This setting is only available if the *CPU Architecture* of the cluster is set to *x86_64*. This setting specifies the chipset and firmware type. Options are:
+
+* *Auto Detect*: This setting automatically detects the chipset and firmware type.
+* *I440FX Chipset with BIOS*: Specifies the chipset to I440FX with a firmware type of legacy BIOS.
+* *Q35 Chipset with Legacy BIOS*: Specifies the Q35 chipset with a firmware type of legacy BIOS without UEFI (Default for clusters with compatibility version 4.4)
+* *Q35 Chipset with UEFI BIOS* Specifies the Q35 chipset with a firmware type of legacy BIOS with UEFI
+* *Q35 Chipset with SecureBoot* Specifies the Q35 chipset with a firmware type of UEFI with SecureBoot, which authenticates the digital signatures of the boot loader.
+
+For more information, see link:{URL_virt_product_docs}{URL_format}administration_guide/index#About_UEFI_Q35-cluster_opt_settings[UEFI and the Q35 chipset] in the _Administration Guide_.
+|*Change Existing VMs/Templates from 1440fx to Q35 Chipset with Bios* |Select this check box to change  existing workloads when the cluster's chipset changes from I440FX to Q35.
 |*FIPS Mode* a|The FIPS mode used by the cluster. All hosts in the cluster must run the FIPS mode you specify or the host will fail.
 
 * *Auto Detect*: This setting automatically detects whether FIPS mode is enabled or disabled. When *Auto Detect* is selected, the FIPS mode is determined by the first host up in the cluster.
@@ -42,19 +52,18 @@ If you change an existing cluster's firewall type, you must xref:Reinstalling_Ho
 If you change the default network provider, you must xref:Reinstalling_Hosts_admin[reinstall all hosts] in the cluster to apply the change.
 
 |*Maximum Log Memory Threshold* |Specifies the logging threshold for maximum memory consumption as a percentage or as an absolute value in MB. A message is logged if a host's memory usage exceeds the percentage value or if a host's available memory falls below the absolute value in MB. The default is `95%`.
-|*Enable Virt Service* |If this radio button is selected, hosts in this cluster will be used to run virtual machines.
-|*Enable Gluster Service* |If this radio button is selected, hosts in this cluster will be used as {gluster-storage-fullname} Server nodes, and not for running virtual machines.
+|*Enable Virt Service* |If this check box is selected, hosts in this cluster will be used to run virtual machines.
+|*Enable Gluster Service* |If this check box is selected, hosts in this cluster will be used as {gluster-storage-fullname} Server nodes, and not for running virtual machines.
 |*Import existing gluster configuration* a|This check box is only available if the *Enable Gluster Service* radio button is selected. This option allows you to import an existing Gluster-enabled cluster and all its attached hosts to {virt-product-fullname} {engine-name}.
 
 The following options are required for each host in the cluster that is being imported:
 
-* *Address*: Enter the IP or fully qualified domain name of the Gluster host server.
+* *Hostname*: Enter the IP or fully qualified domain name of the Gluster host server.
 
-* *Fingerprint*: {virt-product-fullname} {engine-name} fetches the host's fingerprint, to ensure you are connecting with the correct host.
+* *Host ssh public key (PEM)*: {virt-product-fullname} {engine-name} fetches the host's ssh public key, to ensure you are connecting with the correct host.
 
-* *Root Password*: Enter the root password required for communicating with the host.
+* *Password*: Enter the root password required for communicating with the host.
 
-|*Enable to set VM maintenance reason* |If this check box is selected, an optional reason field will appear when a virtual machine in the cluster is shut down from the {engine-name}. This allows you to provide an explanation for the maintenance, which will appear in the logs and when the virtual machine is powered on again.
-|*Enable to set Host maintenance reason* |If this check box is selected, an optional reason field will appear when a host in the cluster is moved into maintenance mode from the {engine-name}. This allows you to provide an explanation for the maintenance, which will appear in the logs and when the host is activated again.
 |*Additional Random Number Generator source* |If the check box is selected, all hosts in the cluster have the additional random number generator device available. This enables passthrough of entropy from the random number generator device to virtual machines.
+|*Gluster Tuned Profile* |This check box is only available if the *Enable Gluster Service* check box is selected. This option specifies the *virtual-host* tuning profile to enable more aggressive writeback of dirty memory pages, which benefits the host performance.
 |===

--- a/source/documentation/administration_guide/topics/Cluster_General_Settings_Explained.adoc
+++ b/source/documentation/administration_guide/topics/Cluster_General_Settings_Explained.adoc
@@ -24,7 +24,7 @@ On existing clusters, the management network can only be changed using the *Mana
 * *ppc64*: For IBM POWER CPU types.
 
 |*CPU Type* |The oldest CPU family in the cluster. For a list of CPU types, see link:{URL_downstream_virt_product_docs}planning_and_prerequisites_guide/index#CPU_Requirements_RHV_planning[CPU Requirements] in the _Planning and Prerequisites Guide_. You cannot change this cannot after creating the cluster without significant disruption. Set CPU type to the oldest CPU model in the cluster. Only features present in all models can be used. For both Intel and AMD CPU types, the listed CPU models are in logical order from the oldest to the newest.
-|*FIPS Mode* |The FIPS mode used by the cluster. All hosts in the cluster must run the FIPS mode you specify or the host will fail.
+|*FIPS Mode* a|The FIPS mode used by the cluster. All hosts in the cluster must run the FIPS mode you specify or the host will fail.
 
 * *Auto Detect*: This setting automatically detects whether FIPS mode is enabled or disabled. When *Auto Detect* is selected, the FIPS mode is determined by the first host up in the cluster.
 

--- a/source/documentation/administration_guide/topics/Cluster_General_Settings_Explained.adoc
+++ b/source/documentation/administration_guide/topics/Cluster_General_Settings_Explained.adoc
@@ -29,7 +29,7 @@ On existing clusters, the management network can only be changed using the *Mana
 * *Auto Detect*: This setting automatically detects the chipset and firmware type. When *Auto Detect* is selected, the chipset and firmware are determined by the first host up in the cluster.
 * *I440FX Chipset with BIOS*: Specifies the chipset to I440FX with a firmware type of BIOS.
 * *Q35 Chipset with BIOS*: Specifies the Q35 chipset with a firmware type of BIOS without UEFI (Default for clusters with compatibility version 4.4).
-* *Q35 Chipset with UEFI* Specifies the Q35 chipset with a firmware type of BIOS with UEFI.
+* *Q35 Chipset with UEFI* Specifies the Q35 chipset with a firmware type of BIOS with UEFI. (Default for clusters with compatibility version 4.7)
 * *Q35 Chipset with UEFI SecureBoot* Specifies the Q35 chipset with a firmware type of UEFI with SecureBoot, which authenticates the digital signatures of the boot loader.
 
 For more information, see link:{URL_virt_product_docs}{URL_format}administration_guide/index#About_UEFI_Q35-cluster_opt_settings[UEFI and the Q35 chipset] in the _Administration Guide_.

--- a/source/documentation/administration_guide/topics/Cluster_General_Settings_Explained.adoc
+++ b/source/documentation/administration_guide/topics/Cluster_General_Settings_Explained.adoc
@@ -34,7 +34,7 @@ On existing clusters, the management network can only be changed using the *Mana
 
 For more information, see link:{URL_virt_product_docs}{URL_format}administration_guide/index#About_UEFI_Q35-cluster_opt_settings[UEFI and the Q35 chipset] in the _Administration Guide_.
 |*Change Existing VMs/Templates from 1440fx to Q35 Chipset with Bios* |Select this check box to change  existing workloads when the cluster's chipset changes from I440FX to Q35.
-|*FIPS Mode* a|The FIPS mode used by the cluster. All hosts in the cluster must run the FIPS mode you specify or the host will fail.
+|*FIPS Mode* a|The FIPS mode used by the cluster. All hosts in the cluster must run the FIPS mode you specify or they will become non-operational.
 
 * *Auto Detect*: This setting automatically detects whether FIPS mode is enabled or disabled. When *Auto Detect* is selected, the FIPS mode is determined by the first host up in the cluster.
 

--- a/source/documentation/administration_guide/topics/Cluster_General_Settings_Explained.adoc
+++ b/source/documentation/administration_guide/topics/Cluster_General_Settings_Explained.adoc
@@ -24,6 +24,14 @@ On existing clusters, the management network can only be changed using the *Mana
 * *ppc64*: For IBM POWER CPU types.
 
 |*CPU Type* |The oldest CPU family in the cluster. For a list of CPU types, see link:{URL_downstream_virt_product_docs}planning_and_prerequisites_guide/index#CPU_Requirements_RHV_planning[CPU Requirements] in the _Planning and Prerequisites Guide_. You cannot change this cannot after creating the cluster without significant disruption. Set CPU type to the oldest CPU model in the cluster. Only features present in all models can be used. For both Intel and AMD CPU types, the listed CPU models are in logical order from the oldest to the newest.
+|*FIPS Mode* |The FIPS mode used by the cluster. All hosts in the cluster must run the FIPS mode you specify or the host will fail.
+
+* *Auto Detect*: This setting automatically detects whether FIPS mode is enabled or disabled. When *Auto Detect* is selected, the FIPS mode is determined by the first host up in the cluster.
+
+* *Disabled*: This setting disables FIPS mode on the cluster.
+
+* *Enabled*:  This setting enables FIPS mode on the cluster.
+
 |*Compatibility Version* |The version of {virt-product-fullname}. You will not be able to select a version earlier than the version specified for the data center.
 |*Switch Type* |The type of switch used by the cluster. *Linux Bridge* is the standard {virt-product-fullname} switch. *OVS* provides support for Open vSwitch networking features.
 |*Firewall Type* |Specifies the firewall type for hosts in the cluster, either *firewalld* (default) or *iptables*.

--- a/source/documentation/administration_guide/topics/Creating_a_New_Cluster.adoc
+++ b/source/documentation/administration_guide/topics/Creating_a_New_Cluster.adoc
@@ -19,6 +19,7 @@ A data center can contain multiple clusters, and a cluster can contain multiple 
 A hosts whose CPU processor family is older than the one you specify with *CPU Type* cannot be part of this cluster.
 For details, see link:https://access.redhat.com/solutions/634853[Which CPU family should a RHEV3 or RHV4 cluster be set to?].
 ====
+. Select the *FIPS Mode* of the cluster from the drop-down list.
 . Select the *Compatibility Version* of the cluster from the drop-down list.
 . Select the *Switch Type* from the drop-down list.
 . Select the *Firewall Type* for hosts in the cluster, either *Firewalld* (default) or *iptables*.

--- a/source/documentation/virtual_machine_management_guide/topics/Virtual_Machine_System_Settings_Explained.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Virtual_Machine_System_Settings_Explained.adoc
@@ -52,7 +52,7 @@ a|Specifies the chipset and firmware type. Defaults to the cluster's default chi
 
 * *I440FX Chipset with BIOS* Legacy BIOS
 * *Q35 Chipset with BIOS* BIOS without UEFI (Default for clusters with compatibility version 4.4)
-* *Q35 Chipset with UEFI* BIOS with UEFI
+* *Q35 Chipset with UEFI* BIOS with UEFI (Default for clusters with compatibility version 4.7)
 * *Q35 Chipset with UEFI SecureBoot* UEFI with SecureBoot, which authenticates the digital signatures of the boot loader
 
 For more information, see link:{URL_virt_product_docs}{URL_format}administration_guide/index#About_UEFI_Q35-cluster_opt_settings[UEFI and the Q35 chipset] in the _Administration Guide_.

--- a/source/documentation/virtual_machine_management_guide/topics/Virtual_Machine_System_Settings_Explained.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Virtual_Machine_System_Settings_Explained.adoc
@@ -50,7 +50,7 @@ The following table details the options available on the *System* tab of the *Ne
 |*Chipset/Firmware Type*
 a|Specifies the chipset and firmware type. Defaults to the cluster's default chipset and firmware type. Options are:
 
-* *I440FX Chipset with BIOS* Legacy BIOS.
+* *I440FX Chipset with BIOS* Legacy BIOS
 * *Q35 Chipset with BIOS* BIOS without UEFI (Default for clusters with compatibility version 4.4)
 * *Q35 Chipset with UEFI* BIOS with UEFI
 * *Q35 Chipset with UEFI SecureBoot* UEFI with SecureBoot, which authenticates the digital signatures of the boot loader

--- a/source/documentation/virtual_machine_management_guide/topics/Virtual_Machine_System_Settings_Explained.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Virtual_Machine_System_Settings_Explained.adoc
@@ -51,9 +51,9 @@ The following table details the options available on the *System* tab of the *Ne
 a|Specifies the chipset and firmware type. Defaults to the cluster's default chipset and firmware type. Options are:
 
 * *I440FX Chipset with BIOS* Legacy BIOS.
-* *Q35 Chipset with Legacy BIOS* Legacy BIOS without UEFI (Default for clusters with compatibility version 4.4)
-* *Q35 Chipset with UEFI BIOS* BIOS with UEFI
-* *Q35 Chipset with SecureBoot* UEFI with SecureBoot, which authenticates the digital signatures of the boot loader
+* *Q35 Chipset with BIOS* BIOS without UEFI (Default for clusters with compatibility version 4.4)
+* *Q35 Chipset with UEFI* BIOS with UEFI
+* *Q35 Chipset with UEFI SecureBoot* UEFI with SecureBoot, which authenticates the digital signatures of the boot loader
 
 For more information, see link:{URL_virt_product_docs}{URL_format}administration_guide/index#About_UEFI_Q35-cluster_opt_settings[UEFI and the Q35 chipset] in the _Administration Guide_.
 | Yes.

--- a/source/documentation/virtual_machine_management_guide/topics/Virtual_Machine_System_Settings_Explained.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Virtual_Machine_System_Settings_Explained.adoc
@@ -47,14 +47,13 @@ The following table details the options available on the *System* tab of the *Ne
 | If OS supports hotplugging, no. Otherwise, yes.
 
 
-|*BIOS Type*
-a|Specifies the chipset and BIOS type. Defaults to the cluster's default BIOS type. Options are:
+|*Chipset/Firmware Type*
+a|Specifies the chipset and firmware type. Defaults to the cluster's default chipset and firmware type. Options are:
 
-* *Cluster default* The BIOS type defined under General cluster settings.
+* *I440FX Chipset with BIOS* Legacy BIOS.
 * *Q35 Chipset with Legacy BIOS* Legacy BIOS without UEFI (Default for clusters with compatibility version 4.4)
 * *Q35 Chipset with UEFI BIOS* BIOS with UEFI
 * *Q35 Chipset with SecureBoot* UEFI with SecureBoot, which authenticates the digital signatures of the boot loader
-* *Legacy* i440fx chipset with legacy BIOS
 
 For more information, see link:{URL_virt_product_docs}{URL_format}administration_guide/index#About_UEFI_Q35-cluster_opt_settings[UEFI and the Q35 chipset] in the _Administration Guide_.
 | Yes.


### PR DESCRIPTION
Fixes issue # https://bugzilla.redhat.com/show_bug.cgi?id=1919809

Changes proposed in this pull request:

- Added FIPS Mode property to General Cluster Settings and Creating a New Cluster topics.

Direct links to the preview of changes:

- https://ovirt.github.io/ovirt-site/previews/2774/documentation/administration_guide/index.html#Creating_a_New_Cluster
- https://ovirt.github.io/ovirt-site/previews/2774/documentation/administration_guide/index.html#Cluster_General_Settings_Explained

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @dcdacosta )

This pull request needs review by: @ahadas 
