### PR TITLE
Update proc-Deploying_the_Self-Hosted_Engine_Using_the_CLI.adoc

### DIFF
--- a/source/documentation/common/install/proc-Deploying_the_Self-Hosted_Engine_Using_the_CLI.adoc
+++ b/source/documentation/common/install/proc-Deploying_the_Self-Hosted_Engine_Using_the_CLI.adoc
@@ -45,7 +45,7 @@ By default, this setting uses system-wide crypto policies. For more information,
 
 {hypervisor-shortname} hosts registered for 4.4.5.5 and later use the strongest algorithm that is supported by both the {engine-name} and {hypervisor-shortname}. The `PubkeyAcceptedKeyTypes` setting helps determine which algorithm is used.
 ====
-** `PermitRoolLogin` is set to `without-password` or `yes`
+** `PermitRootLogin` is set to `without-password` or `yes`
 ** `PubkeyAuthentication` is set to `yes`
 
 .Procedure


### PR DESCRIPTION
[Bug fix]

- Corrected typo 'PermitRoolLogin' to 'PermitRootLogin' regarding /etc/ssh/sshd_config file.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): @cbugk