### PR TITLE
BZ2010307 added fast-datapath to list of repositories for rhel8 hosts…

### DIFF
--- a/source/documentation/common/install/proc-Enabling_the_Red_Hat_Enterprise_Linux_Host_Repositories.adoc
+++ b/source/documentation/common/install/proc-Enabling_the_Red_Hat_Enterprise_Linux_Host_Repositories.adoc
@@ -69,6 +69,7 @@ For {enterprise-linux} 8 hosts, little endian, on IBM POWER8 or IBM POWER9 hardw
     --enable=advanced-virt-for-rhel-8-ppc64le-rpms \
     --enable=rhel-8-for-ppc64le-appstream-rpms \
     --enable=rhel-8-for-ppc64le-baseos-rpms \
+    --enable=fast-datapath-for-rhel-8-ppc64le-rpms \
 ----
 endif::SM_localDB_deploy,SM_remoteDB_deploy[]
 


### PR DESCRIPTION
… on POWER

Bug fix:

Fixes issue # https://bugzilla.redhat.com/show_bug.cgi?id=2010307

Changes proposed in this pull request:

- Added --enable=fast-datapath-for-rhel-8-ppc64le-rpms to Step 4 of "4.2.2. Enabling the Red Hat Enterprise Linux host Repositories"

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (@dcdacosta )

This pull request needs review by: (@ahadas )
This pull requests needs review by: (@emarcusRH )
