### PR TITLE
BZ2006228 - Updates for OVN/OVS upgrade to the Admin and Upgrade Guides

### DIFF
--- a/source/documentation/administration_guide/chap-External_Providers.adoc
+++ b/source/documentation/administration_guide/chap-External_Providers.adoc
@@ -22,7 +22,7 @@ include::topics/Adding_KVM_as_an_External_Provider.adoc[leveloffset=+2]
 
 include::topics/Adding_OVN_as_an_External_Network_Provider.adoc[leveloffset=+2]
 
-include::topics/Adding_an_External_Network_Provider.adoc[leveloffset=+2]
+////Removing for BZ2006228 include::topics/Adding_an_External_Network_Provider.adoc[leveloffset=+2]
 
 include::topics/Add_Provider_General_Settings_Explained.adoc[leveloffset=+2]
 

--- a/source/documentation/administration_guide/topics/Add_Provider_General_Settings_Explained.adoc
+++ b/source/documentation/administration_guide/topics/Add_Provider_General_Settings_Explained.adoc
@@ -82,44 +82,6 @@ The *General* tab in the *Add Provider* window allows you to register the core d
 
 * *Tenant Name*: The name of the OpenStack tenant of which the OpenStack Image service is a member.
 
-*OpenStack Networking*
-
-* *Networking Plugin*: The networking plugin with which to connect to the OpenStack Networking server. For OpenStack Networking, *Open vSwitch* is the only option, and is selected by default.
-
-* *Automatic Synchronization*: Allows you to specify whether the provider will be automatically synchronized with existing networks.
-
-* *Provider URL*: The URL or fully qualified domain name of the machine on which the OpenStack Networking instance is hosted. You must add the port number for the OpenStack Networking instance to the end of the URL or fully qualified domain name. By default, this port number is 9696.
-
-* *Read Only*: Allows you to specify whether the OpenStack Networking instance can be modified from the Administration Portal.
-
-* *Requires Authentication*: Allows you to specify whether authentication is required to access the OpenStack Networking service.
-
-* *Username*: A user name for connecting to the OpenStack Networking instance. This user name must be the user name for OpenStack Networking registered in the Keystone instance of which the OpenStack Networking instance is a member.
-
-* *Password*: The password against which the above user name is to be authenticated. This password must be the password for OpenStack Networking registered in the Keystone instance of which the OpenStack Networking instance is a member.
-
-* *Protocol*: The protocol used to communicate with the Keystone server. The default is *HTTPS*.
-
-* *Hostname*: The IP address or hostname of the Keystone server.
-
-* *API port*: The API port number of the Keystone server.
-
-* *API Version*: The version of the Keystone server. This appears in the URL. If v2.0 appears, select *v2.0*. If v3 appears select `v3`.
-
-The following fields appear when you select `v3` from the *API Version* field:
-
-* *User Domain Name*: The name of the user defined in the domain.
-+
-With Keystone API v3, domains are used to determine administrative boundaries of service entities in OpenStack. Domains allow you to group users together for various purposes, such as setting domain-specific configuration or security options. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/11/html-single/architecture_guide/index#comp-identity[OpenStack Identity (keystone)] in the Red Hat OpenStack Platform _Architecture Guide_.
-
-* *Project Name*: Defines the project name for OpenStack Identity API v3.
-
-* *Project Domain Name*: Defines the project’s domain name for OpenStack Identity API v3.
-
-The following field appears when you select *v2.0* from the *API Version* field:
-
-* *Tenant Name*: Appears only when v2 is selected from the *API Version* field. The name of the OpenStack tenant of which the OpenStack Networking instance is a member.
-
 *OpenStack Volume*
 
 * *Data Center*: The data center to which OpenStack Volume storage volumes will be attached.

--- a/source/documentation/administration_guide/topics/Adding_OVN_as_an_External_Network_Provider.adoc
+++ b/source/documentation/administration_guide/topics/Adding_OVN_as_an_External_Network_Provider.adoc
@@ -17,21 +17,15 @@ deferred-maintenance
 
 The `ovirt-provider-ovn` exposes an OpenStack Networking REST API. You can use this API to create networks, subnets, ports, and routers. For details, see link:https://developer.openstack.org/api-ref/network/v2/[_OpenStack Networking API v2.0_].
 
-[NOTE]
-====
-CloudForms supports OVN as an external provider using the OpenStack Networking API. See link:https://access.redhat.com/documentation/en-us/red_hat_cloudforms/5.0/html/managing_providers/network_providers[Network Managers] in _Red Hat CloudForms: Managing Providers_ for details.
-====
-
 For more details, see the link:http://docs.openvswitch.org/en/latest/[Open vSwitch Documentation] and link:http://openvswitch.org/support/dist-docs/[Open vSwitch Manpages].
 
 
 include::Installing_a_new_OVN_network_provider.adoc[]
 
-include::Adding_an_existing_OVN_network_provider.adoc[]
-
-include::Enabling_IPsec_over_OVN.adoc[]
-
-include::Using_an_Ansible_playbook_to_modify_an_OVN_tunnel_network.adoc[]
+////
+Removing for BZ2006228: include::Adding_an_existing_OVN_network_provider.adoc[]
+ include::Using_an_Ansible_playbook_to_modify_an_OVN_tunnel_network.adoc[]
+////
 
 include::Configuring_Hosts_for_an_OVN_tunnel_network.adoc[]
 

--- a/source/documentation/administration_guide/topics/Configuring_Hosts_for_an_OVN_tunnel_network.adoc
+++ b/source/documentation/administration_guide/topics/Configuring_Hosts_for_an_OVN_tunnel_network.adoc
@@ -9,14 +9,15 @@ You can update the OVN tunnel network on a single host with `vdsm-tool`:
 # vdsm-tool ovn-config OVN_Central_IP Tunneling_IP_or_Network_Name Host_FQDN
 ----
 
+[NOTE]
+====
+The Host_FQDN must match the FQDN that is specified in the engine for this host.
+====
+
 .Updating a Host with `vdsm-tool`
 ====
 [source,terminal]
 ----
 # vdsm-tool ovn-config 192.168.0.1 MyNetwork MyFQDN
 ----
-====
-[NOTE]
-====
-The Host_FQDN must match the FQDN that is specified in the engine for this host.
 ====

--- a/source/documentation/administration_guide/topics/Configuring_Hosts_for_an_OVN_tunnel_network.adoc
+++ b/source/documentation/administration_guide/topics/Configuring_Hosts_for_an_OVN_tunnel_network.adoc
@@ -1,59 +1,22 @@
 :_content-type: PROCEDURE
 [id="Configuring_Hosts_for_an_OVN_tunnel_network"]
-= Configuring Hosts for an OVN Tunnel Network
-
-You can configure your hosts to use an existing network, other than the default `ovirtmgmt` network, with the `ovirt-provider-ovn-driver` Ansible playbook. The network must be accessible to all the hosts in the cluster.
-
-[NOTE]
-====
-The `ovirt-provider-ovn-driver` Ansible playbook updates existing hosts. If you add new hosts to the cluster, you must run the playbook again.
-====
-
-.Procedure
-
-. On the {engine-name} machine, go to the *playbooks* directory:
-+
-[source,terminal,subs="normal"]
-----
-# cd /usr/share/ovirt-engine/playbooks
-----
-
-. Run the `ansible-playbook` command with the following parameters:
-+
-[options="nowrap" subs="normal" ]
-----
-# ansible-playbook --private-key=/etc/pki/ovirt-engine/keys/engine_id_rsa -i /usr/share/ovirt-engine-metrics/bin/ovirt-engine-hosts-ansible-inventory --extra-vars "{nbsp}cluster_name=_Cluster_Name_ ovn_central=_OVN_Central_IP_ ovn_tunneling_interface=_VDSM_Network_Name_" ovirt-provider-ovn-driver.yml
-----
-+
-For example:
-+
-[options="nowrap" subs="normal" ]
-----
-# ansible-playbook --private-key=/etc/pki/ovirt-engine/keys/engine_id_rsa -i /usr/share/ovirt-engine-metrics/bin/ovirt-engine-hosts-ansible-inventory --extra-vars "{nbsp}cluster_name=MyCluster ovn_central=192.168.0.1 ovn_tunneling_interface=MyNetwork" ovirt-provider-ovn-driver.yml
-----
-+
-[NOTE]
-====
-The _OVN_Central_IP_ can be on the new network, but this is not a requirement. The _OVN_Central_IP_ must be accessible to all hosts.
-
-The _VDSM_Network_Name_ is limited to 15 characters. If you defined a logical network name that was longer than 15 characters or contained non-ASCII characters, a 15-character name is automatically generated. See xref:Vdsm_To_Network_Mapping_Tool[Mapping VDSM Names to Logical Network Names] for instructions on displaying a mapping of these names.
-====
-
-*Updating the OVN Tunnel Network on a Single Host*
+= Updating the OVN Tunnel Network on a Single Host
 
 You can update the OVN tunnel network on a single host with `vdsm-tool`:
 
 [source,terminal,subs="normal"]
 ----
-# vdsm-tool ovn-config _OVN_Central_IP_ _Tunneling_IP_or_Network_Name_
+# vdsm-tool ovn-config OVN_Central_IP Tunneling_IP_or_Network_Name Host_FQDN
 ----
 
 .Updating a Host with `vdsm-tool`
 ====
-
-[source,terminal,subs="normal"]
+[source,terminal]
 ----
-# vdsm-tool ovn-config 192.168.0.1 MyNetwork
+# vdsm-tool ovn-config 192.168.0.1 MyNetwork MyFQDN
 ----
-
+====
+[NOTE]
+====
+The Host_FQDN must match the FQDN that is specified in the engine for this host.
 ====

--- a/source/documentation/administration_guide/topics/Installing_a_new_OVN_network_provider.adoc
+++ b/source/documentation/administration_guide/topics/Installing_a_new_OVN_network_provider.adoc
@@ -2,11 +2,6 @@
 [id="Installing_a_new_OVN_network_provider"]
 = Installing a New OVN Network Provider
 
-[WARNING]
-====
-If the `openvswitch` package is already installed and if the version is 1:2.6.1 (version 2.6.1, epoch 1), the OVN installation will fail when it tries to install the latest `openvswitch` package. See the Doc Text in link:https://bugzilla.redhat.com/show_bug.cgi?id=1505398[BZ#1505398] for the details and a workaround.
-====
-
 Installing OVN using `engine-setup` performs the following steps:
 
 * Sets up an OVN central server on the {engine-name} machine.

--- a/source/documentation/common/upgrade/snip-upgrade_considerations.adoc
+++ b/source/documentation/common/upgrade/snip-upgrade_considerations.adoc
@@ -12,5 +12,5 @@
 
 ====
 [NOTE]
-To verify whether the provider and OVN were configured successfully on the host, check the *OVN configured* flag on the *General* tab for the host. If the host's OVN is not confiugred, you can configure it by reinstalling {engine-name} 4.5 or higher.
+To verify whether the provider and OVN were configured successfully on the host, check the *OVN configured* flag on the *General* tab for the host. If the *OVN Configured* is set to *No*, click menu:Management[Refresh Capabilities]. If refreshing the capabilities fails, you can configure OVN by reinstalling {engine-name} 4.5 or higher.
 ====

--- a/source/documentation/common/upgrade/snip-upgrade_considerations.adoc
+++ b/source/documentation/common/upgrade/snip-upgrade_considerations.adoc
@@ -8,9 +8,10 @@
 
 ** The engine is upgraded first.
 ** The ovirt-provider-ovn security groups must be disabled, before the host upgrade, for all OVN networks that are expected to work between hosts with OVN/OvS version 2.11.
-** The hosts are upgraded to match OVN version 2021 or higher and OvS version 2.15.
+** The hosts are upgraded to match OVN version 2021 or higher and OvS version 2.15. Complete this step in the Administration Portal, so you can reconfigure OVN and refresh the certificates.
+** The host is rebooted after an upgrade.
 
 ====
 [NOTE]
-To verify whether the provider and OVN were configured successfully on the host, check the *OVN configured* flag on the *General* tab for the host. If the *OVN Configured* is set to *No*, click menu:Management[Refresh Capabilities]. If refreshing the capabilities fails, you can configure OVN by reinstalling {engine-name} 4.5 or higher.
+To verify whether the provider and OVN were configured successfully on the host, check the *OVN configured* flag on the *General* tab for the host. If the *OVN Configured* is set to *No*, click menu:Management[Refresh Capabilities]. This setting is also available in the REST API. If refreshing the capabilities fails, you can configure OVN by reinstalling {engine-name} 4.5 or higher.
 ====

--- a/source/documentation/common/upgrade/snip-upgrade_considerations.adoc
+++ b/source/documentation/common/upgrade/snip-upgrade_considerations.adoc
@@ -6,12 +6,12 @@
 
 * When upgrading from Open Virtual Network (OVN) and Open vSwitch (OvS) 2.11 to OVN 2021 and OvS 2.15, the process is transparent to the user as long as the following conditions are met:
 
-** The engine is upgraded first.
+** The {engine-name} is upgraded first.
 ** The ovirt-provider-ovn security groups must be disabled, before the host upgrade, for all OVN networks that are expected to work between hosts with OVN/OvS version 2.11.
-** The hosts are upgraded to match OVN version 2021 or higher and OvS version 2.15. Complete this step in the Administration Portal, so you can reconfigure OVN and refresh the certificates.
+** The hosts are upgraded to match OVN version 2021 or higher and OvS version 2.15. You must complete this step in the Administration Portal, so you can properly reconfigure OVN and refresh the certificates.
 ** The host is rebooted after an upgrade.
 
 ====
 [NOTE]
-To verify whether the provider and OVN were configured successfully on the host, check the *OVN configured* flag on the *General* tab for the host. If the *OVN Configured* is set to *No*, click menu:Management[Refresh Capabilities]. This setting is also available in the REST API. If refreshing the capabilities fails, you can configure OVN by reinstalling {engine-name} 4.5 or higher.
+To verify whether the provider and OVN were configured successfully on the host, check the *OVN configured* flag on the *General* tab for the host. If the *OVN Configured* is set to *No*, click menu:Management[Refresh Capabilities]. This setting is also available in the REST API. If refreshing the capabilities fails, you can configure OVN by reinstalling the host from {engine-name} 4.5 or higher.
 ====

--- a/source/documentation/common/upgrade/snip-upgrade_considerations.adoc
+++ b/source/documentation/common/upgrade/snip-upgrade_considerations.adoc
@@ -6,7 +6,7 @@
 
 * When upgrading from Open Virtual Network (OVN) and Open vSwitch (OvS) 2.11 to OVN 2021 and OvS 2.15, the process is transparent to the user as long as the following conditions are met:
 
-** The engine must be upgraded first.
+** The engine is upgraded first.
 ** The ovirt-provider-ovn security groups must be disabled, before the host upgrade, for all OVN networks that are expected to work between hosts with OVN/OvS version 2.11.
 ** The hosts are upgraded to match OVN version 2021 or higher and OvS version 2.15.
 

--- a/source/documentation/common/upgrade/snip-upgrade_considerations.adoc
+++ b/source/documentation/common/upgrade/snip-upgrade_considerations.adoc
@@ -2,4 +2,15 @@
 :_content-type: SNIPPET
 .Upgrade Considerations
 
-When planning to upgrade, see link:https://access.redhat.com/articles/5268351[Red Hat Virtualization 4.4 upgrade considerations and known issues].
+* When planning to upgrade, see link:https://access.redhat.com/articles/5268351[Red Hat Virtualization 4.4 upgrade considerations and known issues].
+
+* When upgrading from Open Virtual Network (OVN) and Open vSwitch (OvS) 2.11 to OVN 2021 and OvS 2.15, the process is transparent to the user as long as the following conditions are met:
+
+** The engine must be upgraded first.
+** The ovirt-provider-ovn security groups must be disabled, before the host upgrade, for all OVN networks that are expected to work between hosts with OVN/OvS version 2.11.
+** The hosts are upgraded to match OVN version 2021 or higher and OvS version 2.15.
+
+====
+[NOTE]
+To verify whether the provider and OVN were configured successfully on the host, check the *OVN configured* flag on the *General* tab for the host. If the host's OVN is not confiugred, you can configure it by reinstalling {engine-name} 4.5 or higher.
+====


### PR DESCRIPTION
This PR is a duplicate of https://github.com/oVirt/ovirt-site/pull/2739. The admin guide changes were previously reviewed and approved. The main difference here is the update to the Upgrade Guide. I created a new PR based on merge conflict issue with original PR that I was unable to untangle. 

Fixes issue https://bugzilla.redhat.com/show_bug.cgi?id=2006228

Changes proposed in this pull request:
Fixes issue: https://bugzilla.redhat.com/show_bug.cgi?id=2006228
Changes proposed in this pull request:

Section 14.2.7: Removed CloudForms support note.
Section 14.2.7.1: Removed the warning about openvswitch version.
Section 14.2.7.2: Removed
Section 14.2.7.3: Removed
Section 14.2.7.4: Keep only the part under "Updating the OVN Tunnel Network on a Single Host", everything else can be removed.
The vdsm-tool snippet should be updated to:
vdsm-tool ovn-config OVN_Central_IP Tunneling_IP_or_Network_Name Host_FQDN
and example to:
vdsm-tool ovn-config 192.168.0.1 MyNetwork MyFQDN

Please add note under the first snippet: The Host_FQDN must match FQDN that is specified in engine for this host.

Section 14.2.8: Removed
Section 14.2.9, Table 14.1: Removed Type "OpenStack Networking".

Added upgrade notes to the Upgrade Considerations snippet in the Upgrade Guide.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @dcdacosta

This pull request needs review by: @almusil