### PR TITLE
admin_xref replacing xref with direct link in Admin Guide

### DIFF
--- a/source/documentation/administration_guide/chap-Virtual_Disks.adoc
+++ b/source/documentation/administration_guide/chap-Virtual_Disks.adoc
@@ -33,7 +33,7 @@ include::topics/proc_improving_disk_performance.adoc[leveloffset=+2]
 
 === Uploading Images to a Data Storage Domain
 
-You can upload virtual disk images and ISO images to your data storage domain in the Administration Portal or with the REST API. See xref:Uploading_Images_to_a_Data_Storage_Domain_storage_tasks[Uploading Images to a Data Storage Domain].
+You can upload virtual disk images and ISO images to your data storage domain in the Administration Portal or with the REST API. See link:{URL_virt_product_docs}{URL_format}administration_guide/index#Uploading_Images_to_a_Data_Storage_Domain_storage_tasks[Uploading Images to a Data Storage Domain] for details.
 
 include::topics/Importing_a_Disk_Image.adoc[leveloffset=+2]
 

--- a/source/documentation/administration_guide/topics/The_ISO_Uploader_Tool.adoc
+++ b/source/documentation/administration_guide/topics/The_ISO_Uploader_Tool.adoc
@@ -4,7 +4,7 @@
 
 [NOTE]
 ====
-The ISO Uploader tool has been deprecated. Upload ISO images to the data domain with the Administration Portal or with the REST API. See xref:Uploading_Images_to_a_Data_Storage_Domain[Uploading Images to a Data Storage Domain] for details.
+The ISO Uploader tool has been deprecated. Upload ISO images to the data domain with the Administration Portal or with the REST API. See link:{URL_virt_product_docs}{URL_format}administration_guide/index#Uploading_Images_to_a_Data_Storage_Domain_storage_tasks[Uploading Images to a Data Storage Domain] for details.
 ====
 
 The ISO uploader is a tool for uploading ISO images to the ISO storage domain. It is installed as part of the {virt-product-fullname} {engine-name}.

--- a/source/documentation/administration_guide/topics/Uploading_the_VirtIO_and_Guest_Tool_Image_Files_to_an_ISO_Storage_Domain.adoc
+++ b/source/documentation/administration_guide/topics/Uploading_the_VirtIO_and_Guest_Tool_Image_Files_to_an_ISO_Storage_Domain.adoc
@@ -4,7 +4,7 @@
 
 [NOTE]
 ====
-The ISO domain is a deprecated storage domain type. The ISO Uploader tool has been removed in {virt-product-fullname} 4.4. {org-fullname} recommends uploading ISO images to the data domain with the Administration Portal or with the REST API. See xref:Uploading_Images_to_a_Data_Storage_Domain[Uploading Images to a Data Storage Domain] for details.
+The ISO domain is a deprecated storage domain type. The ISO Uploader tool has been removed in {virt-product-fullname} 4.4. {org-fullname} recommends uploading ISO images to the data domain with the Administration Portal or with the REST API. See link:{URL_virt_product_docs}{URL_format}administration_guide/index#Uploading_Images_to_a_Data_Storage_Domain_storage_tasks[Uploading Images to a Data Storage Domain] for details.
 ====
 
 The `virtio-win___version__.iso` image contains the following for Windows virtual machines to improve performance and usability:

--- a/source/documentation/administration_guide/topics/proc_Copy_image_to_ISO_domain.adoc
+++ b/source/documentation/administration_guide/topics/proc_Copy_image_to_ISO_domain.adoc
@@ -8,7 +8,7 @@
 
 [NOTE]
 ====
-The ISO domain is a deprecated storage domain type. The ISO Uploader tool, `ovirt-iso-uploader`, is removed in {virt-product-fullname} 4.4. You should upload ISO images to the data domain with the Administration Portal or with the REST API. See xref:Uploading_Images_to_a_Data_Storage_Domain[Uploading Images to a Data Storage Domain] for details.
+The ISO domain is a deprecated storage domain type. The ISO Uploader tool, `ovirt-iso-uploader`, is removed in {virt-product-fullname} 4.4. You should upload ISO images to the data domain with the Administration Portal or with the REST API. See link:{URL_virt_product_docs}{URL_format}administration_guide/index#Uploading_Images_to_a_Data_Storage_Domain_storage_tasks[Uploading Images to a Data Storage Domain] for details.
 
 Although the ISO domain is deprecated, this information is provided in case you must use an ISO domain.
 ====


### PR DESCRIPTION
Changes proposed in this pull request:

- replacing a number of identical xrefs (Uploading_Images_to_a_Data_Storage_Domain) with a direct link URL to the guide
due to error logs in Pantheon publishing tool pointing to a specific xref

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @emarcusRH )

This pull request needs review by: (please @ )
