### PR TITLE
config: adjust for doc-Introduction_to_the_VM_Portal

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -152,8 +152,8 @@ exclude:
   - documentation/disaster_recovery_guide/concept
   - documentation/disaster_recovery_guide/reference
   - documentation/disaster_recovery_guide/task
-  - documentation/introduction_to_the_vm_portal/topics
-  - documentation/introduction_to_the_vm_portal/chap*
+  - documentation/doc-Introduction_to_the_VM_Portal/topics
+  - documentation/doc-Introduction_to_the_VM_Portal/chap*
   - documentation/upgrade_guide/assembly*
   - documentation/upgrade_guide/chap-*
   - documentation/upgrade_guide/topics


### PR DESCRIPTION
Fixes issue #2956

Changes proposed in this pull request:

`doc-Introduction_to_the_VM_Portal` has been introduced obsoleting `introduction_to_the_vm_portal` which is going to be dropped via #2955.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @oVirt/ovirt-documentation 
