### PR TITLE
BZ2108055: remove "dual stack not supported" notes

### DIFF
--- a/source/documentation/administration_guide/topics/Editing_Host_Network_Interfaces_and_Assigning_Logical_Networks_to_Hosts.adoc
+++ b/source/documentation/administration_guide/topics/Editing_Host_Network_Interfaces_and_Assigning_Logical_Networks_to_Hosts.adoc
@@ -63,12 +63,14 @@ If you change the host's management network IP address, you must xref:Reinstalli
 
 Each logical network can have a separate gateway defined from the management network gateway. This ensures traffic that arrives on the logical network will be forwarded using the logical network's gateway instead of the default gateway used by the management network.
 ====
+ifdef::rhv-doc[]
 +
 [IMPORTANT]
 ====
 Set *all* hosts in a cluster to use the same IP stack for their management network; either IPv4 or IPv6 only. Dual stack is not supported.
 ====
-+
+endif::[]
+
 .. Use the *QoS* tab to override the default host network quality of service. Select *Override QoS* and enter the desired values in the following fields:
 
 * *Weighted Share*: Signifies how much of the logical link's capacity a specific network should be allocated, relative to the other networks attached to the same logical link. The exact share depends on the sum of shares of all networks on that link. By default this is a number in the range 1-100.

--- a/source/documentation/doc-Release_Notes/topics/ref-Technology_Preview_Features_RHV.adoc
+++ b/source/documentation/doc-Release_Notes/topics/ref-Technology_Preview_Features_RHV.adoc
@@ -20,7 +20,7 @@ The following table describes features available as Technology Previews in {virt
 
 [NOTE]
 ====
-All hosts in the cluster must use IPv4 or IPv6 for RHV networks, not simultaneous IPv4 and IPv6, because Dual Stack is not supported.
+All hosts in the cluster must use IPv4 or IPv6 for RHV networks, not simultaneous IPv4 and IPv6, because dual stack is not supported.
 ====
 
 For details about IPv6 support, see link:{URL_virt_product_docs}{URL_format}administration_guide/index#IPv6-networking-support-labels[IPv6 Networking Support] in the Administration Guide.


### PR DESCRIPTION
Bug fix

Fixes issue [2108055](https://bugzilla.redhat.com/show_bug.cgi?id=2108055)

Changes proposed in this pull request:

- Remove "Dual stack not supported" notes for upstream only

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): @apinnick 
This pull request needs review by: @arachmani 

Upstream [preview build](https://ovirt.github.io/ovirt-site/previews/3028/documentation/administration_guide/index.html#Editing_Host_Network_Interfaces_and_Assigning_Logical_Networks_to_Hosts)