### PR TITLE
BZ2042398 - Remove functionality: oVirt Scheduler Proxy

### DIFF
--- a/source/documentation/doc-Release_Notes/topics/ref-Deprecated_Features_RHV.adoc
+++ b/source/documentation/doc-Release_Notes/topics/ref-Deprecated_Features_RHV.adoc
@@ -52,6 +52,4 @@ In {virt-product-fullname} 4.4, some tasks may still require the ISO domain.
 
  SSO is not supported for virtual machines running {enterprise-linux} 8 or later, or for Windows operating systems.
 
-| ovirt-scheduler-proxy | The oVirt Scheduler Proxy is deprecated. Development has been discontinued. It will be removed in a future release.
-
 |===

--- a/source/documentation/doc-Release_Notes/topics/ref-Removed_Features_RHV.adoc
+++ b/source/documentation/doc-Release_Notes/topics/ref-Removed_Features_RHV.adoc
@@ -61,7 +61,7 @@ Removing this neither affects the ability to manage {virt-product-fullname} virt
 
 | Cockpit installation for Self-hosted engine| Using Cockpit to install the self-hosted engine is no longer supported. Use the command line installation.
 
-| oVirt Scheduler Proxy | The `ovirt-scheduler-proxy` package is removed in {virt-product-fullname} 4.4.z SP1.
+| oVirt Scheduler Proxy | The `ovirt-scheduler-proxy` package is removed in {virt-product-fullname} 4.4 SP1.
 
 |Ruby software development kit (SDK) |The Ruby SDK is no longer supported.
 |===

--- a/source/documentation/doc-Release_Notes/topics/ref-Removed_Features_RHV.adoc
+++ b/source/documentation/doc-Release_Notes/topics/ref-Removed_Features_RHV.adoc
@@ -61,9 +61,7 @@ Removing this neither affects the ability to manage {virt-product-fullname} virt
 
 | Cockpit installation for Self-hosted engine| Using Cockpit to install the self-hosted engine is no longer supported. Use the command line installation.
 
-// Uncomment this line for RHV release that corresponds to oVirt 4.5.
-// Also, remove Deprecation notice for this feature for same release.
-// | oVirt Scheduler Proxy | The `ovirt-scheduler-proxy` package is removed in {virt-product-fullname} 4.4.z SP1.
+| oVirt Scheduler Proxy | The `ovirt-scheduler-proxy` package is removed in {virt-product-fullname} 4.4.z SP1.
 
 |Ruby software development kit (SDK) |The Ruby SDK is no longer supported.
 |===


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2042398

Changes proposed in this pull request:

- Added ovirt-scheduler-proxy to table of removed features.
- Removed ovirt-scheduler-proxy from table of deprecated features.-

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (@dcdacosta )

This pull request needs review by: (@sandrobonazzola )
This pull request needs peer review by: (@emarcusRH )
