### PR TITLE
BZ#2111254 add nodejs14 instructions to upgrade guide

### DIFF
--- a/source/documentation/common/upgrade/proc-Manually_Updating_Hosts.adoc
+++ b/source/documentation/common/upgrade/proc-Manually_Updating_Hosts.adoc
@@ -115,8 +115,15 @@ You can see the value of the stream by entering:
 ====
 +
 .. Enable the `virt` module in the Advanced Virtualization stream with the following command:
-
++
 include::../install/snip-Enable_virt_module.adoc[]
++
+. Enable version 14 of the `nodejs` module:
+[source,terminal,subs="normal"]
++
+----
+# dnf module -y enable nodejs:14
+----
 +
 // END FOR RHEL HOSTS ONLY
 . Update the host:


### PR DESCRIPTION
[Feature | Bug fix]

Fixes issue # |[BZ 2111254](https://bugzilla.redhat.com/show_bug.cgi?id=2111254) 

Changes proposed in this pull request:

- fix formatting in manually updating hosts procedure ( enable virt section)

- add node js 14 enable instruction to Upgrade Guide manually updating hosts

PREVIEW: https://ovirt.github.io/ovirt-site/previews/3068/documentation/upgrade_guide/index.html#Manually_Updating_Hosts_minor_updates

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): (please @emarcusRH )

This pull request needs review by: (please @mention the reviewer if relevant)
