### PR TITLE
networking - fix typo in port mirroring limitations

### DIFF
--- a/source/documentation/doc-Technical_Reference/topics/Port_Mirroring.adoc
+++ b/source/documentation/doc-Technical_Reference/topics/Port_Mirroring.adoc
@@ -9,7 +9,7 @@ The only traffic copied is internal to one logical network on one host. There is
 Port mirroring is enabled or disabled in the vNIC profiles of logical networks, and has the following limitations:
 
 
-* Hot plugging vNICs with a profile that has port mirroring enabled is not supported.
+* Hot linking vNICs with a profile that has port mirroring enabled is not supported.
 
 * Port mirroring cannot be altered when the vNIC profile is attached to a virtual machine.
 


### PR DESCRIPTION
Hot linking vNICs with a profile that has port mirroring enabled is not
supported, and not hot plugging.

Signed-off-by: Eitan Raviv <eraviv@redhat.com>
Change-Id: I6e43ec7b91964cfefc6984f70588a0d7d6881990

[Feature | Bug fix]

Fixes issue # | \[BZ number or name](Bugzilla_URL)  (delete if not relevant)

Changes proposed in this pull request:

-

-

-

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @mention yourself to sign)

This pull request needs review by: (please @mention the reviewer if relevant)
