### PR TITLE
BZ2071496 - Added -E option to the grep command in the example

### DIFF
--- a/source/documentation/common/upgrade/proc-Upgrading_the_Manager_to_4-4.adoc
+++ b/source/documentation/common/upgrade/proc-Upgrading_the_Manager_to_4-4.adoc
@@ -85,7 +85,7 @@ If you want to reuse the self-hosted engine virtual machine to deploy the {virt-
 +
 [source,terminal,subs="normal"]
 ----
-# hosted-engine --vm-status | grep 'Engine status|Hostname'
+# hosted-engine --vm-status | grep -E 'Engine status|Hostname'
 ----
 +
 [NOTE]


### PR DESCRIPTION
Fixes issue # https://bugzilla.redhat.com/show_bug.cgi?id=2071496

Changes proposed in this pull request:

- Add -E to grep in Step 5 Make sure that the self-hosted engine is shut down.
hosted-engine --vm-status | grep 'Engine status|Hostname'

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (@dcdacosta )

This pull request needs review by: (@ahadas )