### PR TITLE
Update downstream version number

### DIFF
--- a/source/documentation/upgrade_guide/docinfo.xml
+++ b/source/documentation/upgrade_guide/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Upgrade Guide</title>
 <productname>Red Hat Virtualization</productname>
-<productnumber>{vernum_rhv}</productnumber>
+<productnumber>4.3</productnumber>
 <subtitle>Update and upgrade tasks for Red Hat Virtualization</subtitle>
 <abstract><para>A comprehensive guide to upgrading and updating components in a Red Hat Virtualization environment.</para></abstract>
 <authorgroup id="Author_Group">

--- a/source/documentation/upgrade_guide/index.adoc
+++ b/source/documentation/upgrade_guide/index.adoc
@@ -15,6 +15,18 @@ include::common/collateral_files/_attributes.adoc[]
 == {virt-product-fullname} Upgrade Overview
 include::chap-Red_Hat_Virtualization_Upgrade_Overview.adoc[leveloffset=+1]
 
+[id="upgrading-self-hosted-engine-environment"]
+== Upgrading a self-hosted engine environment
+:SHE_upgrade:
+ifdef::ovirt-doc[]
+include::assembly-SHE_Upgrading_from_4-4.adoc[leveloffset=+1]
+endif::ovirt-doc[]
+
+include::assembly-SHE_Upgrading_from_4-3.adoc[leveloffset=+1]
+
+include::assembly-SHE_Upgrading_from_4-2.adoc[leveloffset=+1]
+:SHE_upgrade!:
+
 [id="upgrading-standalone-engine-local-database-environment"]
 == Upgrading a standalone {engine-name} local database environment
 :local_database_upgrade:
@@ -40,18 +52,6 @@ include::assembly-Remote_Upgrading_from_4-3.adoc[leveloffset=+1]
 
 include::assembly-Remote_Upgrading_from_4-2.adoc[leveloffset=+1]
 :remote_database_upgrade!:
-
-[id="upgrading-self-hosted-engine-environment"]
-== Upgrading a self-hosted engine environment
-:SHE_upgrade:
-ifdef::ovirt-doc[]
-include::assembly-SHE_Upgrading_from_4-4.adoc[leveloffset=+1]
-endif::ovirt-doc[]
-
-include::assembly-SHE_Upgrading_from_4-3.adoc[leveloffset=+1]
-
-include::assembly-SHE_Upgrading_from_4-2.adoc[leveloffset=+1]
-:SHE_upgrade!:
 
 [id="updates-between-minor-releases"]
 == Updates between minor releases


### PR DESCRIPTION
Updating downstream version number. Upgrade Guide should be 4.3, not 4.4. 

Republishing doc on 4.3 splash page and removing from 4.4 splash page.

@sandrobonazzola  Please review.