### PR TITLE
BZ#2080192 remove extra space from command Disabling DWH Service

### DIFF
--- a/source/documentation/common/database/proc-disabling-the-data-warehouse-service.adoc
+++ b/source/documentation/common/database/proc-disabling-the-data-warehouse-service.adoc
@@ -36,7 +36,7 @@
 +
 [source,terminal,subs="normal"]
 ----
-# rm -f /etc/ovirt-engine-dwh/ovirt-engine-dwhd.conf.d/* .conf /var/lib/ovirt-engine-dwh/backups/*
+# rm -f /etc/ovirt-engine-dwh/ovirt-engine-dwhd.conf.d/*.conf /var/lib/ovirt-engine-dwh/backups/*
 ----
 
 The Data Warehouse service is now hosted on a separate machine from the {engine-name}.

--- a/source/documentation/common/database/proc-disabling-the-data-warehouse-service.adoc
+++ b/source/documentation/common/database/proc-disabling-the-data-warehouse-service.adoc
@@ -36,7 +36,7 @@
 +
 [source,terminal,subs="normal"]
 ----
-# rm -f /etc/ovirt-engine-dwh/ovirt-engine-dwhd.conf.d/*.conf /var/lib/ovirt-engine-dwh/backups/*
+# rm -f /etc/ovirt-engine-dwh/ovirt-engine-dwhd.conf.d/\*.conf /var/lib/ovirt-engine-dwh/backups/*
 ----
 
 The Data Warehouse service is now hosted on a separate machine from the {engine-name}.


### PR DESCRIPTION
[Feature | Bug fix]

Fixes issue # | \[BZ#2080192](https://bugzilla.redhat.com/show_bug.cgi?id=2080192)  (delete if not relevant)

Changes proposed in this pull request:
Removed extra space in the command for disabling DWH service - but needed to add escape character (backslash) in the ASCIIDOC so that the asterisk is not ignored, and the line is not rendered as bold text.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @emarcusRH )

This pull request needs review by: (please @mention the reviewer if relevant)
