### PR TITLE
fix missing common in introduction_to_the_vm_portal

### DIFF
--- a/source/dropped/introduction_to_the_vm_portal/common
+++ b/source/dropped/introduction_to_the_vm_portal/common
@@ -1,0 +1,1 @@
+../../documentation/common


### PR DESCRIPTION
Bug fix

Changes proposed in this pull request:

- recently moved introduction_to_the_vm_portal missed the symlink to common content. Re-added.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @oVirt/ovirt-documentation 
