### PR TITLE
config: skip generation of asm, chap and topics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -164,6 +164,13 @@ exclude:
   - documentation/doc-Technical_Reference/chap*
   - documentation/doc-Release_Notes/topics
   - documentation/doc-Release_Notes/chap*
+  - documentation/doc-Product_Guide/topics
+  - documentation/doc-Product_Guide/chap*
+  - documentation/doc-Product_Guide/asm-*
+  - documentation/doc-Python_SDK_Guide/topics
+  - documentation/doc-Python_SDK_Guide/chap*
+  - documentation/doc-Planning_and_Prerequisites_Guide/topics
+  - documentation/doc-Planning_and_Prerequisites_Guide/asm-*
 sass:
   add_charset: true
   style: :compressed


### PR DESCRIPTION
[Bug fix]

Fixes issue #2822

Changes proposed in this pull request:

- skip generation of chap, asm and topics for new books

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @oVirt/ovirt-documentation 
