### PR TITLE
PR2786 - Corrected link reference for upstream

### DIFF
--- a/source/documentation/common/install/proc-Installing_Red_Hat_Virtualization_Hosts.adoc
+++ b/source/documentation/common/install/proc-Installing_Red_Hat_Virtualization_Hosts.adoc
@@ -6,7 +6,13 @@
 
 {hypervisor-shortname} supports NIST 800-53 partitioning requirements to improve security. {hypervisor-shortname} uses a NIST 800-53 partition layout by default.
 
+ifdef::rhv-doc[]
 The host must meet the minimum  link:{URL_downstream_virt_product_docs}planning_and_prerequisites_guide/index#host-requirements[host requirements].
+endif::rhv-doc[]
+
+ifdef::ovirt-doc[]
+The host must meet the minimum  link:{URL_virt_product_docs}installing_ovirt_as_a_standalone_manager_with_local_databases/index.html#host-requirements[host requirements].
+endif::ovirt-doc[]
 
 include::../upgrade/snip_WARNING-detach_data_storage.adoc[]
 


### PR DESCRIPTION
Fixes issue https://github.com/oVirt/ovirt-site/issues/2786
Changes proposed in this pull request:

- Used conditional text to correct the link reference for the upstream doc. It now points to https://ovirt.org/documentation/installing_ovirt_as_a_standalone_manager_with_local_databases/index.html#host-requirements

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (@dcdacosta )

This pull request needs review by: (@sandrobonazzola )
