### PR TITLE
Add note to OVA import instructions re: directory location NOT /root

### DIFF
--- a/source/documentation/virtual_machine_management_guide/topics/Importing_an_OVA_file_from_a_host.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Importing_an_OVA_file_from_a_host.adoc
@@ -17,7 +17,7 @@ The import process uses `virt-v2v`. Only virtual machines running operating syst
 +
 [NOTE]
 ====
-The location can be a local directory or a remote nfs mount, as long as it not directly under `/root`. Ensure that it has sufficient space and is accessible to the qemu user (UID 36).
+The location can be a local directory or a remote nfs mount, as long as it is not directly under `/root`. Ensure that it has sufficient space and is accessible to the qemu user (UID 36).
 ====
 +
 . Ensure that the OVA file has permissions allowing read/write access to the *qemu* user (UID 36) and the *kvm* group (GID 36):

--- a/source/documentation/virtual_machine_management_guide/topics/Importing_an_OVA_file_from_a_host.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Importing_an_OVA_file_from_a_host.adoc
@@ -17,7 +17,7 @@ The import process uses `virt-v2v`. Only virtual machines running operating syst
 +
 [NOTE]
 ====
-The location can be a local directory or a remote nfs mount, as long as it has sufficient space and is accessible to the qemu user (UID 36).
+The location can be a local directory or a remote nfs mount, as long as it not directly under `/root`. Ensure that it has sufficient space and is accessible to the qemu user (UID 36).
 ====
 +
 . Ensure that the OVA file has permissions allowing read/write access to the *qemu* user (UID 36) and the *kvm* group (GID 36):


### PR DESCRIPTION
[Feature | Bug fix]

Fixes issue # | \[BZ#1993237](https://bugzilla.redhat.com/show_bug.cgi?id=1993237  (delete if not relevant)

Changes proposed in this pull request:

- Add note regarding location of OVA import directory - NOT directly under /root

Preview - https://ovirt.github.io/ovirt-site/previews/2777/documentation/virtual_machine_management_guide/index.html#Importing_a_virtual_machine_from_a_host


I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @emarcusRH )

This pull request needs review by: (please @ahadas )
