### PR TITLE
RHV44569 - Fixed title for 4.4 SP1

### DIFF
--- a/source/documentation/doc-Release_Notes/topics/ref-ovirt-4.5.0-1.adoc
+++ b/source/documentation/doc-Release_Notes/topics/ref-ovirt-4.5.0-1.adoc
@@ -1,4 +1,4 @@
-=== Red Hat Virtualization 4.5 General Availability (ovirt-4.5.0-1)
+=== Red Hat Virtualization 4.4 SP1 General Availability (ovirt-4.5.0)
 
 
 


### PR DESCRIPTION
Fixes issue with incorrect title that is auto created by the RN script
Changes proposed in this pull request:

- Changed title to reflect RHV 4.4 SP1 instead of RHV 4.5 and ovirt-4.5.0 instead of ovirt-4.5.0-1

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (@dcdacosta )
