### PR TITLE
rhvddf-50 remove comment switch from sample keygen command

### DIFF
--- a/source/documentation/virtual_machine_management_guide/topics/Opening_a_Serial_Console_to_a_Virtual_Machine.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Opening_a_Serial_Console_to_a_Virtual_Machine.adoc
@@ -60,7 +60,7 @@ See link:{URL_rhel_docs_legacy}html/system_administrators_guide/ch-working_with_
 +
 [source,terminal,subs="normal"]
 ----
-# ssh-keygen -t rsa -b 2048 -C "_user@domain_" -f .ssh/serialconsolekey
+# ssh-keygen -t rsa -b 2048 -f .ssh/serialconsolekey
 ----
 This command generates a public key and a private key.
 . In the Administration Portal or the VM Portal, click the name of the signed-in user on the header bar and click *Options*. This opens the *Edit Options* window.


### PR DESCRIPTION
[RHVDDF-50]](https://issues.redhat.com/browse/RHVDDF-50)



Changes proposed in this pull request:

- RHV VMM Guide - remove comment switch from sample ssh-keygen command to avoid confusion



I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): (please @emarcusRH )

This pull request needs review by: (please @mention the reviewer if relevant)
