### PR TITLE
Drop bugzilla references on developer guide

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,13 @@
+{
+  "MD033": {
+    "allowed_elements": [
+      "section"
+    ]
+  },
+  "MD013": {
+    "line_length": 200
+  },
+  "MD025": {
+    "front_matter_title": ""
+  }
+}

--- a/source/community/about/contact.md
+++ b/source/community/about/contact.md
@@ -11,7 +11,7 @@ authors:
 # Communication
 
 There are a number of ways to communicate with the oVirt Community.
-[Mailing lists](/community/about/mailing-lists.html), [IRC](#irc), our [bug tracker](https://bugzilla.redhat.com/enter_bug.cgi?classification=oVirt) and [oVirt GitHub](https://github.com/oVirt).
+[Mailing lists](/community/about/mailing-lists.html), [IRC](#irc) and [oVirt GitHub](https://github.com/oVirt).
 
 ## IRC
 
@@ -19,7 +19,7 @@ We are on **irc.oftc.net** server on **#ovirt** channel.
 
 ## Bug tracker and code review
 
-You can report bugs, or discuss possible solutions to issues, on [Bugzilla](https://bugzilla.redhat.com/enter_bug.cgi?classification=oVirt) and [oVirt GitHub](https://github.com/oVirt).
+You can report bugs, or discuss possible solutions to issues, on [oVirt GitHub](https://github.com/oVirt).
 
 We use GitHub to review patches.
 If you are not familiar with the process, you can read about

--- a/source/community/index.md
+++ b/source/community/index.md
@@ -1,5 +1,5 @@
 ---
-title: Community
+title: Get involved
 authors:
   - bproffitt
   - dneary
@@ -14,26 +14,30 @@ hide_metadata: true
 ---
 
 <section class="community_head">
-# Get involved!
+
+# Get involved
 
 oVirt is a community-driven virtualization project and people just like you are making it happen.
 
 </section>
 
 <section class="container">
+
 # Getting involved
 
-The oVirt community is a group of multidisciplinary individuals who are contributing code, writing documentation, reporting bugs, contributing UX and design expertise, and engaging with the community.
+The oVirt community is a group of multidisciplinary individuals who are contributing code, writing documentation, reporting issues,
+contributing UX and design expertise, and engaging with the community.
 
 Before getting started, we recommend that you:
 
-- Sign up for the [users@ovirt.org mailing list](/community/users-list.html) and send us an email saying how you would like to contribute. Visit our [mailing lists](/community/about/mailing-lists.html) page for other oVirt mailing lists to sign up for.
+- Sign up for the [users@ovirt.org mailing list](/community/users-list.html) and send us an email saying how you would like to contribute.
+  Visit our [mailing lists](/community/about/mailing-lists.html) page for other oVirt mailing lists to sign up for.
 - For fluent, real time communication, [join us on IRC](/community/about/contact.html#irc)
 - Please read our [community etiquette guidelines](/community/about/community-guidelines.html). (Quick summary: Be nice!)
 
 # Community
 
-oVirt is a community project, and we welcome contributions from everyone! If you'd like to write code, report bugs, contribute designs, or enhance the documentation, we would love your help!
+oVirt is a community project, and we welcome contributions from everyone! If you'd like to write code, report issues, contribute designs, or enhance the documentation, we would love your help!
 
 There are a few ways to engage with the oVirt Community:
 
@@ -67,33 +71,36 @@ To contribute translations, please follow our [How-To](/develop/localization.htm
 
 ## Documentation
 
-oVirt needs concise, user-friendly, up-to-date installation and usage documentation. To contribute, visit the [documentation repository](https://github.com/oVirt/ovirt-site/tree/main/source/documentation) and the [documentation issues tracker](https://github.com/oVirt/ovirt-site/issues?q=is%3Aissue+is%3Aopen+label%3Adocumentation). You can also report any documentation issues you find by clicking "Report an issue with this page" at the bottom of the documentation.
+oVirt needs concise, user-friendly, up-to-date installation and usage documentation.
+To contribute, visit the [documentation repository](https://github.com/oVirt/ovirt-site/tree/main/source/documentation)
+and the [documentation issues tracker](https://github.com/oVirt/ovirt-site/issues?q=is%3Aissue+is%3Aopen+label%3Adocumentation).
+You can also report any documentation issues you find by clicking "Report an issue with this page" at the bottom of the documentation.
 
-## Report Bugs and New Feature Requests (RFEs)
+## Report Issues and New Feature Requests (RFEs)
 
-Reporting bugs is one of the most valuable ways you can contribute! Ideas for new features are also very welcome. Report bugs and RFEs using the following issue trackers:
+Reporting issues is one of the most valuable ways you can contribute! Ideas for new features are also very welcome. Report issues and RFEs using the following issue trackers:
 
-- [How to report a bug](/community/report-a-bug.html)
-- [VM Portal GitHub - bugs and RFEs in VM Portal](https://github.com/oVirt/ovirt-web-ui/issues)
-- [oVirt Documentation GitHub - Documentation issues](https://github.com/oVirt/ovirt-site/issues?q=is%3Aissue+is%3Aopen+label%3Adocumentation)
+- [How to report an issue](/community/report-a-bug.html)
+- [oVirt Documentation issues](https://github.com/oVirt/ovirt-site/issues?q=is%3Aissue+is%3Aopen+label%3Adocumentation)
 - Security issues follow a [special reporting procedure](/community/security.html).
 
 ## Monitor security reports for oVirt Node
 
 oVirt Node contains hundreds of packages: some of them may be affected by vulnerabilities which may have critical impact.
-You can help keeping oVirt Node secure by monitoring [security reports](https://bugzilla.redhat.com/buglist.cgi?quicksearch=product%3A%22security%20response%22)
-and open oVirt Node trackers using [Bug 2074469](https://bugzilla.redhat.com/show_bug.cgi?id=2074469) as template.
+You can help keeping oVirt Node secure by monitoring [security reports](https://access.redhat.com/security/security-updates/cve)
+and open [oVirt Node issue trackers](https://github.com/oVirt/ovirt-node-ng-image/issues).
 
 Once the tracker is open you can help monitoring progress of the security fix.
-Look at [existing security reports in oVirt Node](https://bugzilla.redhat.com/buglist.cgi?quicksearch=product%3Aovirt-node%20keyword%3Asecurity)
-and check corresponding package on [CentOS Stream 8 Koji](https://koji.mbox.centos.org/koji/packages).
-If a fix for the CVE is available, update Bugzilla accordingly. As an example you can see [Bug 2074469 handling](https://bugzilla.redhat.com/show_bug.cgi?id=2074469#c1)
+Look at [existing security reports in oVirt Node](https://github.com/oVirt/ovirt-node-ng-image/issues?q=is%3Aissue+is%3Aopen+label%3Asecurity)
+and check corresponding package on [CentOS Stream 8 Koji](https://koji.mbox.centos.org/koji/packages) and [CentOS Stream 9 Koji](https://kojihub.stream.centos.org/koji/packages).
+If a fix for the CVE is available, update the traker issue accordingly.
 
 ## Participate in the oVirt infrastructure
 
 Our project infrastructure can always benefit from extra people, hardware and network bandwidth.
 First of all, consider [hosting a public mirror](/community/get-involved/repository-mirrors.html) of oVirt repositories.
-You can also [become an infra team member](/community/becoming-an-infrastructure-team-member.html) or [donate GitHub runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners) to the project to improve our capacity and redundancy.
+You can also [become an infra team member](/community/becoming-an-infrastructure-team-member.html) or
+[donate GitHub runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners) to the project to improve our capacity and redundancy.
 
 ## Supporters, Sponsors, and Providers
 
@@ -117,4 +124,5 @@ You can find some of them listed here:
 - [oVirt Simple Backup](https://github.com/zipurman/oVIRT_Simple_Backup)
 - [oVirt Desktop Client](https://github.com/nkovacne/ovirt-desktop-client)
 - [oVirt filesystem in userspace](https://github.com/yuvalturg/ovirtfs)
+
 </section>

--- a/source/develop/developer-guide/readme_template.md
+++ b/source/develop/developer-guide/readme_template.md
@@ -4,7 +4,6 @@ In order to welcome contributors be sure to direct them to the right places.
 
 Here you can find a template (be sure to replace links and names accordingly).
 
-
 ```markdown
 # oVirt PROJECTNAME
 
@@ -16,13 +15,15 @@ All contributions are welcome - patches, bug reports, and documentation issues.
 
 ### Submitting patches
 
-Please submit patches to [GitHub:PROJECTNAME](https://github.com/oVirt/PROJECTNAME). If you are not familiar with the process, you can read about [collaborating with pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests) on the GitHub website.
+Please submit patches to [GitHub:PROJECTNAME](https://github.com/oVirt/PROJECTNAME). If you are not familiar with the process, you can read about
+[collaborating with pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests)
+on the GitHub website.
 
-### Found a bug or documentation issue?
+### Found a project or documentation issue?
 
-To submit a bug or suggest an enhancement for oVirt PROJECTNAME please use [oVirt Bugzilla](https://bugzilla.redhat.com/enter_bug.cgi?product=PROJECTNAME).
+To submit a bug or suggest an enhancement for oVirt PROJECTNAME please use [oVirt PROJECTNAME issue tracker](https://github.com/oVirt/PROJECTNAME/issues).
 
-If you don't have a Bugzilla account, you can still report [issues](https://github.com/oVirt/PROJECTNAME/issues). If you find a documentation issue on the oVirt website, please navigate to the page footer and click "Report an issue on GitHub".
+If you find a documentation issue on the oVirt website, please navigate to the page footer and click "Report an issue on GitHub".
 
 ## Still need help?
 

--- a/source/develop/developer-guide/vdsm/todo.md
+++ b/source/develop/developer-guide/vdsm/todo.md
@@ -22,108 +22,75 @@ We intend to move this TODO into this [Trello board](https://trello.com/b/U3lsbV
 
 #### infra
 
-*   `` pylint -E `git ls-files | grep '.py$'` `` makes me cry. A lot of it is "only" about bad style, but we should clear it up and add it to our `make check-local`. We should grow up and pass `pychecker` too.
+* ``pylint -E `git ls-files | grep '.py$'` `` makes me cry.
+  A lot of it is "only" about bad style, but we should clear it up and add it to our `make check-local`.
+  We should grow up and pass `pychecker` too.
 
-<!-- -->
+* Add git submodules for pyflakes and pep8 to vdsm. Control the specific version of each tool to use from within the vdsm build itself.
+  This way we can make sure everyone is using the same version of the tools regardless of where vdsm is being built.
+  * See <https://github.com/jcrocholl/pep8> and <https://github.com/pyflakes/pyflakes/>
 
-*   Add git submodules for pyflakes and pep8 to vdsm. Control the specific version of each tool to use from within the vdsm build itself. This way we can make sure everyone is using the same version of the tools regardless of where vdsm is being built.
-    -   See <https://github.com/jcrocholl/pep8> and <https://github.com/pyflakes/pyflakes/>
-
-<!-- -->
-
-*   BindingXML's wrapApiMethod is incredibly fragile when deciding what not to log. Logging should be done as a decorator per called function, after password entries are converted to ProtectedPassword.
+* BindingXML's wrapApiMethod is incredibly fragile when deciding what not to log. Logging should be done as a decorator per called function, after password entries are converted to ProtectedPassword.
 
 ### Testing
 
-*   Add `` `make distcheck` `` to Jenkins's jobs.
+* Add `` `make distcheck` `` to GitHub actions.
 
-<!-- -->
+* Wrap all tests and fail a test that leaves an open file descriptor behind.
 
-*   Wrap all tests and fail a test that leaves an open file descriptor behind.
+* add a unit test for `qemuimg.rebase`.
 
-<!-- -->
+* make `@permutations` nestable
 
-*   add a unit test for qemuimg.rebase.
+* test `fileSD.scanDomains()`
 
-<!-- -->
+* add migration tests
 
-*   make @permutations nestable
-
-<!-- -->
-
-*   test fileSD.scanDomains()
-
-<!-- -->
-
-*   add migration tests
-
-<!-- -->
-
-*   test cannonizeHostPort
+* test `cannonizeHostPort`
 
 ### Features
 
-*   Support striping for disk images.
+* Support striping for disk images.
 
-<!-- -->
+* let Vdsm install and run on hosts with no iscsid (report that iscsi is missing to Engine?)
 
-*   let Vdsm install and run on hosts with no iscsid (report that iscsi is missing to Engine?)
-
-<!-- -->
-
-*   start Vdsm only when it receives a request (integrate with systemd)
+* start Vdsm only when it receives a request (integrate with systemd)
 
 #### Networking
 
-*   Modify vdsm-tool restore-nets so that the management network (or the network with the default IPv4 route) is the last to be taken down and the first to be taken up to minimize the connectivity loss (very useful when accessing the machine remotely). Minimize vdsm-restore-net-config downtime for the default route network.
+* Modify vdsm-tool restore-nets so that the management network (or the network with the default IPv4 route) is the last
+  to be taken down and the first to be taken up to minimize the connectivity loss (very useful when accessing the machine remotely).
+  Minimize vdsm-restore-net-config downtime for the default route network.
 
-<!-- -->
+* ~~Split off the network restoration from vdsm startup so that it is performed in a different init service.
+  This vdsm-network-restoration service should be oneshot and happen before network.service. <http://gerrit.ovirt.org/#/c/29441/>~~
 
-*   ~~Split off the network restoration from vdsm startup so that it is performed in a different init service. This vdsm-network-restoration service should be oneshot and happen before network.service. <http://gerrit.ovirt.org/#/c/29441/>~~
+* Fine-grained control on network-specific routes.
 
-<!-- -->
+* Allow multiple setting IPv4 and IPv6 addresses per network device. (API change is needed; we report multiple ipv6 addresses).
 
-*   Fine-grained control on network-specific routes.
+* models: support multiple IPv4 and/or IPv6 addresses
 
-<!-- -->
+* get a single dump of all libvirt networks (no libvirt API for it yet...)
 
-*   Allow multiple setting IPv4 and IPv6 addresses per network device. (API change is needed; we report multiple ipv6 addresses).
+* IPv4 routing table Id hash mechanism
+  * change the 'network' argument in routes to 'link scope route'
 
-<!-- -->
+* move source routing info to route.py (which uses netlink instead of using the default configurator). this will also simplify StaticSourceRoute
 
-*   -   models: support multiple IPv4 and/or IPv6 addresses
+* Move vdsm-store-net-config logic to netconfbackpersistence.py
 
-<!-- -->
-
-*   get a single dump of all libvirt networks (no libvirt API for it yet...)
-
-
-<!-- -->
-
-*   IPv4 routing table Id hash mechanism
-    -   change the 'network' argument in routes to 'link scope route'
-
-<!-- -->
-
-*   move source routing info to route.py (which uses netlink instead of using the default configurator). this will also simplify StaticSourceRoute
-
-<!-- -->
-
-*   Move vdsm-store-net-config logic to netconfbackpersistence.py
-
-<!-- -->
-
-*   Add configureIp to the configurators API so that Layer 3 can be configured in parallel after Layer 2 (and it gives much better modelling). Obviously, this isn't really possible in ifcfg without doing a two step write which is an ugly hack.
+* Add configureIp to the configurators API so that Layer 3 can be configured in parallel after Layer 2 (and it gives much better modelling).
+  Obviously, this isn't really possible in ifcfg without doing a two step write which is an ugly hack.
 
 ### refactoring
 
-*   In vm.py, libvirtvm.py, clientIF.py there is a mess of prepare\*Path functions (end their respective teardowns), which is too complex to fathom. We have to convert all drive specifications (PDIV,GUID,path) into Drive object at the API entry.
+* In vm.py, libvirtvm.py, clientIF.py there is a mess of prepare\*Path functions (end their respective teardowns), which is too complex to fathom.
+  We have to convert all drive specifications (PDIV,GUID,path) into Drive object at the API entry.
 
-<!-- -->
+* lvm.PV.guid is devicemapper-owned piece of information; lvm has nothing to do with it, and jumps through [hoops](http://gerrit.ovirt.org/2940) to produce it.
+  Instead, it should be produced by devicemapper and consumed directly by blockSD.
 
-*   lvm.PV.guid is devicemapper-owned piece of information; lvm has nothing to do with it, and jumps through [hoops](http://gerrit.ovirt.org/2940) to produce it. Instead, it should be produced by devicemapper and consumed directly by blockSD.
+### Issues
 
-### Bugzilla
-
-*   pick one of the [<https://bugzilla.redhat.com/buglist.cgi?action=wrap&bug_file_loc>=&bug_file_loc_type=allwordssubstr&bug_id=&bug_id_type=anyexact&chfieldfrom=&chfieldto=Now&chfieldvalue=&product=vdsm&deadlinefrom=&deadlineto=&email1=&email2=&emailtype1=substring&emailtype2=substring&field0-0-0=flagtypes.name&keywords=&keywords_type=allwords&longdesc=&longdesc_type=allwordssubstr&short_desc=&short_desc_type=allwordssubstr&status_whiteboard=&status_whiteboard_type=allwordssubstr&type0-0-0=notsubstring&value0-0-0=rhel-6.2.0&votes=&=&bug_status=NEW NEW bugs], post a patch to [gerrit](http://gerrit.ovirt.org), and make the bug yours.
-
+* pick one of the [open issues](https://github.com/oVirt/vdsm/issues), post a pull request to [GitHub](https://github.com/oVirt/vdsm/pulls), and make the issue yours.

--- a/source/develop/index.md
+++ b/source/develop/index.md
@@ -1,5 +1,5 @@
 ---
-title: Developers Community
+title: Joining the developers community
 authors:
   - sandrobonazzola
 page_classes: community
@@ -15,7 +15,7 @@ oVirt is a community-driven virtualization project and people just like you are 
 
 <section class="container">
 
-# I’m interested - how can I get familiar with oVirt?
+## I’m interested - how can I get familiar with oVirt?
 
 You should start by deploying oVirt in a test lab. The minimum configuration needed is a single host or a single VM with at least 16GB of RAM and 4 cores CPU.
 On this system you will be able to setup everything needed to run virtual machines (what we call oVirt Host) and the virtualization manager (what we call oVirt Engine)
@@ -32,19 +32,17 @@ For fluent, real time communication, you can [join us on IRC](/community/about/c
 
 Please read our [community etiquette guidelines](/community/about/community-guidelines.html). (Quick summary: Be nice!)
 
-# Exploring the documentation
+## Exploring the documentation
 
 Skim through the [user documentation](/documentation/index.html) and the [developers documentation](devdocs.html) in order to understand how the system works and can be configured.
 
 Several presentations both on the technical side and on the user side are available on [oVirt Youtube channel](https://www.youtube.com/ovirtproject).
 
-# Joining a team
+## Joining a team
 
 Within oVirt project several teams are taking care of different aspects of the system.
 
-The [oVirt Bugzilla](https://bugzilla.redhat.com/buglist.cgi?quicksearch=classification%3Aovirt) tickets are classified by oVirt team to identify the main impacted area.
-
-At the same way the [oVirt GitHub issues](https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aovirt+archived%3Afalse) are labeled accordingly to identify the main impacted area.
+The [oVirt GitHub issues](https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aovirt+archived%3Afalse) are labeled accordingly to identify the main impacted area.
 
 - [Project Infrastructure](infra/infrastructure.html): takes care of the oVirt datacenter and of all the systems and services running within the datacenter such as Jenkins, Gerrit, Apache, ...
 - [Integration and Node](integration/index.html): integrates the oVirt subprojects making them work together as a complete solution.
@@ -54,22 +52,17 @@ At the same way the [oVirt GitHub issues](https://github.com/issues?q=is%3Aopen+
 - Virtualization: responsible for VM lifecycle, System and host level scheduling / SLA
 - User Experience: responsible for UI Infra and overall UX consistency.
 
-You can check open tickets for each team for getting a brief idea of what we are working on with this report:
-[oVirt bugs per team](https://bugzilla.redhat.com/report.cgi?x_axis_field=bug_status&y_axis_field=cf_ovirt_team&z_axis_field=target_milestone&no_redirect=1&query_format=report-table&bug_status=__open__&j_top=AND&f1=OP&j1=OR&f2=classification&o2=equals&v2=oVirt&f4=CP&f5=noop&o5=noop&v5=&format=table&action=wrap)
-
-
 The teams are discussing their work on [devel@ovirt.org](https://lists.ovirt.org/archives/list/devel@ovirt.org/) mailing list so to join a team
 you should start getting involved in these conversations.
 
-
-# Contributing Code
+## Contributing Code
 
 oVirt is an open-source project composed by several sub projects. Most of them are licensed under the [Apache license version 2.0](https://www.apache.org/licenses/LICENSE-2.0.html)
 but please check the license of the subproject you're going to contribute before submitting code.
 Contributions of all types are gladly accepted!
 
 If you are looking for some task to pick up, you can ask for it on [devel@ovirt.org](https://lists.ovirt.org/archives/list/devel@ovirt.org/) mailing list.
-As an alternative you can look at open tickets on [oVirt Bugzilla](https://bugzilla.redhat.com/buglist.cgi?quicksearch=classification%3Aovirt) and once you choose what to work on
+As an alternative you can look at open tickets on [oVirt GitHub issues](https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aovirt+archived%3Afalse) and once you choose what to work on
 please comment on the ticket you are looking into it. If the ticket has already an assignee, please get in touch with the assignee before starting to work on the ticket.
 
 Before writing any code, please check the subproject coding standards in the README file. If there is no mention about coding standards, try to follow
@@ -77,7 +70,7 @@ the coding style used within the subproject existing sources.
 
 You can find us on both our mailing list and IRC if you run into trouble when selecting issues or setting up your development environment or if you have questions.
 
-# Setting up a development environment
+## Setting up a development environment
 
 Each subproject should have instructions on how to setup your development environment to be able to develop and test your changes.
 If you don't find adequate documentation and you need help, please contact us on IRC or on the [devel@ovirt.org](https://lists.ovirt.org/archives/list/devel@ovirt.org/) mailing list.

--- a/source/develop/integration/index.md
+++ b/source/develop/integration/index.md
@@ -14,70 +14,66 @@ authors:
 
 The members of the Integration team are
 
-*   [Asaf Rachmani](https://github.com/arachmani)
-*   [Lev Veyde (Lveyde)](https://github.com/lveyde)
-*   [Yedidyah Bar David (Didi)](https://github.com/didib)
+* [Asaf Rachmani](https://github.com/arachmani)
+* [Lev Veyde (Lveyde)](https://github.com/lveyde)
+* [Yedidyah Bar David (Didi)](https://github.com/didib)
 
 Past contributors
 
-*   [Alon Bar-Lev](https://github.com/alonbl)
-*   [Antoni Segura Puimedon](https://github.com/celebdor)
-*   [Aviv Turgeman](https://github.com/avivtur)
-*   [David Caro](https://github.com/david-caro)
-*   [Doron Fediuck (Doron)](https://github.com/doron-fediuck)
-*   [Douglas Landgraf](https://github.com/dougsland)
-*   [Evgeny Slutsky](https://github.com/eslutsky)
-*   [Gal Zaidman](https://github.com/Gal-Zaidman)
-*   [Ido Rosenzwig](https://github.com/irosenzw)
-*   [Juan Hernandez](https://github.com/jhernand)
-*   [Rafael Martins](https://github.com/rafaelmartins)
-*   [Sandro Bonazzola](https://github.com/sandrobonazzola)
-*   [Simone Tiraboschi (Stirabos)](https://github.com/tiraboschi)
-
+* [Alon Bar-Lev](https://github.com/alonbl)
+* [Antoni Segura Puimedon](https://github.com/celebdor)
+* [Aviv Turgeman](https://github.com/avivtur)
+* [David Caro](https://github.com/david-caro)
+* [Doron Fediuck (Doron)](https://github.com/doron-fediuck)
+* [Douglas Landgraf](https://github.com/dougsland)
+* [Evgeny Slutsky](https://github.com/eslutsky)
+* [Gal Zaidman](https://github.com/Gal-Zaidman)
+* [Ido Rosenzwig](https://github.com/irosenzw)
+* [Juan Hernandez](https://github.com/jhernand)
+* [Rafael Martins](https://github.com/rafaelmartins)
+* [Sandro Bonazzola](https://github.com/sandrobonazzola)
+* [Simone Tiraboschi (Stirabos)](https://github.com/tiraboschi)
 
 ## What does Integration team do?
 
 Leads the following projects:
 
-*   [oVirt Node](/download/node.html)
-*   [oVirt Engine Setup](https://github.com/oVirt/ovirt-engine/tree/master/packaging/setup)
-*   [oVirt DWH Setup](https://github.com/oVirt/ovirt-dwh/tree/master/packaging/setup)
-*   [oVirt Hosted Engine Setup](https://github.com/oVirt/ovirt-hosted-engine-setup)
-*   [oVirt Websoket Proxy Setup](https://github.com/oVirt/ovirt-engine/tree/master/packaging/setup)
-*   [oVirt Log Collector](/develop/developer-guide/engine/engine-tools.html#ovirt-log-collector)
-*   [oVirt Releases](/develop/release-management/releases/) and Release management
-*   [oVirt Windows Guest Tools](/develop/release-management/features/integration/windows-guest-tools.html)
-*   [oVirt Quality Assurance](/develop/qa/index.html)
-*   [OTOPI](/develop/developer-guide/engine/otopi.html)
+* [oVirt Node](/download/node.html)
+* [oVirt Engine Setup](https://github.com/oVirt/ovirt-engine/tree/master/packaging/setup)
+* [oVirt DWH Setup](https://github.com/oVirt/ovirt-dwh/tree/master/packaging/setup)
+* [oVirt Hosted Engine Setup](https://github.com/oVirt/ovirt-hosted-engine-setup)
+* [oVirt Websoket Proxy Setup](https://github.com/oVirt/ovirt-engine/tree/master/packaging/setup)
+* [oVirt Log Collector](/develop/developer-guide/engine/engine-tools.html#ovirt-log-collector)
+* [oVirt Releases](/develop/release-management/releases/) and Release management
+* [oVirt Windows Guest Tools](/develop/release-management/features/integration/windows-guest-tools.html)
+* [oVirt Quality Assurance](/develop/qa/index.html)
+* [OTOPI](/develop/developer-guide/engine/otopi.html)
 
 ## Projects deprecated / dropped in latest oVirt releases
 
-*   [oVirt Orb](/dropped/ovirt-orb/index.html)
-*   [oVirt Iso Uploader](https://github.com/ovirt/ovirt-iso-uploader)
-*   [oVirt Image Uploader](https://github.com/ovirt/ovirt-image-uploader)
-*   [oVirt Live](https://github.com/ovirt/ovirt-live)
-*   [oVirt Host Deploy](https://github.com/ovirt/ovirt-host-deploy)
+* [oVirt Orb](/dropped/ovirt-orb/index.html)
+* [oVirt Iso Uploader](https://github.com/ovirt/ovirt-iso-uploader)
+* [oVirt Image Uploader](https://github.com/ovirt/ovirt-image-uploader)
+* [oVirt Live](https://github.com/ovirt/ovirt-live)
+* [oVirt Host Deploy](https://github.com/ovirt/ovirt-host-deploy)
 
 ## Other communities collaborations
 
 Collaborates with other communities / projects:
 
-*   [Fedora](https://getfedora.org/)
-*   [CentOS](http://centos.org/)
-*   [CentOS OpsTools SIG](https://wiki.centos.org/SpecialInterestGroup/OpsTools)
-*   [SOS](https://github.com/sosreport)
-*   [Sanlock](https://pagure.io/sanlock)
-*   [VDSM](/develop/developer-guide/vdsm/vdsm.html)
-*   [Libvirt](http://libvirt.org/)
-*   [oVirt Continuous Integration / Infra](/develop/infra/infrastructure.html)
-*   [Gluster](http://www.gluster.org/)
+* [Fedora](https://getfedora.org/)
+* [CentOS](http://centos.org/)
+* [CentOS OpsTools SIG](https://wiki.centos.org/SpecialInterestGroup/OpsTools)
+* [SOS](https://github.com/sosreport)
+* [Sanlock](https://pagure.io/sanlock)
+* [VDSM](/develop/developer-guide/vdsm/vdsm.html)
+* [Libvirt](http://libvirt.org/)
+* [oVirt Continuous Integration / Infra](/develop/infra/infrastructure.html)
+* [Gluster](http://www.gluster.org/)
 
 ### How may I help?
 
-*   Fixing one of the open [oVirt Integration Bugzilla](https://bugzilla.redhat.com/buglist.cgi?quicksearch=cf_ovirt_team%3Aintegration%20status%3Anew) we have
-*   Fixing one of the open [oVirt Node Bugzilla](https://bugzilla.redhat.com/buglist.cgi?quicksearch=cf_ovirt_team%3Anode%20status%3Anew) we have
-*   Fixing one of the open issues on [oVirt Integration overview](https://github.com/orgs/oVirt/projects/2) GitHub project
-*   Fixing one of the open issues on [oVirt Node overview](https://github.com/orgs/oVirt/projects/1) GitHub project
-*   Testing one of the [bugs we fixed](https://bugzilla.redhat.com/buglist.cgi?quicksearch=cf_ovirt_team%3Aintegration%2Cnode%20status%3Amodifed%2Con_qa)
-*   Joining the [oVirt Quality Assurance](/develop/qa/index.html) effort
-*   Help porting oVirt to other distributions
+* Fixing one of the open issues on [oVirt Integration overview](https://github.com/orgs/oVirt/projects/2) GitHub project
+* Fixing one of the open issues on [oVirt Node overview](https://github.com/orgs/oVirt/projects/1) GitHub project
+* Joining the [oVirt Quality Assurance](/develop/qa/index.html) effort
+* Help porting oVirt to other distributions

--- a/source/develop/qa/index.md
+++ b/source/develop/qa/index.md
@@ -18,26 +18,19 @@ It's our goal to continually improve the quality of oVirt releases and updates.
 
 The Quality Assurance project is engaged in the following activities:
 
-*   Testing of software as it is released into nightly, updates-testing, or as it appears in a supported public release
-*   Developing and executing test plans and [Test Cases](/develop/qa/test-cases/) to test important functionality in a systematic way, usually with multiple cooperating testers
-*   Developing and running tools that use automation to find potential bugs ( <https://docs.github.com/en/actions> )
-*   Running test days to coordinate focused testing on a specific feature or component
-*   Working with developers to maintain the release criteria, which are used to determine what bugs should be fixed before a release of oVirt is made
-*   Verifying bugs fixed by oVirt developers
-*   Triage oVirt bugs in Bugzilla and issues on GitHub. Request missing information, verify correct component has been chosen, and close duplicates.
+* Testing of software as it is released into nightly, updates-testing, or as it appears in a supported public release
+* Developing and executing test plans and [Test Cases](/develop/qa/test-cases/) to test important functionality in a systematic way, usually with multiple cooperating testers
+* Developing and running tools that use automation to find potential issues ( <https://docs.github.com/en/actions> )
+* Running test days to coordinate focused testing on a specific feature or component
+* Working with developers to maintain the release criteria, which are used to determine what issues should be fixed before a release of oVirt is made
+* Verifying issues fixed by oVirt developers
+* Triage oVirt issues on GitHub. Request missing information, verify correct project has been chosen, and close duplicates.
 
 ## Get Involved
 
 We're always eager to have new contributors to the QA project, no matter your experience level.
 
 If you'd like to get involved with helping to make oVirt better, join oVirt [Community](/community/)
-
-We've also created a user in bugzilla as default QA assignee: `bugs@ovirt.org` so if you want to be updated on QE bugs activity you can just add that user to your bugzilla account watch list:
-
-*   go to <https://bugzilla.redhat.com/userprefs.cgi?tab=email>
-*   select Watch user list -> add "`bugs@ovirt.org`"
-
-Any email sent by bugzilla to that user will be also sent to you.
 
 ## Communicate
 
@@ -48,9 +41,8 @@ You can also join oVirt users mailing list, where quality assurance-related topi
 ## Next releases
 
 * 4.5.5:
-  - GitHub Tracker: [oVirt 4.5.5 issues](https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aovirt+archived%3Afalse+milestone%3Aovirt-4.5.5)
+  * GitHub Tracker: [oVirt 4.5.5 issues](https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aovirt+archived%3Afalse+milestone%3Aovirt-4.5.5)
 
-## Notes:
+## Notes
 
 This page has been created following <https://fedoraproject.org/wiki/QA> as a model
-


### PR DESCRIPTION
Bug fix

Changes proposed in this pull request:

- Bugzilla oVirt classification is not accepting new tickets as the project migrated to GitHub issues tracking system.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): @sandrobonazzola 

