### PR TITLE
Fix the link in Zero-copy migrations feature page

### DIFF
--- a/source/develop/release-management/features/virt/zerocopy-migrations.md
+++ b/source/develop/release-management/features/virt/zerocopy-migrations.md
@@ -29,7 +29,7 @@ Nothing special, just up-to-date libvirt and QEMU.
 
 Current implementation of zero-copy migration in QEMU has some restrictions:
 
-- It can be used only with [parallel migrations](parallel-migrations.html) and thus the same limitations as for parallel migrations apply.
+- It can be used only with [parallel migrations](parallel-migration-connections.html) and thus the same limitations as for parallel migrations apply.
 
 - It cannot be used with migration encryption.
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix the broken link to parallel migrations feature page.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): @mz-pdm 
