### PR TITLE
Don't build Product Guide and Technical Notes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -164,13 +164,12 @@ exclude:
   - documentation/doc-Technical_Reference/chap*
   - documentation/doc-Release_Notes/topics
   - documentation/doc-Release_Notes/chap*
-  - documentation/doc-Product_Guide/topics
-  - documentation/doc-Product_Guide/chap*
-  - documentation/doc-Product_Guide/asm-*
+  - documentation/doc-Product_Guide/**
   - documentation/doc-Python_SDK_Guide/topics
   - documentation/doc-Python_SDK_Guide/chap*
   - documentation/doc-Planning_and_Prerequisites_Guide/topics
   - documentation/doc-Planning_and_Prerequisites_Guide/asm-*
+  - documentation/doc-Technical_Notes/**
 sass:
   add_charset: true
   style: :compressed


### PR DESCRIPTION
Bug fix

Related-To: https://github.com/oVirt/ovirt-site/issues/2842#issuecomment-1096778313

Changes proposed in this pull request:

- skip building Product Guide and Technical Notes for oVirt as they are relevant for RHV only.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @apinnick 
