### PR TITLE
BZ#2028192 add ovirt scheduler proxy to Deprecated Functionality table in Rel Notes

### DIFF
--- a/source/documentation/doc-Release_Notes/topics/ref-Deprecated_Features_RHV.adoc
+++ b/source/documentation/doc-Release_Notes/topics/ref-Deprecated_Features_RHV.adoc
@@ -55,4 +55,6 @@ In {virt-product-fullname} 4.4, some tasks may still require the ISO domain.
 
  SSO is not supported for virtual machines running {enterprise-linux} 8 or later, or for Windows operating systems.
 
+|oVirt Scheduler Proxy | `ovirt-scheduler-proxy` is deprecated. Development has been discontinued. It will be removed in a future release.
+
 |===

--- a/source/documentation/doc-Release_Notes/topics/ref-Removed_Features_RHV.adoc
+++ b/source/documentation/doc-Release_Notes/topics/ref-Removed_Features_RHV.adoc
@@ -61,7 +61,7 @@ Removing this neither affects the ability to manage {virt-product-fullname} virt
 
 | Cockpit installation for Self-hosted engine| Using Cockpit to install the self-hosted engine is no longer supported. Use the command line installation.
 
-| oVirt Scheduler Proxy | The `ovirt-scheduler-proxy` package is removed in {virt-product-fullname} 4.4 SP1.
+//| oVirt Scheduler Proxy | The `ovirt-scheduler-proxy` package is removed in {virt-product-fullname} 4.4 SP1.
 
 |Ruby software development kit (SDK) |The Ruby SDK is no longer supported.
 |===

--- a/source/documentation/upgrade_guide/chap-Red_Hat_Virtualization_Upgrade_Overview.adoc
+++ b/source/documentation/upgrade_guide/chap-Red_Hat_Virtualization_Upgrade_Overview.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="Red_Hat_Virtualization_Upgrade_Overview"]
-= {virt-product-fullname} Upgrade Overview
+//= {virt-product-fullname} Upgrade Overview
 
 This guide explains how to upgrade the following environments to {virt-product-fullname} 4.3 or 4.4 :
 

--- a/source/documentation/upgrade_guide/index.adoc
+++ b/source/documentation/upgrade_guide/index.adoc
@@ -9,6 +9,8 @@ include::common/collateral_files/_attributes.adoc[]
 [discrete]
 = Upgrade Guide
 
+= {virt-product-fullname} Upgrade Overview
+
 :upgrade:
 
 include::chap-Red_Hat_Virtualization_Upgrade_Overview.adoc[leveloffset=+1]

--- a/source/documentation/upgrade_guide/master.adoc
+++ b/source/documentation/upgrade_guide/master.adoc
@@ -4,26 +4,10 @@ include::common/collateral_files/_attributes.adoc[]
 [id="upgrade-guide"]
 = Upgrade Guide
 
+= {virt-product-fullname} Upgrade Overview
 :upgrade:
 [preface]
 include::chap-Red_Hat_Virtualization_Upgrade_Overview.adoc[leveloffset=+1]
-
-////
-
->> Fast-forward does not work with migration from 4.3 to 4.4, because the migration path requires installing RHEL 8.2 or later before you can install RHV 4.4.
-
-= Fast-forward Upgrading a Local Database Environment
-
-:local_database_upgrade_ff:
-
-This section applies to both self-hosted engine and standalone {engine-name} environments.
-
-include::topics/ovirt-fast-forward-upgrade_Explained.adoc[leveloffset=+1]
-
-include::assembly-Upgrading_from_4-2_ff.adoc[leveloffset=+1]
-
-:local_database_upgrade_ff!:
-////
 
 
 = Upgrading a standalone {engine-name} local database environment


### PR DESCRIPTION
Fixes issue # | \[BZ#2028192](https://bugzilla.redhat.com/show_bug.cgi?id=2028192)  (delete if not relevant)

Changes proposed in this pull request:

- Add ovirt scheduler proxy to Deprecated Functionality table in Rel Notes
- comment out same notice from Removed Functionality table in Rel Notes

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @emarcusRH )


