### PR TITLE
Rhv 46139  fix index.haml for upstream doc portal

### DIFF
--- a/source/documentation/index.haml
+++ b/source/documentation/index.haml
@@ -28,7 +28,7 @@ hide_metadata: true
       - [Upgrade Guide](/documentation/upgrade_guide/index.html)
       - [Administration Guide](/documentation/administration_guide/index.html)
       - [Virtual Machine Management Guide](/documentation/virtual_machine_management_guide/index.html)
-      - [Introduction to the VM Portal](/documentation/introduction_to_the_vm_portal/index.html)
+      - [Introduction to the VM Portal](/documentation/doc-Introduction_to_the_VM_Portal/index.html)
       - [Data Warehouse Guide](/documentation/data_warehouse_guide/index.html)
       - [Disaster Recovery Guide](/documentation/disaster_recovery_guide/index.html)
       - [Overview of Networking in oVirt](/develop/networking/networking-overview/index.html)


### PR DESCRIPTION
 fix index.haml for upstream doc portal - redirect to correct doc folder

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): (please @emarcusRH )

This pull request needs review by: (please @mention the reviewer if relevant)
