### PR TITLE
BZ#2056937  move ovirt scheduler proxy and RHVM appliance from Deprecated to Removed

### DIFF
--- a/source/documentation/doc-Release_Notes/topics/ref-Deprecated_Features_RHV.adoc
+++ b/source/documentation/doc-Release_Notes/topics/ref-Deprecated_Features_RHV.adoc
@@ -19,9 +19,6 @@ The following table describes deprecated features to be removed in a future vers
 |===
 |Deprecated Feature |Details
 
-|Red Hat Virtualization Manager (RHVM) appliance |The Red Hat Virtualization Manager (RHVM) appliance is being retired. The last supported build of the RHVM appliance will be shipped with the release of Red Hat Virtualization 4.4 SP1.
-Following the Red Hat Virtualization 4.4 SP1 release, you can update the RHVM by running the dnf update command followed by engine-setup after connecting to the Content Delivery Network.
-
 |OpenStack Glance |Support for OpenStack Glance is now deprecated. This functionality will be removed in a future release.
 
 |Ruby software development kit (SDK) |The Ruby SDK is now deprecated. This functionality will be removed in a future release.
@@ -52,8 +49,6 @@ In {virt-product-fullname} 4.4, some tasks may still require the ISO domain.
 | SSO for virtual machines | Since the ovirt-guest-agent package was deprecated, Single Sign-On (SSO) is deprecated for virtual machines running {enterprise-linux} version 7 or earlier.
 
  SSO is not supported for virtual machines running {enterprise-linux} 8 or later, or for Windows operating systems.
-
-|oVirt Scheduler Proxy | ovirt-scheduler-proxy is deprecated. Development has been discontinued. It will be removed in a future release.
 
 |GlusterFS Storage | GlusterFS Storage is deprecated, and will no longer be supported in future releases.
 

--- a/source/documentation/doc-Release_Notes/topics/ref-Removed_Features_RHV.adoc
+++ b/source/documentation/doc-Release_Notes/topics/ref-Removed_Features_RHV.adoc
@@ -61,9 +61,12 @@ Removing this neither affects the ability to manage {virt-product-fullname} virt
 
 | Cockpit installation for Self-hosted engine| Using Cockpit to install the self-hosted engine is no longer supported. Use the command line installation.
 
-// | oVirt Scheduler Proxy | The `ovirt-scheduler-proxy` package is removed in {virt-product-fullname} 4.4 SP1.
+| oVirt Scheduler Proxy | The ovirt-scheduler-proxy package is removed in {virt-product-fullname} 4.4 SP1.
 
 |Ruby software development kit (SDK) |The Ruby SDK is no longer supported.
 
 |systemtap |The `systemtap` package is no longer supported on {hypervisor-shortname} {vername_rhv}.
+
+|Red Hat Virtualization Manager (RHVM) appliance |With this release, the Red Hat Virtualization Manager (RHVM) appliance is being retired. Following this release, you can update the RHVM by running the dnf update command followed by engine-setup after connecting to the Content Delivery Network.
+
 |===


### PR DESCRIPTION
…eprecated, now both in Removed Functionality table

[Feature | Bug fix]

Fixes issue # | \[BZ#2056937](https://bugzilla.redhat.com/show_bug.cgi?id=2056937)  (delete if not relevant)

Changes proposed in this pull request:

- move ovirt scheduler proxy and RHVM appliance from Deprecated to Removed-

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @emarcusRH )

This pull request needs review by: (please @mention the reviewer if relevant)
