### PR TITLE
BZ#2115388 Update RHEL 8.6 version limitation 

### DIFF
--- a/source/documentation/common/prereqs/ref-Manager_Operating_System_Requirements.adoc
+++ b/source/documentation/common/prereqs/ref-Manager_Operating_System_Requirements.adoc
@@ -6,7 +6,7 @@
 // PPG
 // Install
 
-The {virt-product-fullname} {engine-name} must be installed on a base installation of {enterprise-linux} 8 that has been updated to the latest minor release.
+The {virt-product-fullname} {engine-name} must be installed on a base installation of {enterprise-linux} 8.6.
 
 Do not install any additional packages after the base installation, as they may cause dependency issues when attempting to install the packages required by the {engine-name}.
 

--- a/source/documentation/common/upgrade/proc-Manually_Updating_Hosts.adoc
+++ b/source/documentation/common/upgrade/proc-Manually_Updating_Hosts.adoc
@@ -115,7 +115,7 @@ You can see the value of the stream by entering:
 ====
 +
 .. Enable the `virt` module in the Advanced Virtualization stream with the following command:
-+
+
 include::../install/snip-Enable_virt_module.adoc[]
 +
 // END FOR RHEL HOSTS ONLY

--- a/source/documentation/common/upgrade/proc-Manually_Updating_Hosts.adoc
+++ b/source/documentation/common/upgrade/proc-Manually_Updating_Hosts.adoc
@@ -115,7 +115,7 @@ You can see the value of the stream by entering:
 ====
 +
 .. Enable the `virt` module in the Advanced Virtualization stream with the following command:
-
++
 include::../install/snip-Enable_virt_module.adoc[]
 +
 // END FOR RHEL HOSTS ONLY

--- a/source/documentation/common/upgrade/proc-Upgrading_hosts_to_4-4.adoc
+++ b/source/documentation/common/upgrade/proc-Upgrading_hosts_to_4-4.adoc
@@ -22,7 +22,7 @@ CPU-passthrough virtual machines might not migrate properly from {virt-product-s
 
 .Prerequisites
 
-* Hosts for {virt-product-shortname} 4.4 require {enterprise-linux} 8.2 or later. A clean installation of {enterprise-linux} 8.2 or later, or {hypervisor-fullname} 4.4 is required, even if you are using the same physical machine that you use to run hosts for {virt-product-shortname} 4.3.
+* Hosts for {virt-product-shortname} 4.4 require {enterprise-linux} versions 8.2 to 8.6. A clean installation of {enterprise-linux} versions 8.2 to 8.6, or {hypervisor-fullname} 4.4 is required, even if you are using the same physical machine that you use to run hosts for {virt-product-shortname} 4.3.
 * {virt-product-fullname} {engine-name} 4.4 is installed and running.
 * The compatibility level of the data center and cluster to which the hosts belong is set to 4.2 or 4.3.
 All data centers and clusters in the environment must have the cluster compatibility level set to version 4.2 or 4.3 before you start the procedure.
@@ -34,7 +34,7 @@ link:{URL_virt_product_docs}{URL_format}virtual_machine_management_guide/index#s
 
 . Put the host into maintenance mode and remove the host from the {engine-name}. For more information, see link:{URL_virt_product_docs}{URL_format}administration_guide/index#Removing_a_host[Removing a Host] in the _Administration Guide_.
 
-. Install {enterprise-linux} 8.2 or later, or {hypervisor-shortname} 4.4. For more information, see link:{URL_virt_product_docs}{URL_format}installing_{URL_product_virt}_as_a_standalone_manager_with_local_databases/index#Installing_Hosts_for_RHV_SM_localDB_deploy[Installing Hosts for {virt-product-fullname}] in one of the _Installing {virt-product-fullname}_ guides.
+. Install {enterprise-linux} 8.6, or {hypervisor-shortname} 4.4. For more information, see link:{URL_virt_product_docs}{URL_format}installing_{URL_product_virt}_as_a_standalone_manager_with_local_databases/index#Installing_Hosts_for_RHV_SM_localDB_deploy[Installing Hosts for {virt-product-fullname}] in one of the _Installing {virt-product-fullname}_ guides.
 
 . Install the appropriate packages to enable the host for {virt-product-shortname} 4.4. For more information, see link:{URL_virt_product_docs}{URL_format}installing_{URL_product_virt}_as_a_standalone_manager_with_local_databases/index#Installing_Hosts_for_RHV_SM_localDB_deploy[Installing Hosts for {virt-product-fullname}] in one of the _Installing {virt-product-fullname}_ guides.
 

--- a/source/documentation/common/upgrade/proc-Upgrading_hosts_to_4-4.adoc
+++ b/source/documentation/common/upgrade/proc-Upgrading_hosts_to_4-4.adoc
@@ -22,7 +22,7 @@ CPU-passthrough virtual machines might not migrate properly from {virt-product-s
 
 .Prerequisites
 
-* Hosts for {virt-product-shortname} 4.4 require {enterprise-linux} versions 8.2 to 8.6. A clean installation of {enterprise-linux} versions 8.2 to 8.6, or {hypervisor-fullname} 4.4 is required, even if you are using the same physical machine that you use to run hosts for {virt-product-shortname} 4.3.
+* Hosts for {virt-product-shortname} 4.4 require {enterprise-linux} versions 8.2 to 8.6. A clean installation of {enterprise-linux} 8.6, or {hypervisor-fullname} 4.4 is required, even if you are using the same physical machine that you use to run hosts for {virt-product-shortname} 4.3.
 * {virt-product-fullname} {engine-name} 4.4 is installed and running.
 * The compatibility level of the data center and cluster to which the hosts belong is set to 4.2 or 4.3.
 All data centers and clusters in the environment must have the cluster compatibility level set to version 4.2 or 4.3 before you start the procedure.

--- a/source/documentation/common/upgrade/proc-Upgrading_the_Manager_to_4-4.adoc
+++ b/source/documentation/common/upgrade/proc-Upgrading_the_Manager_to_4-4.adoc
@@ -6,13 +6,13 @@
 // Upgrade Guide
 
 ifndef::SHE_upgrade[]
-{virt-product-fullname} {engine-name} 4.4 is only supported on {enterprise-linux} 8.2 or later. You need to do a clean installation of {enterprise-linux} 8.2 or later and {virt-product-fullname} {engine-name} 4.4, even if you are using the same physical machine that you use to run {virt-product-shortname} {engine-name} 4.3.
+{virt-product-fullname} {engine-name} 4.4 is only supported on {enterprise-linux} versions 8.2 to 8.6. You need to do a clean installation of {enterprise-linux} versions 8.2 to 8.6 and {virt-product-fullname} {engine-name} 4.4, even if you are using the same physical machine that you use to run {virt-product-shortname} {engine-name} 4.3.
 
 The upgrade process requires restoring {virt-product-fullname} {engine-name} 4.3 backup files onto the {virt-product-fullname} {engine-name} 4.4 machine.
 endif::SHE_upgrade[]
 
 ifdef::SHE_upgrade[]
-The {virt-product-fullname} {engine-name} 4.4 is only supported on {enterprise-linux} 8.2 or later. You need to do a clean installation of {enterprise-linux} 8.2 or later, or {hypervisor-fullname} on the self-hosted engine host, even if you are using the same physical machine that you use to run the {virt-product-shortname} 4.3 self-hosted engine.
+The {virt-product-fullname} {engine-name} 4.4 is only supported on {enterprise-linux} versions 8.2 to 8.6. You need to do a clean installation of {enterprise-linux} versions 8.2 to 8.6, or {hypervisor-fullname} on the self-hosted engine host, even if you are using the same physical machine that you use to run the {virt-product-shortname} 4.3 self-hosted engine.
 
 The upgrade process requires restoring {virt-product-fullname} {engine-name} 4.3 backup files onto the {virt-product-fullname} {engine-name} 4.4 virtual machine.
 endif::SHE_upgrade[]
@@ -92,7 +92,7 @@ If you want to reuse the self-hosted engine virtual machine to deploy the {virt-
 ====
 If any of the hosts report the `detail` field as `Up`, log in to that specific host and shut it down with the `hosted-engine --vm-shutdown` command.
 ====
-. Install {hypervisor-shortname} 4.4 or {enterprise-linux} 8.2 or later on the existing node currently running the {engine-name} virtual machine to use it as the self-hosted engine deployment host. See link:{URL_virt_product_docs}{URL_format}/installing_{URL_product_virt}_as_a_self-hosted_engine_using_the_command_line/index#Installing_the_self-hosted_engine_deployment_host_SHE_cli_deploy[Installing the Self-hosted Engine Deployment Host] for more information.
+. Install {hypervisor-shortname} 4.4 or {enterprise-linux} 8.6 on the existing node currently running the {engine-name} virtual machine to use it as the self-hosted engine deployment host. See link:{URL_virt_product_docs}{URL_format}/installing_{URL_product_virt}_as_a_self-hosted_engine_using_the_command_line/index#Installing_the_self-hosted_engine_deployment_host_SHE_cli_deploy[Installing the Self-hosted Engine Deployment Host] for more information.
 +
 [NOTE]
 ====
@@ -143,7 +143,7 @@ endif::SHE_upgrade[]
 
 ifdef::local_database_upgrade,remote_database_upgrade[]
 
-. Install {enterprise-linux} 8.2 or later. See link:{URL_rhel_docs_latest}html/performing_a_standard_rhel_installation/index[_Performing a standard RHEL installation_] for more information.
+. Install {enterprise-linux} 8.6. See link:{URL_rhel_docs_latest}html/performing_a_standard_rhel_installation/index[_Performing a standard RHEL installation_] for more information.
 
 . Complete the steps to install {virt-product-fullname} {engine-name} 4.4, including running the command `yum install rhvm`, but do not run `engine-setup`. See one of the _Installing {virt-product-fullname}_ guides for more information.
 

--- a/source/documentation/common/upgrade/proc-Upgrading_the_Manager_to_4-4.adoc
+++ b/source/documentation/common/upgrade/proc-Upgrading_the_Manager_to_4-4.adoc
@@ -6,13 +6,13 @@
 // Upgrade Guide
 
 ifndef::SHE_upgrade[]
-{virt-product-fullname} {engine-name} 4.4 is only supported on {enterprise-linux} versions 8.2 to 8.6. You need to do a clean installation of {enterprise-linux} versions 8.2 to 8.6 and {virt-product-fullname} {engine-name} 4.4, even if you are using the same physical machine that you use to run {virt-product-shortname} {engine-name} 4.3.
+{virt-product-fullname} {engine-name} 4.4 is only supported on {enterprise-linux} versions 8.2 to 8.6. You need to do a clean installation of {enterprise-linux} 8.6 and {virt-product-fullname} {engine-name} 4.4, even if you are using the same physical machine that you use to run {virt-product-shortname} {engine-name} 4.3.
 
 The upgrade process requires restoring {virt-product-fullname} {engine-name} 4.3 backup files onto the {virt-product-fullname} {engine-name} 4.4 machine.
 endif::SHE_upgrade[]
 
 ifdef::SHE_upgrade[]
-The {virt-product-fullname} {engine-name} 4.4 is only supported on {enterprise-linux} versions 8.2 to 8.6. You need to do a clean installation of {enterprise-linux} versions 8.2 to 8.6, or {hypervisor-fullname} on the self-hosted engine host, even if you are using the same physical machine that you use to run the {virt-product-shortname} 4.3 self-hosted engine.
+The {virt-product-fullname} {engine-name} 4.4 is only supported on {enterprise-linux} versions 8.2 to 8.6. You need to do a clean installation of {enterprise-linux} 8.6, or {hypervisor-fullname} on the self-hosted engine host, even if you are using the same physical machine that you use to run the {virt-product-shortname} 4.3 self-hosted engine.
 
 The upgrade process requires restoring {virt-product-fullname} {engine-name} 4.3 backup files onto the {virt-product-fullname} {engine-name} 4.4 virtual machine.
 endif::SHE_upgrade[]

--- a/source/documentation/common/upgrade/proc_upgrading-the-remote-data-warehouse-service-and-database.adoc
+++ b/source/documentation/common/upgrade/proc_upgrading-the-remote-data-warehouse-service-and-database.adoc
@@ -6,7 +6,7 @@
 
 Run this procedure on the remote machine with the Data Warehouse service and database.
 
-Notice that part of this procedure requires you to install {enterprise-linux} 8.2 or later, or {hypervisor-fullname} 4.4.
+Notice that part of this procedure requires you to install {enterprise-linux} 8.6, or {hypervisor-fullname} 4.4.
 
 .Prerequisites
 * You are logged in to the Data Warehouse machine.
@@ -36,7 +36,7 @@ Grafana is not supported on {virt-product-shortname} 4.3, but on {virt-product-s
 # systemctl disable ovirt-engine-dwhd
 ----
 
-. Reinstall the Data Warehouse machine with {enterprise-linux} 8.2 or later, or {hypervisor-fullname} 4.4.
+. Reinstall the Data Warehouse machine with {enterprise-linux} 8.6, or {hypervisor-fullname} 4.4.
 
 . Prepare a PostgreSQL database. For information, see link:{URL_virt_product_docs}{URL_format}installing_{URL_product_virt}_as_a_standalone_manager_with_remote_databases/index#Preparing_a_Remote_PostgreSQL_Database_install_RHVM[Preparing a Remote PostgreSQL Database] in _Installing {virt-product-fullname} as a standalone {engine-name} with remote databases_.
 


### PR DESCRIPTION
Bug fix

Fixes [BZ 2115388](https://bugzilla.redhat.com/show_bug.cgi?id=2115388)

Changes proposed in this pull request:

- fix formatting in chapter on updating RHV manager

add note in following regarding RHEL 8.6 limitation:
- source/documentation/common/prereqs/ref-Manager_Operating_System_Requirements.adoc
- source/documentation/common/upgrade/proc_upgrading-the-remote-data-warehouse-service-and-database.adoc
- source/documentation/common/upgrade/proc-Upgrading_hosts_to_4-4.adoc
- source/documentation/common/upgrade/proc-Upgrading_the_Manager_to_4-4.adoc

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): @emarcusRH

This pull request needs review by: (please @mention the reviewer if relevant)
