### PR TITLE
Updated the GPG key(s) infomation

### DIFF
--- a/source/download/rpms_and_gpg.md
+++ b/source/download/rpms_and_gpg.md
@@ -83,4 +83,6 @@ If you do not use yum, you can check the signature of the package using the foll
 | Key ID     | Key Type     | Key Fingerprint                                     | Key Description | Created    | Expires    | Revoked | Notes |
 |------------|--------------|-----------------------------------------------------|-----------------|------------|------------|---------|-------|
 | `FE590CB7` | 2048-bit RSA | `31A5 D783 7FAD 7CB2 86CD 3469 AB8C 4F9D FE59 0CB7` | oVirt           | 2014-03-30 | 2028-04-06 |         |       |
+|------------|--------------|-----------------------------------------------------|-----------------|------------|------------|---------|-------|
+| `24901D0C` | 4096-bit RSA | `3C98 E81D B93D EA6D 54DE 690E 44E4 75CB 2490 1D0C` | oVirt           | 2022-11-02 | 2032-10-30 |         |       |
 {: .bordered}


### PR DESCRIPTION
Added the details of the new signing key (24901D0C).

Changes proposed in this pull request:

- Updated the GPG key(s) information with the details of the new key (24901D0C)

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): (@lveyde)

This pull request needs review by: (@sandrobonazzola )
