### PR TITLE
config: exclude adoc from dropped dir

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -170,6 +170,9 @@ exclude:
   - documentation/doc-Planning_and_Prerequisites_Guide/topics
   - documentation/doc-Planning_and_Prerequisites_Guide/asm-*
   - documentation/doc-Technical_Notes/**
+  - dropped/introduction_to_the_vm_portal/common/**/*.adoc
+  - dropped/introduction_to_the_vm_portal/topics
+  - dropped/introduction_to_the_vm_portal/chap*
 sass:
   add_charset: true
   style: :compressed


### PR DESCRIPTION
Bug fix

Changes proposed in this pull request:

- excluding adoc previously excluded by documentation directory regular expressions also in the dropped directory after docs content moved there.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @sandrobonazzola 

