### PR TITLE
Bump artifacts actions to v4

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -109,7 +109,7 @@ jobs:
     - name: "Build website"
       run: docker run --rm --mount type=bind,source=$(pwd),target=/srv/site ovirt-site build
     - name: "Upload generated content"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ovirt-site
         if-no-files-found: error
@@ -137,7 +137,7 @@ jobs:
       - name: "Create preview build directory"
         run: mkdir -p "${{needs.build.outputs.PREVIEW_PATH}}"
       - name: "Download generated content"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ovirt-site
           path: "${{needs.build.outputs.PREVIEW_PATH}}"


### PR DESCRIPTION
dependabot suggested bumping download-artifact only but both need to have compatible versions.
