### PR TITLE
community: point to github

### DIFF
--- a/source/community/index.md
+++ b/source/community/index.md
@@ -48,7 +48,8 @@ Before getting started, please read our [community etiquette guidelines](/commun
 
 ## Developers
 
-If you'd like to contribute code to oVirt, visit the [Developer section](/develop/) of the site for guidelines. All of our projects use git. Most are hosted at [https://gerrit.ovirt.org/](https://gerrit.ovirt.org/), and the rest are hosted at [https://github.com/oVirt](https://github.com/oVirt/).
+If you'd like to contribute code to oVirt, visit the [Developer section](/develop/) of the site for guidelines.
+All of our projects use git and are hosted at [https://github.com/oVirt](https://github.com/oVirt/).
 
 We also have an [overview](https://github.com/oVirt/ovirt-site/blob/dashpanel/dashpanel-ovirt.md) of all open issues and PRs for oVirt on GitHub.
 


### PR DESCRIPTION
Changes proposed in this pull request:

- previously we were saying we develop most of the projects on gerrit. We are now on GitHub.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @oVirt/developers 
