### PR TITLE
Fix Installing Console Components section

### DIFF
--- a/source/documentation/virtual_machine_management_guide/topics/Installing_Remote_Viewer_on_Windows.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Installing_Remote_Viewer_on_Windows.adoc
@@ -10,6 +10,7 @@ The Remote Viewer application provides users with a graphical console for connec
 . Open a web browser and download one of the following installers according to the architecture of your system.
 
 
+ifdef::rhv-doc[]
 * Virt Viewer for 32-bit Windows:
 +
 [source,terminal,subs="normal"]
@@ -23,6 +24,18 @@ https://_your-manager-fqdn_/ovirt-engine/services/files/spice/virt-viewer-x86.ms
 ----
 https://_your-manager-fqdn_/ovirt-engine/services/files/spice/virt-viewer-x64.msi
 ----
+endif::rhv-doc[]
+
+ifdef::ovirt-doc[]
+* Virt Viewer download page:
++
+[source,terminal,subs="normal"]
+----
+ link:https://virt-manager.org/download/[https://virt-manager.org/download/]
+----
+
+endif::ovirt-doc[]
+
 
 . Open the folder where the file was saved.
 . Double-click the file.

--- a/source/documentation/virtual_machine_management_guide/topics/Installing_Remote_Viewer_on_Windows.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Installing_Remote_Viewer_on_Windows.adoc
@@ -27,15 +27,10 @@ https://_your-manager-fqdn_/ovirt-engine/services/files/spice/virt-viewer-x64.ms
 endif::rhv-doc[]
 
 ifdef::ovirt-doc[]
-* Virt Viewer download page:
-+
-[source,terminal,subs="normal"]
-----
- link:https://virt-manager.org/download/[https://virt-manager.org/download/]
-----
+
+* link:https://virt-manager.org/download/[Virt Viewer download page]
 
 endif::ovirt-doc[]
-
 
 . Open the folder where the file was saved.
 . Double-click the file.

--- a/source/documentation/virtual_machine_management_guide/topics/Installing_usbdk_on_Windows.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Installing_usbdk_on_Windows.adoc
@@ -26,12 +26,8 @@ https://_[your manager's address]_/ovirt-engine/services/files/spice/usbdk-x64.m
 endif::rhv-doc[]
 
 ifdef::ovirt-doc[]
-* `usbdk` download page:
-+
-[source,terminal,subs="normal"]
-----
- link:https://www.spice-space.org/download.html[https://www.spice-space.org/download.html]
-----
+
+* link:https://www.spice-space.org/download.html[`usbdk` download page]
 
 endif::ovirt-doc[]
 

--- a/source/documentation/virtual_machine_management_guide/topics/Installing_usbdk_on_Windows.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Installing_usbdk_on_Windows.adoc
@@ -9,7 +9,7 @@
 
 . Open a web browser and download one of the following installers according to the architecture of your system.
 
-
+ifdef::rhv-doc[]
 * `usbdk` for 32-bit Windows:
 +
 [source,terminal,subs="normal"]
@@ -23,6 +23,17 @@ https://_[your manager's address]_/ovirt-engine/services/files/spice/usbdk-x86.m
 ----
 https://_[your manager's address]_/ovirt-engine/services/files/spice/usbdk-x64.msi
 ----
+endif::rhv-doc[]
+
+ifdef::ovirt-doc[]
+* `usbdk` download page:
++
+[source,terminal,subs="normal"]
+----
+ link:https://www.spice-space.org/download.html[https://www.spice-space.org/download.html]
+----
+
+endif::ovirt-doc[]
 
 . Open the folder where the file was saved.
 . Double-click the file.


### PR DESCRIPTION
Bug fix

Fixes issue #2772

Changes proposed in this pull request:

- Fix `Installing Console Components` section within `Virtual Machine Management Guide` for oVirt,
  pointing to the upstream download pages for virt-manager adn usbdk.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @oVirt/ovirt-documentation 
