### PR TITLE
BZ#2041216 add note regarding Grafana dashboard direct links to Admin Portal

### DIFF
--- a/source/documentation/administration_guide/topics/Grafana_dashboards.adoc
+++ b/source/documentation/administration_guide/topics/Grafana_dashboards.adoc
@@ -48,7 +48,7 @@ The following dashboards are available in the initial Grafana setup to report Da
 
 [NOTE]
 ====
-The Grafana dashboards includes direct links to the {virt-product-fullname}, allowing you to quickly view additional details for your clusters, hosts, and virtual machines. 
+The Grafana dashboards includes direct links to the {virt-product-fullname} Administration Portal, allowing you to quickly view additional details for your clusters, hosts, and virtual machines. 
 ====
 
 

--- a/source/documentation/administration_guide/topics/Grafana_dashboards.adoc
+++ b/source/documentation/administration_guide/topics/Grafana_dashboards.adoc
@@ -48,7 +48,7 @@ The following dashboards are available in the initial Grafana setup to report Da
 
 [NOTE]
 ====
-The Grafana dashboards includes direct links to the Red Hat Virtualization Administration Portal, allowing you to quickly view additional details for your clusters, hosts, and virtual machines. 
+The Grafana dashboards includes direct links to the {virt-product-fullname}, allowing you to quickly view additional details for your clusters, hosts, and virtual machines. 
 ====
 
 

--- a/source/documentation/administration_guide/topics/Grafana_dashboards.adoc
+++ b/source/documentation/administration_guide/topics/Grafana_dashboards.adoc
@@ -46,6 +46,12 @@ The following dashboards are available in the initial Grafana setup to report Da
 |===
 
 
+[NOTE]
+====
+The Grafana dashboards includes direct links to the Red Hat Virtualization Administration Portal, allowing you to quickly view additional details for your clusters, hosts, and virtual machines. 
+====
+
+
 = Customized Grafana dashboards
 
 You can create customized dashboards or copy and modify existing dashboards according to your reporting needs.


### PR DESCRIPTION
Fixes issue # | \[BZ#2041216](https://bugzilla.redhat.com/show_bug.cgi?id=2041216)  (delete if not relevant)

Changes proposed in this pull request:

- add note regarding Grafana dashboard direct links to Admin Portal
Preview link - https://ovirt.github.io/ovirt-site/previews/2917/documentation/administration_guide/index.html#Grafana_dashboards

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @emarcusRH )

This pull request needs review by: (please @mention the reviewer if relevant)
