### PR TITLE
BZ#2060085  remove deprecated RHV Host build RHEL 8 from Rel Notes table

### DIFF
--- a/source/documentation/doc-Release_Notes/topics/Additional_Packages_from_Red_Hat_Network.adoc
+++ b/source/documentation/doc-Release_Notes/topics/Additional_Packages_from_Red_Hat_Network.adoc
@@ -12,7 +12,6 @@ The packages provided in the following repositories are not required to install 
 |`{enterprise-linux} Server` |`{enterprise-linux} 7 Server - RH Common (v.7 Server for x86_64)` |`rhel-7-server-rh-common-rpms` |Provides the `ovirt-guest-agent-common` package for {enterprise-linux} 7, which enables monitoring virtual machine resources on {enterprise-linux} 7 clients.
 |`{enterprise-linux} Server` |`Red Hat Enterprise Virt Agent (v.6 Server for x86_64)` |`rhel-6-server-rhv-4-agent-rpms` |Provides the `ovirt-guest-agent-common` package for {enterprise-linux} 6, which enables monitoring virtual machine resources on {enterprise-linux} 6 clients.
 |`{enterprise-linux} Server` |`Red Hat Enterprise Virt Agent (v.5 Server for x86_64)` |`rhel-5-server-rhv-4-agent-rpms` |Provides the `rhevm-guest-agent` package for {enterprise-linux} 5, which enables monitoring virtual machine resources on {enterprise-linux} 5 clients.
-|`{enterprise-linux} Server` |`{hypervisor-fullname} Build for RHEL 8 x86_64` |`rhvh-4-build-for-rhel-8-x86_64-rpms`​ | Provides the `rhevm-guest-agent` package for {enterprise-linux} 8 clients.
 |`Cinderlib for x86_64` |`Cinderlib option`​ | `openstack-16-cinderlib-for-rhel-8-x86_64-rpms` | Provides `cinderlib` libraries for Cinderlib support in {virt-product-fullname}.
 |`Cinderlib for IBM POWER LE`| `Cinderlib option for Power LE` | `openstack-16-cinderlib-for-rhel-8-ppc64le-rpms` | Provides `cinderlib` libraries for Cinderlib support in {virt-product-fullname}.
 |===


### PR DESCRIPTION
… RHV Host Build for RHEL 8

[ Bug fix]

Fixes issue # | \[BZ#2060085](https://bugzilla.redhat.com/show_bug.cgi?id=2060085) 
Changes proposed in this pull request:

-remove row in additional packages table - RHV Host build for RHEL 8

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @emarcusRH )

This pull request needs review by: (please @mention the reviewer if relevant)
