### PR TITLE
BZ1886803 - Added information regarding risk levels for IBM POWER9

### DIFF
--- a/source/documentation/doc-Release_Notes/chap-RHEV_for_IBM_Power.adoc
+++ b/source/documentation/doc-Release_Notes/chap-RHEV_for_IBM_Power.adoc
@@ -34,6 +34,11 @@ The packages provided in the following repositories are required to install and 
 |{enterprise-linux} 8 virtual machines, little endian |`{enterprise-linux} for Power, little endian` |`RHV Tools for IBM Power, little endian` |`rhv-4-tools-for-rhel-8-ppc64le-rpms` |Provides the `ovirt-guest-agent-common` package for {enterprise-linux} 8 virtual machines on emulated IBM Power (little endian) hardware. The guest agents allow you to monitor virtual machine resources on {enterprise-linux} 8 clients.
 |===
 
+[NOTE]
+====
+If the virtual machine fails to boot on IBM POWER9, it might be because of the risk level setting on your firmware. To resolve this issue, see the Troubleshooting scenarios in  link:{URL_virt_product_docs}{URL_format}virtual_machine_management_guide/index#Powering_on_a_virtual_machine[Starting a virtual machine].
+====
+
 .Unsupported Features for IBM POWER
 
 The following {virt-product-fullname} features are not supported:

--- a/source/documentation/virtual_machine_management_guide/topics/Powering_on_a_virtual_machine.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Powering_on_a_virtual_machine.adoc
@@ -32,3 +32,29 @@ Possible solutions to this problem:
 * Create a new virtual machine with a local boot disk managed by {virt-product-shortname} that contains the OS and application binaries.
 
 * Install the OS by booting from the *Network (PXE)* boot option.
+
+Scenario - the virtual machine on IBM POWER9 fails to boot with the following error message:
+
+[source,terminal]
+----
+qemu-kvm: Requested count cache flush assist capability level not supported by kvm, try appending -machine cap-ccf-assist=off
+----
+
+Default risk level protections can prevent VMs from starting on IBM POWER9. To resolve this issue:
+
+. Create or edit the `/var/lib/obmc/cfam_overrides` on the BMC.
+. Set the firmware risk level to `0`:
++
+[options="nowrap" subs="quotes"]
+----
+# Control speculative execution mode
+0 0x283a 0x00000001  # bits 28:31 are used for init level -- in this case 1 (Kernel protection only)
+0 0x283F 0x20000000  # Indicate override register is valid
+----
++
+. Reboot the host system for the changes to take affect.
+
+[NOTE]
+====
+Overriding the risk level can cause unexpected behavior when running virtual machines.
+====

--- a/source/documentation/virtual_machine_management_guide/topics/Powering_on_a_virtual_machine.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Powering_on_a_virtual_machine.adoc
@@ -48,7 +48,7 @@ Default risk level protections can prevent VMs from starting on IBM POWER9. To r
 [options="nowrap" subs="quotes"]
 ----
 # Control speculative execution mode
-0 0x283a 0x00000001  # bits 28:31 are used for init level -- in this case 1 (Kernel protection only)
+0 0x283a 0x00000000  # bits 28:31 are used for init level -- in this case 0 Kernel and User protection (safest, default)
 0 0x283F 0x20000000  # Indicate override register is valid
 ----
 +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1886803

Changes proposed in this pull request:
- Added steps to change risk level to 0 if VM fails to boot on Power9

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (@dcdacosta )

This pull request needs review by: @mz-pdm, David Gibson
