### PR TITLE
BZ2066055 - updated partition sizes in host storage reqs info

### DIFF
--- a/source/documentation/common/prereqs/ref-Host_Storage_Requirements.adoc
+++ b/source/documentation/common/prereqs/ref-Host_Storage_Requirements.adoc
@@ -16,7 +16,7 @@ The minimum storage requirements for host installation are listed below. However
 * /home - 1 GB
 * /tmp - 1 GB
 * /boot - 1 GB
-* /var - 15 GB
+* /var - 5 GB
 * /var/crash - 10 GB
 * /var/log - 8 GB
 * /var/log/audit - 2 GB
@@ -24,6 +24,6 @@ The minimum storage requirements for host installation are listed below. However
 * Anaconda reserves 20% of the thin pool size within the volume group for future metadata expansion. This is to prevent an out-of-the-box configuration from running out of space under normal usage conditions. Overprovisioning of thin pools during installation is also not supported.
 * *Minimum Total - 64 GiB*
 
-If you are also installing the {engine-appliance-name} for self-hosted engine installation, `/var/tmp` must be at least 8 GB.
+If you are also installing the {engine-appliance-name} for self-hosted engine installation, `/var/tmp` must be at least 10 GB.
 
 If you plan to use memory overcommitment, add enough swap space to provide virtual memory for all of virtual machines. See link:{URL_virt_product_docs}{URL_format}administration_guide/index#Memory_Optimization[Memory Optimization].

--- a/source/documentation/common/prereqs/ref-Host_Storage_Requirements.adoc
+++ b/source/documentation/common/prereqs/ref-Host_Storage_Requirements.adoc
@@ -20,6 +20,7 @@ The minimum storage requirements for host installation are listed below. However
 * /var/crash - 10 GB
 * /var/log - 8 GB
 * /var/log/audit - 2 GB
+* /var/tmp - 10 GB
 * swap - 1 GB (for the recommended swap size, see link:https://access.redhat.com/solutions/15244[])
 * Anaconda reserves 20% of the thin pool size within the volume group for future metadata expansion. This is to prevent an out-of-the-box configuration from running out of space under normal usage conditions. Overprovisioning of thin pools during installation is also not supported.
 * *Minimum Total - 64 GiB*


### PR DESCRIPTION
[Bug fix]

Fixes issue https://bugzilla.redhat.com/show_bug.cgi?id=2066055

Changes proposed in this pull request:

- Changed /var to 5GB and  /var/tmp to 10GB

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (@dcdacosta )

This pull request needs review by: (@sandrobonazzola )
