### PR TITLE
PR2784_1 - Fixed variable issue in Install via command line doc

### DIFF
--- a/source/documentation/common/she/proc_Manually_installing_the_appliance.adoc
+++ b/source/documentation/common/she/proc_Manually_installing_the_appliance.adoc
@@ -44,9 +44,18 @@ include::../install/snip-Enable_virt_module.adoc[]
 //ansible lock addition
 . Install the {engine-appliance-name} to the host manually:
 +
+ifdef::rhv-doc[]
 [source,terminal]
 ----
-# dnf install {engine-package}-appliance
+# dnf install rhvm-appliance
 ----
+endif::rhv-doc[]
+
+ifdef::ovirt-doc[]
+[source,terminal]
+----
+# dnf install ovirt-engine-appliance
+----
+endif::ovirt-doc[]
 
 Now, when you deploy the self-hosted engine, the installer detects that the appliance is already installed.


### PR DESCRIPTION
Broken variable in https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/installing_red_hat_virtualization_as_a_self-hosted_engine_using_the_command_line/index#proc_Manually_installing_the_appliance_install_RHVM (Step 2)

Changes proposed in this pull request:

- Fixed broken variable in step 2 using conditional text to render correctly in both upstream and downstream doc.-

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (@dcdacosta )

This pull request needs review by: (@sandrobonazzola )
