### PR TITLE
BZ2036586 - Added information about the system-coredump service

### DIFF
--- a/source/documentation/administration_guide/topics/Red_Hat_Virtualization_Hosts.adoc
+++ b/source/documentation/administration_guide/topics/Red_Hat_Virtualization_Hosts.adoc
@@ -8,7 +8,13 @@
 
 Access the Cockpit web interface at https://_HostFQDNorIP_:9090 in your web browser. Cockpit for {hypervisor-shortname} includes a custom *Virtualization* dashboard that displays the host's health status, SSH Host Key, self-hosted engine status, virtual machines, and virtual machine statistics.
 
+ifdef::[rhv-doc]
 Starting in {virt-product-fullname} version 4.4 SP1 the {hypervisor-shortname} uses `systemd-coredump` to gather, save and process core dumps. For more information, see the documentation for link:https://www.freedesktop.org/software/systemd/man/coredump.conf.html[core dump storage configuration files] and link:https://www.freedesktop.org/software/systemd/man/systemd-coredump.html[systemd-coredump service].
+endif::[rhv-doc]
+
+ifdef::[ovirt-doc]
+Starting in {virt-product-fullname} version 4.5 the {hypervisor-shortname} uses `systemd-coredump` to gather, save and process core dumps. For more information, see the documentation for link:https://www.freedesktop.org/software/systemd/man/coredump.conf.html[core dump storage configuration files] and link:https://www.freedesktop.org/software/systemd/man/systemd-coredump.html[systemd-coredump service].
+endif::[ovirt-doc]
 
 In {virt-product-fullname} 4.4 and earlier {hypervisor-shortname} uses the Automatic Bug Reporting Tool (ABRT) to collect meaningful debug information about application crashes. For more information, see the link:{URL_rhel_docs_legacy}html-single/system_administrators_guide/index#ch-abrt[_{enterprise-linux} System Administrator's Guide_].
 

--- a/source/documentation/administration_guide/topics/Red_Hat_Virtualization_Hosts.adoc
+++ b/source/documentation/administration_guide/topics/Red_Hat_Virtualization_Hosts.adoc
@@ -8,7 +8,9 @@
 
 Access the Cockpit web interface at https://_HostFQDNorIP_:9090 in your web browser. Cockpit for {hypervisor-shortname} includes a custom *Virtualization* dashboard that displays the host's health status, SSH Host Key, self-hosted engine status, virtual machines, and virtual machine statistics.
 
-{hypervisor-shortname} uses the Automatic Bug Reporting Tool (ABRT) to collect meaningful debug information about application crashes. For more information, see the link:{URL_rhel_docs_legacy}html-single/system_administrators_guide/index#ch-abrt[_{enterprise-linux} System Administrator's Guide_].
+Starting in {virt-product-fullname} version 4.4 SP1 the {hypervisor-shortname} uses `systemd-coredump` to gather, save and process core dumps. For more information, see the documentation for link:https://www.freedesktop.org/software/systemd/man/coredump.conf.html[core dump storage configuration files] and link:https://www.freedesktop.org/software/systemd/man/systemd-coredump.html[systemd-coredump service].
+
+In {virt-product-fullname} 4.4 and earlier {hypervisor-shortname} uses the Automatic Bug Reporting Tool (ABRT) to collect meaningful debug information about application crashes. For more information, see the link:{URL_rhel_docs_legacy}html-single/system_administrators_guide/index#ch-abrt[_{enterprise-linux} System Administrator's Guide_].
 
 [NOTE]
 ====


### PR DESCRIPTION
[Feature]

Fixes issue https://bugzilla.redhat.com/show_bug.cgi?id=2036586

Changes proposed in this pull request:

- Added a statement that starting in RHV 4.4 SP1 system-coredump will be used by the hypervisor for coredumps.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (@dcdacosta )

This pull request needs review by: (@hbraha )
