### PR TITLE
BZ#2059877 add --nobest switch to yum update command in RHVM upgrade 

### DIFF
--- a/source/documentation/common/upgrade/proc-Updating_the_Red_Hat_Virtualization_Manager.adoc
+++ b/source/documentation/common/upgrade/proc-Updating_the_Red_Hat_Virtualization_Manager.adoc
@@ -97,7 +97,7 @@ The update process might take some time. Do not stop the process before it compl
 . Update the base operating system and any optional packages installed on the {engine-name}:
 +
 ----
-# yum update
+# yum update --nobest
 ----
 +
 [IMPORTANT]


### PR DESCRIPTION
[ Bug fix]

Fixes issue # | \[BZ#2059877](https://bugzilla.redhat.com/show_bug.cgi?id=2059877)  (delete if not relevant)

Changes proposed in this pull request:

-add --nobest switch to yum update command in RHVM upgrade

Previews: 
https://ovirt.github.io/ovirt-site/previews/2875/documentation/upgrade_guide/index.html#Updating_the_Red_Hat_Virtualization_Manager_4-3_remote_db
https://ovirt.github.io/ovirt-site/previews/2875/documentation/upgrade_guide/index.html#Updating_the_Red_Hat_Virtualization_Manager_4-2_remote_db
https://ovirt.github.io/ovirt-site/previews/2875/documentation/upgrade_guide/index.html#Updating_the_Red_Hat_Virtualization_Manager_4-4_SHE
https://ovirt.github.io/ovirt-site/previews/2875/documentation/upgrade_guide/index.html#Updating_the_Red_Hat_Virtualization_Manager_4-3_SHE
https://ovirt.github.io/ovirt-site/previews/2875/documentation/upgrade_guide/index.html#Updating_the_Red_Hat_Virtualization_Manager_4-2_SHE
https://ovirt.github.io/ovirt-site/previews/2875/documentation/upgrade_guide/index.html#Updating_the_Red_Hat_Virtualization_Manager_minor_updates

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @emarcusRH )

This pull request needs review by: (please @dcdacosta )
