### PR TITLE
BZ#2064259 adding 2 params / removing 2 params in DWH virtual disk stats table

### DIFF
--- a/source/documentation/data_warehouse_guide/topics/Virtual_machine_disk_hourly_and_samples_history_views.adoc
+++ b/source/documentation/data_warehouse_guide/topics/Virtual_machine_disk_hourly_and_samples_history_views.adoc
@@ -34,8 +34,6 @@
 |write_rate_bytes_per_second |integer |Write rate to disk in bytes per second. |No
 |max_read_latency_seconds |numeric(18,9) |The maximum read latency for the aggregation period, measured in seconds. For hourly aggregations, this is the maximum collected sample value. For daily aggregations, it is the maximum hourly average value. |No
 |max_write_rate_bytes_per_second |integer |The maximum write rate for the aggregation period. For hourly aggregations, this is the maximum collected sample value. For daily aggregations, it is the maximum hourly average value. |No
-|write_ops_per_second |bigint |The number of write I/O operations per second to disk.
-|No
 |write_ops_total_count |numeric(20,0) |Write I/O operations to disk since vm start.
 |No
 |write_latency_seconds |numeric(18,9) |The virtual disk write latency measured in seconds. |No

--- a/source/documentation/data_warehouse_guide/topics/Virtual_machine_disk_hourly_and_samples_history_views.adoc
+++ b/source/documentation/data_warehouse_guide/topics/Virtual_machine_disk_hourly_and_samples_history_views.adoc
@@ -28,8 +28,6 @@
 |vm_disk_actual_size_mb |integer |The actual size allocated to the disk. |No
 |read_rate_bytes_per_second |integer |Read rate to disk in bytes per second. |No
 |max_read_rate_bytes_per_second |integer |The maximum read rate for the aggregation period. For hourly aggregations, this is the maximum collected sample value. For daily aggregations, it is the maximum hourly average value. |No
-|read_ops_per_second |bigint |The number of read I/O operations per second to disk.
-|No
 |read_ops_total_count |numeric(20,0) |Read I/O operations to disk since vm start.
 |No
 |read_latency_seconds |numeric(18,9) |The virtual disk read latency measured in seconds. |No

--- a/source/documentation/data_warehouse_guide/topics/Virtual_machine_disk_hourly_and_samples_history_views.adoc
+++ b/source/documentation/data_warehouse_guide/topics/Virtual_machine_disk_hourly_and_samples_history_views.adoc
@@ -30,7 +30,7 @@
 |max_read_rate_bytes_per_second |integer |The maximum read rate for the aggregation period. For hourly aggregations, this is the maximum collected sample value. For daily aggregations, it is the maximum hourly average value. |No
 |read_ops_per_second |bigint |The number of read I/O operations per second to disk.
 |No
-|max_read_ops_per_second |bigint |The maximum number of read I/O operations per second for the aggregation period. For hourly aggregations, this is the maximum collected sample value. For daily aggregations, it is the maximum hourly average value.
+|read_ops_total_count |numeric(20,0) |Read I/O operations to disk since vm start.
 |No
 |read_latency_seconds |numeric(18,9) |The virtual disk read latency measured in seconds. |No
 |write_rate_bytes_per_second |integer |Write rate to disk in bytes per second. |No
@@ -38,7 +38,7 @@
 |max_write_rate_bytes_per_second |integer |The maximum write rate for the aggregation period. For hourly aggregations, this is the maximum collected sample value. For daily aggregations, it is the maximum hourly average value. |No
 |write_ops_per_second |bigint |The number of write I/O operations per second to disk.
 |No
-|max_write_ops_per_second |bigint |The maximum number of write I/O operations per second for the aggregation period. For hourly aggregations, this is the maximum collected sample value. For daily aggregations, it is the maximum hourly average value.
+|write_ops_total_count |numeric(20,0) |Write I/O operations to disk since vm start.
 |No
 |write_latency_seconds |numeric(18,9) |The virtual disk write latency measured in seconds. |No
 |max_write_latency_seconds |numeric(18,9) |The maximum write latency for the aggregation period, measured in seconds. For hourly aggregations, this is the maximum collected sample value. For daily aggregations, it is the maximum hourly average value. |No


### PR DESCRIPTION
Fixes issue # | \[BZ #2064259](https://bugzilla.redhat.com/show_bug.cgi?id=2064259)  (delete if not relevant)

Changes proposed in this pull request:

- adding 2 params and removing 2 params in DWH virtual disk stats table
- Preview - https://ovirt.github.io/ovirt-site/previews/2918/documentation/data_warehouse_guide/index.html#Virtual_machine_disk_hourly_and_samples_history_views

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @emarcusRH )

This pull request needs review by: (please @mention the reviewer if relevant)
