### PR TITLE
BZ#2028192 add deprecation notce for ovirt scheduler proxy

### DIFF
--- a/source/documentation/doc-Release_Notes/topics/ref-Deprecated_Features_RHV.adoc
+++ b/source/documentation/doc-Release_Notes/topics/ref-Deprecated_Features_RHV.adoc
@@ -55,4 +55,6 @@ In {virt-product-fullname} 4.4, some tasks may still require the ISO domain.
 
  SSO is not supported for virtual machines running {enterprise-linux} 8 or later, or for Windows operating systems.
 
+|oVirt Scheduler Proxy | `ovirt-scheduler-proxy` is deprecated. Development has been discontinued. It will be removed in a future release.
+
 |===

--- a/source/documentation/doc-Release_Notes/topics/ref-Removed_Features_RHV.adoc
+++ b/source/documentation/doc-Release_Notes/topics/ref-Removed_Features_RHV.adoc
@@ -61,7 +61,7 @@ Removing this neither affects the ability to manage {virt-product-fullname} virt
 
 | Cockpit installation for Self-hosted engine| Using Cockpit to install the self-hosted engine is no longer supported. Use the command line installation.
 
-| oVirt Scheduler Proxy | The `ovirt-scheduler-proxy` package is removed in {virt-product-fullname} 4.4 SP1.
+// | oVirt Scheduler Proxy | The `ovirt-scheduler-proxy` package is removed in {virt-product-fullname} 4.4 SP1.
 
 |Ruby software development kit (SDK) |The Ruby SDK is no longer supported.
 |===


### PR DESCRIPTION
Fixes issue # | [BZ#2028192](https://bugzilla.redhat.com/show_bug.cgi?id=2028192) (delete if not relevant)

Changes proposed in this pull request:

    Add ovirt scheduler proxy to Deprecated Functionality table in Rel Notes
    comment out same notice from Removed Functionality table in Rel Notes

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @emarcusRH )
This pull request needs review by: (please @mention the reviewer if relevant)
