### PR TITLE
Adding Ubuntu 22.04 Jammy info

### DIFF
--- a/source/develop/troubleshooting-nfs-storage-issues.md
+++ b/source/develop/troubleshooting-nfs-storage-issues.md
@@ -11,6 +11,7 @@ authors:
   - sgordon
   - suppentopf
   - wdennis
+  - Phurion
 ---
 
 # Troubleshooting NFS Storage Issues
@@ -105,6 +106,16 @@ A new **nfs-check** script is now available to test whether an NFS export is rea
      /storage    *(rw)
 
      #>/etc/init.d/nfs-kernel-server restart
+```
+#### Ubuntu 22.04 (Jammy)
+In addition to what is above you will need to edit the file /etc/nfs.conf and comment out manage-gids=y
+```console
+      [mountd]
+      # manage-gids=y
+ ```
+Restart the service
+ ```console
+      /etc/init.d/nfs-kernel-server restart
 ```
 
 #### Fedora 26 or higher

--- a/source/develop/troubleshooting-nfs-storage-issues.md
+++ b/source/develop/troubleshooting-nfs-storage-issues.md
@@ -113,9 +113,14 @@ In addition to what is above you will need to edit the file /etc/nfs.conf and co
       [mountd]
       # manage-gids=y
  ```
-Restart the service
+ Edit /etc/default/nfs-kernel-server and remove --manage-gids from RPCMOUNTDOPTS="--manage-gids"
  ```console
-      /etc/init.d/nfs-kernel-server restart
+      RPCMOUNTDOPTS=""
+ ```
+Restart the services
+ ```console
+      systemctl restart nfs-kernel-server
+      systemctl restart rpcbind
 ```
 
 #### Fedora 26 or higher


### PR DESCRIPTION
Added information about what is required for NFS to work with Ubuntu 22.04 ( Jammy )

[Feature]

Changes proposed in this pull request:

- Added information needed to allow Ubuntu 22.04 (Jammy) nfs-kernel-server to work with oVirt

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): (please @mention yourself to sign)

This pull request needs review by: (please @mention the reviewer if relevant)
