### PR TITLE
Fixed 'ifdefs' so that snip-upgrade-considerations appears

### DIFF
--- a/source/documentation/upgrade_guide/assembly-Remote_Upgrading_from_4-3.adoc
+++ b/source/documentation/upgrade_guide/assembly-Remote_Upgrading_from_4-3.adoc
@@ -8,8 +8,10 @@
 Upgrading your environment from 4.3 to 4.4 involves the following steps:
 
 ifdef::rhv-doc[]
+
 //Upgrade considerations
 include::common/upgrade/snip-upgrade_considerations.adoc[]
+
 endif::rhv-doc[]
 
 . xref:Upgrade_Prerequisites_4-3_remote_db[Make sure you meet the prerequisites, including enabling the correct repositories.]

--- a/source/documentation/upgrade_guide/assembly-SHE_Upgrading_from_4-3.adoc
+++ b/source/documentation/upgrade_guide/assembly-SHE_Upgrading_from_4-3.adoc
@@ -8,8 +8,10 @@
 Upgrading a self-hosted engine environment from version 4.3 to 4.4 involves the following steps:
 
 ifdef::rhv-doc[]
+
 //Upgrade considerations
 include::common/upgrade/snip-upgrade_considerations.adoc[]
+
 endif::rhv-doc[]
 
 . xref:Upgrade_Prerequisites_4-3_SHE[Make sure you meet the prerequisites, including enabling the correct repositories]

--- a/source/documentation/upgrade_guide/assembly-Upgrading_from_4-3.adoc
+++ b/source/documentation/upgrade_guide/assembly-Upgrading_from_4-3.adoc
@@ -7,12 +7,13 @@
 
 Upgrading your environment from 4.3 to 4.4 involves the following steps:
 
-////
-ifdef::rvh-doc[]
+ifdef::rhv-doc[]
+
 //Upgrade considerations
 include::common/upgrade/snip-upgrade_considerations.adoc[]
+
 endif::rhv-doc[]
-////
+
 . xref:Upgrade_Prerequisites_4-3_local_db[Make sure you meet the prerequisites, including enabling the correct repositories]
 
 ifdef::rhv-doc[]

--- a/source/documentation/upgrade_guide/chap-Updates_between_Minor_Releases.adoc
+++ b/source/documentation/upgrade_guide/chap-Updates_between_Minor_Releases.adoc
@@ -24,11 +24,10 @@ If upgrading from version 4.4.9 to a later version fails on {hypervisor-shortnam
 endif::ovirt-doc[]
 
 ifdef::rhv-doc[]
+
 //Upgrade considerations
 include::common/upgrade/snip-upgrade_considerations.adoc[]
-endif::rhv-doc[]
 
-ifdef::rhv-doc[]
 include::common/upgrade/proc-Analyzing_the_Environment.adoc[leveloffset=+1]
 endif::rhv-doc[]
 


### PR DESCRIPTION
@erav Reported that the snippet "Upgrade Considerations" did not appear in the published RHV docs.

This PR fixes the "snip-upgrade-considerations" not displaying correctly and a typo in one of the "ifdefs".

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @apinnick 


