### PR TITLE
BZ2054250 - rearranged Upgrade Guide

### DIFF
--- a/source/documentation/upgrade_guide/chap-Red_Hat_Virtualization_Upgrade_Overview.adoc
+++ b/source/documentation/upgrade_guide/chap-Red_Hat_Virtualization_Upgrade_Overview.adoc
@@ -41,16 +41,16 @@ Select the appropriate instructions for your environment from the following tabl
 |===
 
 |Current {engine-name} version |Target {engine-name} version |Relevant section
-|4.2 |4.3 a|*Local database environment -* xref:Upgrading_from_4-2[]
+|4.3 |4.4 a|*Local database environment -* xref:Upgrading_from_4-3[Upgrading from Red Hat Virtualization 4.3 to 4.4]
 
-*Remote database environment:* xref:Remote_Upgrading_from_4-2[]
+*Remote database environment:* xref:Remote_Upgrading_from_4-3[Upgrading a Remote Database Environment from Red Hat Virtualization 4.3 to 4.4]
 
-*Self-hosted engine, local database environment:* xref:SHE_Upgrading_from_4-2[]
+*Self-hosted engine, local database environment:* xref:SHE_Upgrading_from_4-3[Upgrading a self-Hosted engine from Red Hat Virtualization 4.3 to 4.4]
 
-|4.3 |4.4 a| *Local database environment:* xref:Upgrading_from_4-3[]
+|4.2 |4.3 a| *Local database environment:* xref:Upgrading_from_4-2[Upgrading from Red Hat Virtualization 4.2 to 4.3]
 
-*Remote database environment:* xref:Remote_Upgrading_from_4-3[]
+*Remote database environment:* xref:Remote_Upgrading_from_4-2[Upgrading a Remote Database Environment from Red Hat Virtualization 4.2 to 4.3]
 
-*Self-hosted engine, local database environment:* xref:SHE_Upgrading_from_4-3[]
+*Self-hosted engine, local database environment:* xref:SHE_Upgrading_from_4-2[Upgrading a Self-Hosted Engine from Red Hat Virtualization 4.2 to 4.3]
 
 |===

--- a/source/documentation/upgrade_guide/index.adoc
+++ b/source/documentation/upgrade_guide/index.adoc
@@ -40,24 +40,24 @@ include::assembly-SHE_Upgrading_from_4-2_ff.adoc[leveloffset=+1]
 = Upgrading a standalone {engine-name} local database environment
 :local_database_upgrade:
 
-include::assembly-Upgrading_from_4-2.adoc[leveloffset=+1]
-
 include::assembly-Upgrading_from_4-3.adoc[leveloffset=+1]
+
+include::assembly-Upgrading_from_4-2.adoc[leveloffset=+1]
 :local_database_upgrade!:
 
 = Upgrading a standalone {engine-name} remote database environment
 :remote_database_upgrade:
 
-include::assembly-Remote_Upgrading_from_4-2.adoc[leveloffset=+1]
-
 include::assembly-Remote_Upgrading_from_4-3.adoc[leveloffset=+1]
+
+include::assembly-Remote_Upgrading_from_4-2.adoc[leveloffset=+1]
 :remote_database_upgrade!:
 
 = Upgrading a self-hosted engine environment
 :SHE_upgrade:
-include::assembly-SHE_Upgrading_from_4-2.adoc[leveloffset=+1]
-
 include::assembly-SHE_Upgrading_from_4-3.adoc[leveloffset=+1]
+
+include::assembly-SHE_Upgrading_from_4-2.adoc[leveloffset=+1]
 :SHE_upgrade!:
 
 = Updates between minor releases

--- a/source/documentation/upgrade_guide/master.adoc
+++ b/source/documentation/upgrade_guide/master.adoc
@@ -29,25 +29,25 @@ include::assembly-Upgrading_from_4-2_ff.adoc[leveloffset=+1]
 = Upgrading a standalone {engine-name} local database environment
 :local_database_upgrade:
 
-include::assembly-Upgrading_from_4-2.adoc[leveloffset=+1]
-
 include::assembly-Upgrading_from_4-3.adoc[leveloffset=+1]
+
+include::assembly-Upgrading_from_4-2.adoc[leveloffset=+1]
 :local_database_upgrade!:
 
 = Upgrading a standalone {engine-name} remote database environment
 :remote_database_upgrade:
 
-include::assembly-Remote_Upgrading_from_4-2.adoc[leveloffset=+1]
-
 include::assembly-Remote_Upgrading_from_4-3.adoc[leveloffset=+1]
+
+include::assembly-Remote_Upgrading_from_4-2.adoc[leveloffset=+1]
 :remote_database_upgrade!:
 
 = Upgrading a self-hosted engine environment
 :SHE_upgrade:
 
-include::assembly-SHE_Upgrading_from_4-2.adoc[leveloffset=+1]
-
 include::assembly-SHE_Upgrading_from_4-3.adoc[leveloffset=+1]
+
+include::assembly-SHE_Upgrading_from_4-2.adoc[leveloffset=+1]
 :SHE_upgrade!:
 
 = Updates between minor releases


### PR DESCRIPTION
Fixes issue https://bugzilla.redhat.com/show_bug.cgi?id=2054250

Changes proposed in this pull request:

- Change order of assemblies so that 4.3 upgrade appears before 4.2 upgrade
- Changed order of table in overview so 4.3 is before 4.2

Direct link to preview document:
https://ovirt.github.io/ovirt-site/previews/2778/documentation/upgrade_guide/index.html

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @dcdacosta)

This pull request needs review by: (@emarcusRH )
