### PR TITLE
REST_API_Guide: fix duplicate ids

### DIFF
--- a/source/documentation/doc-REST_API_Guide/model.adoc
+++ b/source/documentation/doc-REST_API_Guide/model.adoc
@@ -3076,7 +3076,7 @@ This section enumerates all the requests that are available in the API.
 * <<services-permission-methods-get,GET>> /<<services-vnic_profiles,vnicprofiles>>/<<services-vnic_profile,{profile:id}>>/<<services-assigned_permissions,permissions>>/<<services-permission,{permission:id}>>
 * <<services-permission-methods-remove,DELETE>> /<<services-vnic_profiles,vnicprofiles>>/<<services-vnic_profile,{profile:id}>>/<<services-assigned_permissions,permissions>>/<<services-permission,{permission:id}>>
 
-[id="services"]
+
 == Services
 
 This section enumerates all the services that are available in the API.
@@ -33582,7 +33582,6 @@ of the current request. See <<documents-003_common_concepts-follow, here>> for d
 
 Sets the maximum number of weights to return. If not specified all the weights are returned.
 
-[id="types"]
 == Types
 
 This section enumerates all the data types that are available in the API.


### PR DESCRIPTION
Bug fix

Changes proposed in this pull request:

Fixes:
- asciidoctor: WARNING: model.adoc: line 3080: id assigned to section already in use: services
- asciidoctor: WARNING: model.adoc: line 33586: id assigned to section already in use: types

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @oVirt/ovirt-documentation 
