### PR TITLE
_config: fix typo in config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -172,7 +172,7 @@ exclude:
   - documentation/doc-Technical_Notes/**
 sass:
   add_charset: true
-  style: :compressed
+  style: compressed
 
 font-awesome:
   assets: true


### PR DESCRIPTION
Bug fix

Changes proposed in this pull request:

- `:compressed` is not a valid value, dropped the `:` which seems to be a typo.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @duck-rh 
