### PR TITLE
BZ#1986834 and BZ#2080505 add nodejs:14 and maven to modules that are enabled

### DIFF
--- a/source/documentation/common/install/proc-Enabling_the_Red_Hat_Virtualization_Manager_Repositories.adoc
+++ b/source/documentation/common/install/proc-Enabling_the_Red_Hat_Virtualization_Manager_Repositories.adoc
@@ -152,6 +152,18 @@ ifdef::ovirt-doc[]
 # dnf module -y enable mod_auth_openidc:2.3
 ----
 endif::ovirt-doc[]
+. Enable version 14 of the `nodejs` module:
+[source,terminal,subs="normal"]
++
+----
+# dnf module -y enable nodejs:14
+----
+. Enable the `maven` module:
+[source,terminal,subs="normal"]
++
+----
+# dnf module -y enable maven
+----
 . Synchronize installed packages to update them to the latest available versions.
 +
 [source,terminal,subs="normal"]

--- a/source/documentation/common/install/proc-Enabling_the_Red_Hat_Virtualization_Manager_Repositories.adoc
+++ b/source/documentation/common/install/proc-Enabling_the_Red_Hat_Virtualization_Manager_Repositories.adoc
@@ -158,12 +158,23 @@ endif::ovirt-doc[]
 ----
 # dnf module -y enable nodejs:14
 ----
+ifdef::rhv-doc[]
 . Enable the `maven` module:
 [source,terminal,subs="normal"]
 +
 ----
-# dnf module -y enable maven
+# dnf module -y enable maven:3.5
 ----
+endif::rhv-doc[]
+ifdef::ovirt-doc[]
+. Enable the `maven` module:
+[source,terminal,subs="normal"]
++
+----
+# dnf module -y enable maven:3.6
+----
+endif::ovirt-doc[]
+
 . Synchronize installed packages to update them to the latest available versions.
 +
 [source,terminal,subs="normal"]

--- a/source/documentation/common/install/proc-Enabling_the_Red_Hat_Virtualization_Manager_Repositories.adoc
+++ b/source/documentation/common/install/proc-Enabling_the_Red_Hat_Virtualization_Manager_Repositories.adoc
@@ -122,7 +122,6 @@ You can check which repositories are currently enabled by running `dnf repolist`
 ----
 # dnf module -y enable javapackages-tools
 ----
-
 endif::ovirt-doc[]
 
 
@@ -158,6 +157,23 @@ endif::ovirt-doc[]
 ----
 # dnf module -y enable nodejs:14
 ----
+. Synchronize installed packages to update them to the latest available versions.
++
+[source,terminal,subs="normal"]
+----
+# dnf distro-sync --nobest
+----
+//ansible lock addition
+.Additional resources
+For information on modules and module streams, see the following sections in _Installing, managing, and removing user-space components_
+
+* link:{URL_rhel_docs_latest}html-single/installing_managing_and_removing_user-space_components/index#module-streams_introduction-to-modules[Module streams]
+* link:{URL_rhel_docs_latest}html-single/installing_managing_and_removing_user-space_components/index#selecting-a-stream-before-installation-of-packages_installing-rhel-8-content[Selecting a stream before installation of packages]
+* link:{URL_rhel_docs_latest}html-single/installing_managing_and_removing_user-space_components/index#resetting-module-streams_removing-rhel-8-content[Resetting module streams]
+* link:{URL_rhel_docs_latest}html-single/installing_managing_and_removing_user-space_components/index#switching-to-a-later-stream_managing-versions-of-appstream-content[Switching to a later stream]
+
+////
+//for later build
 ifdef::rhv-doc[]
 . Enable the `maven` module:
 [source,terminal,subs="normal"]
@@ -174,18 +190,4 @@ ifdef::ovirt-doc[]
 # dnf module -y enable maven:3.6
 ----
 endif::ovirt-doc[]
-
-. Synchronize installed packages to update them to the latest available versions.
-+
-[source,terminal,subs="normal"]
-----
-# dnf distro-sync --nobest
-----
-//ansible lock addition
-.Additional resources
-For information on modules and module streams, see the following sections in _Installing, managing, and removing user-space components_
-
-* link:{URL_rhel_docs_latest}html-single/installing_managing_and_removing_user-space_components/index#module-streams_introduction-to-modules[Module streams]
-* link:{URL_rhel_docs_latest}html-single/installing_managing_and_removing_user-space_components/index#selecting-a-stream-before-installation-of-packages_installing-rhel-8-content[Selecting a stream before installation of packages]
-* link:{URL_rhel_docs_latest}html-single/installing_managing_and_removing_user-space_components/index#resetting-module-streams_removing-rhel-8-content[Resetting module streams]
-* link:{URL_rhel_docs_latest}html-single/installing_managing_and_removing_user-space_components/index#switching-to-a-later-stream_managing-versions-of-appstream-content[Switching to a later stream]
+////


### PR DESCRIPTION
Fixes issue # | [BZ#1986834](https://bugzilla.redhat.com/show_bug.cgi?id=1986834)  and [BZ#2080505](https://bugzilla.redhat.com/show_bug.cgi?id=2080505)

Changes proposed in this pull request:

- add nodejs:14 and maven to modules that are enabled  in the Installation Guide and Upgrade Guide
- Preview - https://ovirt.github.io/ovirt-site/previews/2922/documentation/installing_ovirt_as_a_self-hosted_engine_using_the_command_line/index.html#Enabling_the_Red_Hat_Virtualization_Manager_Repositories_install_RHVM

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @emarcusRH )

This pull request needs review by: (please @sandrobonazzola )
