### PR TITLE
rhvddf-51 adding note regarding mypass password in auth keys

### DIFF
--- a/source/documentation/administration_guide/topics/Updating_SSL_certificates.adoc
+++ b/source/documentation/administration_guide/topics/Updating_SSL_certificates.adoc
@@ -38,3 +38,8 @@ Run the following commands after the `ovirt-engine-rename` command to update the
         --san=DNS:"${ENGINE_FQDN}"
   done
 ----
+
+[NOTE]
+====
+The specified `--password=mypass` parameter in this command is literally the password that needs to be used. Do not change it.
+====

--- a/source/documentation/common/upgrade/proc-Replacing_SHA-1_Certificates_with_SHA-256_Certificates.adoc
+++ b/source/documentation/common/upgrade/proc-Replacing_SHA-1_Certificates_with_SHA-256_Certificates.adoc
@@ -64,17 +64,17 @@ endif::SHE_upgrade[]
         --keep-key
 done
 ----
-
-. Restart the *httpd* service:
-+
-----
-# systemctl restart httpd
-----
 +
 [NOTE]
 ====
 The specified `--password=mypass` parameter in this command is literally the password that needs to be used. Do not change it.
 ====
+. Restart the *httpd* service:
++
+----
+# systemctl restart httpd
+----
+
 ifdef::SHE_upgrade[]
 . Log in to one of the self-hosted engine nodes and disable global maintenance:
 +

--- a/source/documentation/common/upgrade/proc-Replacing_SHA-1_Certificates_with_SHA-256_Certificates.adoc
+++ b/source/documentation/common/upgrade/proc-Replacing_SHA-1_Certificates_with_SHA-256_Certificates.adoc
@@ -70,7 +70,11 @@ done
 ----
 # systemctl restart httpd
 ----
-
++
+[NOTE]
+====
+The specified `--password=mypass` parameter in this command is literally the password that needs to be used. Do not change it.
+====
 ifdef::SHE_upgrade[]
 . Log in to one of the self-hosted engine nodes and disable global maintenance:
 +
@@ -166,7 +170,11 @@ endif::SHE_upgrade[]
         --keep-key
 done
 ----
-
++
+[NOTE]
+====
+The specified `--password=mypass` parameter in this command is literally the password that needs to be used. Do not change it.
+====
 . Restart the following services:
 +
 ----


### PR DESCRIPTION
[[RHVDDF-51]](https://issues.redhat.com/browse/RHVDDF-51)


Changes proposed in this pull request:

-add note regarding hard coded password value in authorization keys
 - Administration Guide - Updating SSL certificates
 -  Upgrade Guide - Replacing SHA-1 with SHA-256


I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): (please @emarcusRH )

This pull request needs review by: (please @mention the reviewer if relevant)
