### PR TITLE
BZ#2011159 add reference link to Admin Guide sec using host power management

### DIFF
--- a/source/documentation/administration_guide/topics/Using_host_power_management_functions.adoc
+++ b/source/documentation/administration_guide/topics/Using_host_power_management_functions.adoc
@@ -28,4 +28,4 @@ When two fencing agents are defined on a host, they can be used concurrently or 
 . Click btn:[OK].
 
 .Additional resources
-link:{URL_customer-portal}{URL_docs}{URL_lang-locale}{URL_product_rhel}{URL_vernum_rhel_latest}html/configuring_and_managing_high_availability_clusters/assembly_configuring-fencing-configuring-and-managing-high-availability-clusters#proc_configuring-acpi-for-fence-devices-configuring-fencing
+link:{URL_customer-portal}{URL_docs}{URL_lang-locale}{URL_product_rhel}{URL_vernum_rhel_latest}html/configuring_and_managing_high_availability_clusters/assembly_configuring-fencing-configuring-and-managing-high-availability-clusters#proc_configuring-acpi-for-fence-devices-configuring-fencing[Configuring ACPI for use with integrated fence devices]

--- a/source/documentation/administration_guide/topics/Using_host_power_management_functions.adoc
+++ b/source/documentation/administration_guide/topics/Using_host_power_management_functions.adoc
@@ -26,3 +26,6 @@ When two fencing agents are defined on a host, they can be used concurrently or 
 ====
 +
 . Click btn:[OK].
+
+.Additional resources
+link:{URL_customer-portal}{URL_docs}{URL_lang-locale}{URL_product_rhel}{URL_vernum_rhel_latest}/html/configuring_and_managing_high_availability_clusters/assembly_configuring-fencing-configuring-and-managing-high-availability-clusters#proc_configuring-acpi-for-fence-devices-configuring-fencing

--- a/source/documentation/administration_guide/topics/Using_host_power_management_functions.adoc
+++ b/source/documentation/administration_guide/topics/Using_host_power_management_functions.adoc
@@ -28,4 +28,4 @@ When two fencing agents are defined on a host, they can be used concurrently or 
 . Click btn:[OK].
 
 .Additional resources
-link:{URL_customer-portal}{URL_docs}{URL_lang-locale}{URL_product_rhel}{URL_vernum_rhel_latest}html/configuring_and_managing_high_availability_clusters/assembly_configuring-fencing-configuring-and-managing-high-availability-clusters#proc_configuring-acpi-for-fence-devices-configuring-fencing[Configuring ACPI for use with integrated fence devices]
+* link:{URL_customer-portal}{URL_docs}{URL_lang-locale}{URL_product_rhel}{URL_vernum_rhel_latest}html/configuring_and_managing_high_availability_clusters/assembly_configuring-fencing-configuring-and-managing-high-availability-clusters#proc_configuring-acpi-for-fence-devices-configuring-fencing[Configuring ACPI for use with integrated fence devices]

--- a/source/documentation/administration_guide/topics/Using_host_power_management_functions.adoc
+++ b/source/documentation/administration_guide/topics/Using_host_power_management_functions.adoc
@@ -28,4 +28,4 @@ When two fencing agents are defined on a host, they can be used concurrently or 
 . Click btn:[OK].
 
 .Additional resources
-link:{URL_customer-portal}{URL_docs}{URL_lang-locale}{URL_product_rhel}{URL_vernum_rhel_latest}/html/configuring_and_managing_high_availability_clusters/assembly_configuring-fencing-configuring-and-managing-high-availability-clusters#proc_configuring-acpi-for-fence-devices-configuring-fencing
+link:{URL_customer-portal}{URL_docs}{URL_lang-locale}{URL_product_rhel}{URL_vernum_rhel_latest}html/configuring_and_managing_high_availability_clusters/assembly_configuring-fencing-configuring-and-managing-high-availability-clusters#proc_configuring-acpi-for-fence-devices-configuring-fencing


### PR DESCRIPTION


[Feature | Bug fix]

Fixes issue # | [BZ#2011159](https://bugzilla.redhat.com/show_bug.cgi?id=2011159)  
Changes proposed in this pull request:

- add link to RHEL power management section in Admin Guide using host power management functions

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): (please @emarcusRH )

This pull request needs review by: (please @mention the reviewer if relevant)
