### PR TITLE
el9 is not tech preview anymore

### DIFF
--- a/source/documentation/common/install/proc-Installing_Red_Hat_Enterprise_Linux_Hosts.adoc
+++ b/source/documentation/common/install/proc-Installing_Red_Hat_Enterprise_Linux_Hosts.adoc
@@ -6,9 +6,9 @@ ifdef::rhv-doc[]
 A {enterprise-linux-host-fullname} is based on a standard basic installation of {enterprise-linux} 8 on a physical server, with the `{enterprise-linux} Server` and `{virt-product-fullname}` subscriptions attached.
 endif::[]
 ifdef::ovirt-doc[]
-A {enterprise-linux-host-fullname} is based on a standard basic installation of {enterprise-linux} 8 on a physical server, with the `{enterprise-linux} Server` and `{virt-product-fullname}` repositories enabled.
+A {enterprise-linux-host-fullname} is based on a standard basic installation of {enterprise-linux} {supported-rhel-version} on a physical server, with the `{enterprise-linux} Server` and `{virt-product-fullname}` repositories enabled.
 
-The oVirt project also provides packages for {enterprise-linux} 9 but only as a Technology Preview.
+The oVirt project also provides packages for {enterprise-linux} 9.
 endif::[]
 
 For detailed installation instructions, see the link:{URL_rhel_docs_latest}html/performing_a_standard_rhel_installation/index.html[_Performing a standard {enterprise-linux-shortname} installation_].


### PR DESCRIPTION
Changes proposed in this pull request:

- Moving el9 out of tech preview as it's supported since 4.5.4

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @oVirt/ovirt-documentation 

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>