### PR TITLE
Fix broken link in `Installing_Remote_Viewer_on_Windows.adoc`

### DIFF
--- a/source/documentation/virtual_machine_management_guide/topics/Installing_Remote_Viewer_on_Windows.adoc
+++ b/source/documentation/virtual_machine_management_guide/topics/Installing_Remote_Viewer_on_Windows.adoc
@@ -28,7 +28,7 @@ endif::rhv-doc[]
 
 ifdef::ovirt-doc[]
 
-* link:https://virt-manager.org/download/[Virt Viewer download page]
+* link:https://virt-manager.org/download[Virt Viewer download page]
 
 endif::ovirt-doc[]
 


### PR DESCRIPTION
[Bug fix]

Fixes broken hyperlink in a documentation page. 

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): @arthurvr