### PR TITLE
rhvddf-13 - Updated max VM memory to 16TB

### DIFF
--- a/source/documentation/common/prereqs/ref-Host_Memory_Requirements.adoc
+++ b/source/documentation/common/prereqs/ref-Host_Memory_Requirements.adoc
@@ -6,6 +6,6 @@
 // PPG
 // Install
 
-The minimum required RAM is 2 GB. The maximum supported RAM per VM in {hypervisor-fullname} is 4 TB.
+The minimum required RAM is 2 GB. The maximum supported RAM per VM in {hypervisor-fullname} is 16 TB.
 
 However, the amount of RAM required varies depending on guest operating system requirements, guest application requirements, and guest memory activity and usage. KVM can also overcommit physical RAM for virtualized guests, allowing you to provision guests with RAM requirements greater than what is physically present, on the assumption that the guests are not all working concurrently at peak load. KVM does this by only allocating RAM for guests as required and shifting underutilized guests into swap.


### PR DESCRIPTION
Fixes issue # https://issues.redhat.com/browse/RHVDDF-13

Changes proposed in this pull request:

- Updated Memory Requirements statement "The maximum supported RAM per VM in Red Hat Virtualization Host is 4 TB." to "The maximum supported RAM per VM in Red Hat Virtualization Host is 16 TB."

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (@dcdacosta )

This pull request needs review by: (@ahadas )
