### PR TITLE
BZ2155633: remove note from VM clone procedure

### DIFF
--- a/source/documentation/virtual_machine_management_guide/topics/Cloning_a_Virtual_Machine.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Cloning_a_Virtual_Machine.adoc
@@ -4,12 +4,6 @@
 
 You can clone virtual machines without having to create a template or a snapshot first.
 
-[IMPORTANT]
-====
-The *Clone VM* button is disabled while virtual machines are running; you must shut down a virtual machine before you can clone it.
-====
-
-
 .Procedure
 
 . Click menu:Compute[Virtual Machines] and select the virtual machine to clone.


### PR DESCRIPTION
Bug fix

Fixes [BZ2155633](https://bugzilla.redhat.com/show_bug.cgi?id=2155633) 

Changes proposed in this pull request:

- Remove admonition in [Cloning VMs](https://ovirt.github.io/ovirt-site/previews/3108/documentation/virtual_machine_management_guide/index.html#Cloning_a_Virtual_Machine)

-

-

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): (please @mention yourself to sign)

This pull request needs review by: (please @mention the reviewer if relevant)
