### PR TITLE
point to lifecycle page only for RHV

### DIFF
--- a/source/documentation/common/install/assembly-Installing_Hosts_for_RHV.adoc
+++ b/source/documentation/common/install/assembly-Installing_Hosts_for_RHV.adoc
@@ -26,7 +26,10 @@ endif::[]
 
 .Host Compatibility
 
-When you create a new data center, you can set the compatibility version. Select the compatibility version that suits all the hosts in the data center. Once set, version regression is not allowed. For a fresh {virt-product-fullname} installation, the latest compatibility version is set in the default data center and default cluster; to use an earlier compatibility version, you must create additional data centers and clusters. For more information about compatibility versions see _{virt-product-fullname} {engine-name} Compatibility_ in link:https://access.redhat.com/support/policy/updates/rhev[{virt-product-fullname} Life Cycle].
+When you create a new data center, you can set the compatibility version. Select the compatibility version that suits all the hosts in the data center. Once set, version regression is not allowed. For a fresh {virt-product-fullname} installation, the latest compatibility version is set in the default data center and default cluster; to use an earlier compatibility version, you must create additional data centers and clusters.
+ifdef::rhv-doc[]
+For more information about compatibility versions see _{virt-product-fullname} {engine-name} Compatibility_ in link:https://access.redhat.com/support/policy/updates/rhev[{virt-product-fullname} Life Cycle].
+endif::[]
 
 [id='Red_Hat_Virtualization_Hosts_{context}']
 == {hypervisor-fullname}s


### PR DESCRIPTION
[Bug fix]

Fixes issue #2785

Changes proposed in this pull request:

- drop link to RHV lifecycle page on oVirt site. There's no equivalent to RHV lifecycle page for oVirt.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @oVirt/ovirt-documentation 
