### PR TITLE
Removing prompts for user/pw

### DIFF
--- a/source/documentation/doc-Release_Notes/update-beta.sh
+++ b/source/documentation/doc-Release_Notes/update-beta.sh
@@ -47,33 +47,7 @@ then
   exit 1
 fi
 
-echo
-
-echo -ne "Enter your Bugzilla user name, including the \e[4m@redhat.com\e[0m part: "
-
-read username
-
-if [ -z "$username" ]
-then
-  echo -e "\nNo user name specified. Exiting." >&2
-  exit 1
-fi
-
-echo
-
-echo -n "Enter your Bugzilla password: "
-
-read -s password
-
-if [ -z "$password" ]
-then
-  echo -e "\nNo password specified. Exiting." >&2
-  exit 1
-else
-  echo -e "\n\nAll values specified, running the \e[1mrelnotes\e[0m tool...\n"
-fi
-
-relnotes --username=${username} --password=${password} --product-set="Red Hat Virtualization" \
+relnotes --product-set="Red Hat Virtualization" \
          --flags=rhevm-${release}-ga?,rhevm-${release}-ga+,ovirt-${release}?,ovirt-${release}+ \
          --file=topics/ref-ovirt-${release}-beta.adoc --milestones=${milestones} \
          --releases= --verbose --force --section --asciidoc --include-all --next \
@@ -89,7 +63,7 @@ echo -e "Updating the \e[1m$MASTER\e[0m file.\n"
 
 cat >> $MASTER <<EOF
 
-include::topics/ref-ovirt-${release}-beta.adoc[]
+include::topics/ref-ovirt-${release}-beta.adoc[leveloffset=+1]
 
 EOF
 

--- a/source/documentation/doc-Release_Notes/update-ga.sh
+++ b/source/documentation/doc-Release_Notes/update-ga.sh
@@ -64,33 +64,7 @@ then
   exit
 fi
 
-echo
-
-echo -ne "Enter your Bugzilla user name, including the \e[4m@redhat.com\e[0m part: "
-
-read username
-
-if [ -z "$username" ]
-then
-  echo -e "\nNo user name specified. Exiting." >&2
-  exit 1
-fi
-
-echo
-
-echo -n "Enter your Bugzilla password: "
-
-read -s password
-
-if [ -z "$password" ]
-then
-  echo -e "\nNo password specified. Exiting." >&2
-  exit 1
-else
-  echo -e "\n\nAll values specified, running the \e[1mrelnotes\e[0m tool...\n"
-fi
-
-relnotes --username=${username} --password=${password} --product-set="Red Hat Virtualization" \
+relnotes --product-set="Red Hat Virtualization" \
          --flags=rhevm-${release}-ga?,rhevm-${release}-ga+,ovirt-${release}?,ovirt-${release}+ \
          --file=topics/ref-${milestone}.adoc --milestones=${milestones} \
          --releases= --verbose --force --section --asciidoc --include-all --next \
@@ -106,7 +80,7 @@ echo -e "Updating the \e[1m$MASTER\e[0m file.\n"
 
 cat >> $MASTER <<EOF
 
-include::topics/ref-${milestone}.adoc[]
+include::topics/ref-${milestone}.adoc[leveloffset=+1]
 
 EOF
 

--- a/source/documentation/doc-Release_Notes/update-zstream.sh
+++ b/source/documentation/doc-Release_Notes/update-zstream.sh
@@ -58,34 +58,7 @@ then
   exit
 fi
 
-echo
-
-echo -ne "Enter your Bugzilla user name, including \e[4m@redhat.com\e[0m. For example: francis@redhat.com \
-\nBugzilla user name: "
-
-read username
-
-if [ -z "$username" ]
-then
-  echo -e "\nNo user name specified. Exiting." >&2
-  exit 1
-fi
-
-echo
-
-echo -n "Enter your Bugzilla password: "
-
-read -s password
-
-if [ -z "$password" ]
-then
-  echo -e "\nNo password specified. Exiting." >&2
-  exit 1
-else
-  echo -e "\n\nAll values specified, running the \e[1mrelnotes\e[0m tool...\n"
-fi
-
-relnotes --username=${username} --password=${password} --product-set="Red Hat Virtualization" \
+relnotes --product-set="Red Hat Virtualization" \
          --flags=rhevm-${release}.z?,rhevm-${release}.z+,ovirt-${release}?,ovirt-${release}+ \
          --file=topics/ref-${milestone}.adoc --milestones=${milestone} \
          --releases= --verbose --force --section --asciidoc --include-all --next \
@@ -101,7 +74,7 @@ echo -e "Updating the \e[1m$MASTER\e[0m file.\n"
 
 cat >> $MASTER <<EOF
 
-include::topics/ref-${milestone}.adoc[]
+include::topics/ref-${milestone}.adoc[leveloffset=+1]
 
 EOF
 


### PR DESCRIPTION
Removing prompts for username and password in the downstream RN scripts because BZ uses API key.

