### PR TITLE
4.5 now requires mod_auth_openidc:2.3

### DIFF
--- a/source/develop/developer-guide/migrating_to_github.md
+++ b/source/develop/developer-guide/migrating_to_github.md
@@ -154,6 +154,7 @@ jobs:
           yum module enable -y maven:3.5
           yum module enable -y pki-deps:10.6
           yum module enable -y postgresql:12
+          yum module enable -y mod_auth_openidc:2.3
           yum --downloadonly install -y exported-artifacts/*noarch.rpm
           yum --downloadonly install -y ovirt-engine ovirt-engine-setup-plugin-websocket-proxy
     - name: Upload artifacts

--- a/source/documentation/common/install/proc-Enabling_the_Red_Hat_Virtualization_Manager_Repositories.adoc
+++ b/source/documentation/common/install/proc-Enabling_the_Red_Hat_Virtualization_Manager_Repositories.adoc
@@ -148,6 +148,15 @@ endif::remote_database_install,manual_database_install,migrate_SHE_DB,migrate_DW
 ----
 # dnf module -y enable postgresql:12
 ----
+ifdef::ovirt-doc[]
+. Enable version 2.3 of the `mod_auth_openidc` module.
++
+[source,terminal,subs="normal"]
++
+----
+# dnf module -y enable mod_auth_openidc:2.3
+----
+endif::ovirt-doc[]
 . Synchronize installed packages to update them to the latest available versions.
 +
 [source,terminal,subs="normal"]


### PR DESCRIPTION
[Feature]

[BZ 2021497](https://bugzilla.redhat.com/show_bug.cgi?id=2021497)

Changes proposed in this pull request:

Add note about enabling mod_auth_openidc:2.3
See also: https://github.com/oVirt/ovirt-release/pull/166

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @arso @mwperina @oVirt/ovirt-documentation 
