### PR TITLE
BZ#2011218  add note regarding Windows  Server 2016 config in a VM

### DIFF
--- a/source/documentation/virtual_machine_management_guide/topics/Configuring_operating_systems_with_osinfo.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Configuring_operating_systems_with_osinfo.adoc
@@ -20,3 +20,6 @@ Do not change values that come directly from the operating system or the {engine
 To change the operating system configurations, create an override file in */etc/ovirt-engine/osinfo.conf.d/*. The file name must begin with a value greater than `00`, so that the file appears after */etc/ovirt-engine/osinfo.conf.d/00-defaults.properties*, and ends with the extension, *.properties*.
 
 For example, *10-productkeys.properties* overrides the default file, *00-defaults.properties*. The last file in the file list has precedence over earlier files.
+
+For virtual machines with *Windows Server 2016*,
+on each {virt-product-shortname} host, modify the `/etc/modprobe.d/kvm.conf` configuration file by adding the line: `options kvm ignore_msrs=1`


### PR DESCRIPTION
[Feature | Bug fix]

Fixes issue # | [BZ#2011218](https://bugzilla.redhat.com/show_bug.cgi?id=2011218)  

Changes proposed in this pull request:

-In VMM GUIDE,  add note regarding Windows  Server 2016 config in a VM

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): (please @emarcusRH )

This pull request needs review by: (please @mention the reviewer if relevant)
