### PR TITLE
BZ#2021874 add manual engine renaming procedure for remote DWH deploy

### DIFF
--- a/source/documentation/administration_guide/topics/Renaming_the_Manager_with_the_Ovirt_Engine_Rename_Tool.adoc
+++ b/source/documentation/administration_guide/topics/Renaming_the_Manager_with_the_Ovirt_Engine_Rename_Tool.adoc
@@ -59,7 +59,7 @@ Now, all new and existing self-hosted engine nodes use the new FQDN.
 
 [NOTE]
 ====
-The oVirt Engine Rename Tool is designed to work only on local machines. Changing the engine name does not automatically update the name on remote Data Warehouse machines. Changing the names on remote DWH machines must be performed manually.
+The oVirt Engine Rename Tool is designed to work only on local machines. Changing the {engine-name} name does not automatically update the name on remote Data Warehouse machines. Changing the names on remote DWH machines must be performed manually.
 ====
 
 *For remote Data Warehouse deployments, follow these steps on the remote machine (not on the {engine-name} machine):*

--- a/source/documentation/administration_guide/topics/Renaming_the_Manager_with_the_Ovirt_Engine_Rename_Tool.adoc
+++ b/source/documentation/administration_guide/topics/Renaming_the_Manager_with_the_Ovirt_Engine_Rename_Tool.adoc
@@ -62,13 +62,13 @@ Now, all new and existing self-hosted engine nodes use the new FQDN.
 The oVirt Engine Rename Tool is designed to work only on local machines. Changing the engine name does not automatically update the name on remote Data Warehouse machines. Changing the names on remote DWH machines must be performed manually.
 ====
 
-*For remote Data Warehouse deployments, follow these steps on the remote machine:*
+*For remote Data Warehouse deployments, follow these steps on the remote machine (not on the {engine-name} machine):*
 
 . Remove the following PKI files:
 +
 `/etc/pki/ovirt-engine/apache-ca.pem`
 `/etc/pki/ovirt-engine/apache-grafana-ca.pem`
-`/etc/pki/ovirt-engine/certs/*`
+`/etc/pki/ovirt-engine/certs/\*`
 `/etc/pki/ovirt-engine/keys/*`
 . In the following files, update the engine fqdn to the new name (for example, `vm-new-name.local_lab_server.redhat.com`):
 +

--- a/source/documentation/administration_guide/topics/Renaming_the_Manager_with_the_Ovirt_Engine_Rename_Tool.adoc
+++ b/source/documentation/administration_guide/topics/Renaming_the_Manager_with_the_Ovirt_Engine_Rename_Tool.adoc
@@ -70,12 +70,12 @@ The oVirt Engine Rename Tool is designed to work only on local machines. Changin
 `/etc/pki/ovirt-engine/apache-grafana-ca.pem`
 `/etc/pki/ovirt-engine/certs/\*`
 `/etc/pki/ovirt-engine/keys/*`
-. In the following files, update the engine fqdn to the new name (for example, `vm-new-name.local_lab_server.redhat.com`):
+. In the following files, update the {engine-name} fqdn to the new name (for example, `vm-new-name.local_lab_server.redhat.com`):
 +
 `/etc/grafana/grafana.ini`
 `/etc/ovirt-engine-dwh/ovirt-engine-dwhd.conf.d/10-setup-database.conf`
 `/etc/ovirt-engine-setup.conf.d/20-setup-ovirt-post.conf`
-. Run engine-setup with the --offline switch to prevent updates at this time:
+. Run engine-setup with the `--offline` switch to prevent updates at this time:
 +
 ----
 # engine-setup --offline

--- a/source/documentation/administration_guide/topics/Renaming_the_Manager_with_the_Ovirt_Engine_Rename_Tool.adoc
+++ b/source/documentation/administration_guide/topics/Renaming_the_Manager_with_the_Ovirt_Engine_Rename_Tool.adoc
@@ -75,8 +75,8 @@ The oVirt Engine Rename Tool is designed to work only on local machines. Changin
 `/etc/grafana/grafana.ini`
 `/etc/ovirt-engine-dwh/ovirt-engine-dwhd.conf.d/10-setup-database.conf`
 `/etc/ovirt-engine-setup.conf.d/20-setup-ovirt-post.conf`
-. Run engine-setup:
+. Run engine-setup with the --offline switch to prevent updates at this time:
 +
 ----
-# engine-setup
+# engine-setup --offline
 ----

--- a/source/documentation/administration_guide/topics/Renaming_the_Manager_with_the_Ovirt_Engine_Rename_Tool.adoc
+++ b/source/documentation/administration_guide/topics/Renaming_the_Manager_with_the_Ovirt_Engine_Rename_Tool.adoc
@@ -55,3 +55,28 @@ This command modifies the FQDN in each self-hosted engine node's local copy of [
 This command modifies the FQDN in the main copy of [filename]`/etc/ovirt-hosted-engine-ha/hosted-engine.conf` on the shared storage domain.
 
 Now, all new and existing self-hosted engine nodes use the new FQDN.
+
+
+[NOTE]
+====
+The oVirt Engine Rename Tool is designed to work only on local machines. Changing the engine name does not automatically update the name on remote Data Warehouse machines. Changing the names on remote DWH machines must be performed manually.
+====
+
+*For remote Data Warehouse deployments, follow these steps on the remote machine:*
+
+. Remove the following PKI files:
++
+`/etc/pki/ovirt-engine/apache-ca.pem`
+`/etc/pki/ovirt-engine/apache-grafana-ca.pem`
+`/etc/pki/ovirt-engine/certs/*`
+`/etc/pki/ovirt-engine/keys/*`
+. In the following files, update the engine fqdn to the new name (for example, `vm-new-name.local_lab_server.redhat.com`):
++
+`/etc/grafana/grafana.ini`
+`/etc/ovirt-engine-dwh/ovirt-engine-dwhd.conf.d/10-setup-database.conf`
+`/etc/ovirt-engine-setup.conf.d/20-setup-ovirt-post.conf`
+. Run engine-setup:
++
+----
+# engine-setup
+----


### PR DESCRIPTION
Bug fix

Fixes [BZ#2021874](https://bugzilla.redhat.com/show_bug.cgi?id=2021874)

Changes proposed in this pull request:

- add manual engine renaming procedure for remote DWH deploy


I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): @emarcusRH


