### PR TITLE
Cleanup PRG and related doco

### DIFF
--- a/source/documentation/common/arch/con-Self-hosted_Engine_Architecture.adoc
+++ b/source/documentation/common/arch/con-Self-hosted_Engine_Architecture.adoc
@@ -6,7 +6,7 @@ The {virt-product-fullname} {engine-name} runs as a virtual machine on self-host
 
 The minimum setup of a self-hosted engine environment includes:
 
-* One {virt-product-fullname} {engine-name} virtual machine that is hosted on the self-hosted engine nodes. The {engine-appliance-name} is used to automate the installation of a {enterprise-linux} 8 virtual machine, and the {engine-name} on that virtual machine.
+* One {virt-product-fullname} {engine-name} virtual machine that is hosted on the self-hosted engine nodes. The {engine-appliance-name} is used to automate the installation of a {enterprise-linux} 9 virtual machine, and the {engine-name} on that virtual machine.
 
 * A minimum of two self-hosted engine nodes for virtual machine high availability. You can use {enterprise-linux-host-fullname}s or {hypervisor-fullname}s ({hypervisor-shortname}). VDSM (the host agent) runs on all hosts to facilitate communication with the {virt-product-fullname} {engine-name}. The HA services run on all self-hosted engine nodes to manage the high availability of the {engine-name} virtual machine.
 

--- a/source/documentation/common/arch/con-Standalone_Manager_Architecture.adoc
+++ b/source/documentation/common/arch/con-Standalone_Manager_Architecture.adoc
@@ -2,11 +2,11 @@
 [id='Standalone_Manager_Architecture_{context}']
 = Standalone {engine-name} Architecture
 
-The {virt-product-fullname} {engine-name} runs on a physical server, or a virtual machine hosted in a separate virtualization environment. A standalone {engine-name} is easier to deploy and manage, but requires an additional physical server. The {engine-name} is only highly available when managed externally with a product such as Red Hat's High Availability Add-On.
+The {virt-product-fullname} {engine-name} runs on a physical server, or a virtual machine hosted in a separate virtualization environment. A standalone {engine-name} is easier to deploy and manage, but requires an additional physical server. The {engine-name} is only highly available when managed externally with a supported High Availability Add-On.
 
 The minimum setup for a standalone {engine-name} environment includes:
 
-* One {virt-product-fullname} {engine-name} machine. The {engine-name} is typically deployed on a physical server. However, it can also be deployed on a virtual machine, as long as that virtual machine is hosted in a separate environment. The {engine-name} must run on {enterprise-linux} 8.
+* One {virt-product-fullname} {engine-name} machine. The {engine-name} is typically deployed on a physical server. However, it can also be deployed on a virtual machine, as long as that virtual machine is hosted in a separate environment. The {engine-name} must run on {enterprise-linux} 9.
 
 * A minimum of two hosts for virtual machine high availability. You can use {enterprise-linux-host-fullname}s or {hypervisor-fullname}s ({hypervisor-shortname}). VDSM (the host agent) runs on all hosts to facilitate communication with the {virt-product-fullname} {engine-name}.
 

--- a/source/documentation/common/collateral_files/_attributes.adoc
+++ b/source/documentation/common/collateral_files/_attributes.adoc
@@ -109,5 +109,5 @@ ifdef::ovirt-doc[]
 :org-fullname: oVirt
 :container-platform: OKD
 :container-platform-virt: KubeVirt
-:supported-rhel-version: 8.7 or later
+:supported-rhel-version: 9 or later
 endif::ovirt-doc[]

--- a/source/documentation/common/prereqs/asm-Networking_Requirements.adoc
+++ b/source/documentation/common/prereqs/asm-Networking_Requirements.adoc
@@ -8,7 +8,7 @@
 
 == General requirements
 
-{virt-product-fullname} requires IPv6 to remain enabled on the physical or virtual machine running the {engine-name}. link:https://access.redhat.com/solutions/8709[Do not disable IPv6] on the {engine-name} machine, even if your systems do not use it.
+{virt-product-fullname} requires IPv6 to remain enabled on the physical or virtual machine running the {engine-name}. Do not disable IPv6 on the {engine-name} machine, even if your systems do not use it.
 
 ifdef::SHE_cli_deploy,RHV_planning[]
 include::ref-Network-range-for-SHE-deployment.adoc[leveloffset=+1]

--- a/source/documentation/common/prereqs/ref-Database_Server_Firewall_Requirements.adoc
+++ b/source/documentation/common/prereqs/ref-Database_Server_Firewall_Requirements.adoc
@@ -15,13 +15,6 @@ Similarly, if you plan to access a local or remote Data Warehouse database from 
 Accessing the {engine-name} database from external systems is not supported.
 ====
 
-ifdef::rhv-doc[]
-[NOTE]
-====
-A diagram of these firewall requirements is available at https://access.redhat.com/articles/3932211.
-You can use the IDs in the table to look up connections in the diagram.
-====
-endif::[]
 
 .Database Server Firewall Requirements
 [options="header", cols="2,2,2,5,5,5,3", frame=all, grid=all]
@@ -33,7 +26,7 @@ endif::[]
 Data Warehouse service |{engine-name} (`engine`) database server
 
 Data Warehouse (`ovirt-engine-history`) database server |Default port for PostgreSQL database connections.
-|link:{URL_virt_product_docs}{URL_format}installing_{URL_product_virt}_as_a_self-hosted_engine_using_the_command_line/index#Migrating_the_Data_Warehouse_Database_to_a_Separate_Machine_migrate_DWH[No, but can be enabled].
+|link:{URL_virt_product_docs}{URL_format}installing_{URL_product_virt}_as_a_self-hosted_engine_using_the_command_line/index#Migrating_Data_Warehouse_to_a_Separate_Machine_SHE_cli_deploy[No, but can be enabled].
 |D2 |5432 |TCP, UDP |External systems |Data Warehouse (`ovirt-engine-history`) database server |Default port for PostgreSQL database connections.
-| Disabled by default. link:{URL_virt_product_docs}{URL_format}installing_{URL_product_virt}_as_a_self-hosted_engine_using_the_command_line/index#Migrating_the_Data_Warehouse_Database_to_a_Separate_Machine_migrate_DWH[No, but can be enabled].
+| Disabled by default. link:{URL_virt_product_docs}{URL_format}installing_{URL_product_virt}_as_a_self-hosted_engine_using_the_command_line/index#Migrating_Data_Warehouse_to_a_Separate_Machine_SHE_cli_deploy[No, but can be enabled].
 |===

--- a/source/documentation/common/prereqs/ref-Host_PCI_Device_Requirements.adoc
+++ b/source/documentation/common/prereqs/ref-Host_PCI_Device_Requirements.adoc
@@ -8,4 +8,4 @@
 
 Hosts must have at least one network interface with a minimum bandwidth of 1 Gbps. Each host should have two network interfaces, with one dedicated to supporting network-intensive activities, such as virtual machine migration. The performance of such operations is limited by the bandwidth available.
 
-For information about how to use PCI Express and conventional PCI devices with Intel Q35-based virtual machines, see link:https://access.redhat.com/articles/3201152[_Using PCI Express and Conventional PCI Devices with the Q35 Virtual Machine_].
+For information about how to use PCI Express and conventional PCI devices with Intel Q35-based virtual machines, see link:https://wiki.qemu.org/images/4/4e/Q35.pdf[_Q35_] and link:https://wiki.qemu.org/images/f/f6/PCIvsPCIe.pdf[_PCI vs PCI Express in Q35_].

--- a/source/documentation/common/prereqs/ref-Host_Storage_Requirements.adoc
+++ b/source/documentation/common/prereqs/ref-Host_Storage_Requirements.adoc
@@ -21,10 +21,10 @@ The minimum storage requirements for host installation are listed below. However
 * /var/log - 8 GB
 * /var/log/audit - 2 GB
 * /var/tmp - 10 GB
-* swap - 1 GB. See link:https://access.redhat.com/solutions/15244[What is the recommended swap size for Red Hat platforms?] for details.
+* swap - 1 GB. 
 * Anaconda reserves 20% of the thin pool size within the volume group for future metadata expansion. This is to prevent an out-of-the-box configuration from running out of space under normal usage conditions. Overprovisioning of thin pools during installation is also not supported.
 * *Minimum Total - 64 GiB*
 
 If you are also installing the {engine-appliance-name} for self-hosted engine installation, `/var/tmp` must be at least 10 GB.
 
-If you plan to use memory overcommitment, add enough swap space to provide virtual memory for all of virtual machines. See link:{URL_virt_product_docs}{URL_format}administration_guide/index#Memory_Optimization[Memory Optimization].
+If you plan to use memory overcommitment, add enough swap space to provide virtual memory for all of virtual machines. See link:{URL_virt_product_docs}{URL_format}administration_guide/index#Cluster_Optimization_Settings_Explained[Memory Optimization].

--- a/source/documentation/common/prereqs/ref-MTU_Requirements.adoc
+++ b/source/documentation/common/prereqs/ref-MTU_Requirements.adoc
@@ -6,4 +6,45 @@
 // PPG
 // Install
 
-The recommended Maximum Transmission Units (MTU) setting for Hosts during deployment is 1500. It is possible to update this setting after the environment is set up to a different MTU. For more information on changing the MTU setting, see link:https://access.redhat.com/solutions/4129641[How to change the Hosted Engine VM network MTU].
+The recommended Maximum Transmission Units (MTU) setting for Hosts during deployment is 1500. It is possible to update this setting after the environment is set up to a different MTU. 
+Starting with {virt-product-fullname} 4.2, these changes can be made from the Admin Portal, however will require a reboot of the Hosted Engine VM and any other VM's using the management network should be powered down first.
+
+* Shutdown or unplug the vNIcs of all VM's that use the management network except for {engine-name}.
+* Change the MTU via Admin Portal - Network -> Networks -> Select the management network -> Edit -> MTU
+* Enable Global Maintenance:
+
+[source,terminal,subs="normal"]
+----
+# hosted-engine --set-maintenance --mode=global
+----
+
+* Then shutdown the HE VM:
+
+[source,terminal,subs="normal"]
+----
+# hosted-engine --vm-shutdown
+----
+
+* Check the status to confirm it is down:
+
+[source,terminal,subs="normal"]
+----
+# hosted-engine --vm-status
+----
+
+* Start the VM again:
+
+[source,terminal,subs="normal"]
+----
+  # hosted-engine --vm-start
+----
+
+* Check the status again to ensure it is back up and try to migrate the HE VM, the MTU value should persist through migrations.
+* If everything looks OK, disable Global Maintenance:
+
+[source,terminal,subs="normal"]
+----
+# hosted-engine --set-maintenance --mode=none
+----
+
+Note: Only the {engine-name} VM can be using the management network while making these changes (all other VM's using the management network should be down), otherwise the config does not come into effect immediately, and causes the VM to boot yet again with wrong MTU even after the change.

--- a/source/documentation/common/prereqs/ref-Manager_Client_Requirements.adoc
+++ b/source/documentation/common/prereqs/ref-Manager_Client_Requirements.adoc
@@ -8,7 +8,7 @@
 // Introduction_to_the_Administration_Portal
 // Introduction_to_the_VM_Portal
 
-Virtual machine consoles can only be accessed using supported Remote Viewer (`virt-viewer`) clients on {enterprise-linux} and Windows. To install `virt-viewer`, see link:{URL_virt_product_docs}{URL_format}virtual_machine_management_guide/index#sect-installing_supporting_components[Installing Supporting Components on Client Machines] in the _Virtual Machine Management Guide_. Installing `virt-viewer` requires Administrator privileges.
+Virtual machine consoles can only be accessed using supported Remote Viewer (`virt-viewer`) clients on {enterprise-linux} and Windows. To install `virt-viewer`, see link:{URL_virt_product_docs}{URL_format}virtual_machine_management_guide/index#sect-Installing_Supporting_Components[Installing Supporting Components on Client Machines] in the _Virtual Machine Management Guide_. Installing `virt-viewer` requires Administrator privileges.
 
 You can access virtual machine consoles using the SPICE, VNC, or RDP (Windows only) protocols. You can install the QXLDOD graphical driver in the guest operating system to improve the functionality of SPICE. SPICE currently supports a maximum resolution of 2560x1600 pixels.
 

--- a/source/documentation/common/prereqs/ref-Manager_Firewall_Requirements.adoc
+++ b/source/documentation/common/prereqs/ref-Manager_Firewall_Requirements.adoc
@@ -12,13 +12,6 @@ The `engine-setup` script can configure the firewall automatically.
 
 The firewall configuration documented here assumes a default configuration.
 
-ifdef::rhv-doc[]
-[NOTE]
-====
-A diagram of these firewall requirements is available at https://access.redhat.com/articles/3932211.
-You can use the IDs in the table to look up connections in the diagram.
-====
-endif::[]
 
 .{virt-product-fullname} {engine-name} Firewall Requirements
 [options="header", cols="3,3,3,4,4,4,4", frame=all, grid=all]
@@ -52,7 +45,7 @@ VM Portal clients |{virt-product-fullname} {engine-name} |Provides websocket pro
 |No
 |M6 |7410 |UDP |{hypervisor-fullname}s
 
-{enterprise-linux-host-fullname}s |{virt-product-fullname} {engine-name} |If Kdump is enabled on the hosts, open this port for the fence_kdump listener on the {engine-name}. See link:{URL_virt_product_docs}{URL_format}administration_guide/index#sect-fence_kdump_Advanced_Configuration[fence_kdump Advanced Configuration]. `fence_kdump` doesn't provide a way to encrypt the connection. However, you can manually configure this port to block access from hosts that are not eligible.
+{enterprise-linux-host-fullname}s |{virt-product-fullname} {engine-name} |If Kdump is enabled on the hosts, open this port for the fence_kdump listener on the {engine-name}. See link:{URL_virt_product_docs}{URL_format}administration_guide/index#fence_kdump_Advanced_Configuration[fence_kdump Advanced Configuration]. `fence_kdump` doesn't provide a way to encrypt the connection. However, you can manually configure this port to block access from hosts that are not eligible.
 |No
 |M7 |54323 |TCP |Administration Portal clients |{virt-product-fullname} {engine-name} (`ovirt-imageio` service) |Required for communication with the `ovirt-imageo` service.
 |Yes

--- a/source/documentation/common/prereqs/ref-Manager_Hardware_Requirements.adoc
+++ b/source/documentation/common/prereqs/ref-Manager_Hardware_Requirements.adoc
@@ -8,11 +8,8 @@
 
 The minimum and recommended hardware requirements outlined here are based on a typical small to medium-sized installation. The exact requirements vary between deployments based on sizing and load.
 
-ifdef::rhv-doc[]
-Hardware certification for {virt-product-fullname} is covered by the hardware certification for {enterprise-linux}. For more information, see link:https://access.redhat.com/solutions/725243[Does Red Hat Virtualization also have hardware certification?]. To confirm whether specific hardware items are certified for use with {enterprise-linux}, see link:https://catalog.redhat.com/hardware[Red Hat certified hardware].
-endif::[]
 ifdef::ovirt-doc[]
-The {virt-product-fullname} {engine-name} runs on {enterprise-linux} operating systems like link:https://www.centos.org/[CentOS Linux] or link:https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux[Red Hat Enterprise Linux].
+The {virt-product-fullname} {engine-name} runs on {enterprise-linux} operating systems like link:https://www.centos.org/[CentOS Linux Stream 9] or link:https://www.almalinux.org/[AlmaLinux 9] 
 endif::[]
 
 .{virt-product-fullname} {engine-name} Hardware Requirements
@@ -22,7 +19,5 @@ endif::[]
 |CPU |A dual core x86_64 CPU. |A quad core x86_64 CPU or multiple dual core x86_64 CPUs.
 |Memory |4 GB of available system RAM if Data Warehouse is not installed and if memory is not being consumed by existing processes. |16 GB of system RAM.
 |Hard Disk |25 GB of locally accessible, writable disk space. |50 GB of locally accessible, writable disk space.
-
-You can use the link:https://access.redhat.com/labs/rhevmhdsc/[RHV {engine-name} History Database Size Calculator] to calculate the appropriate disk space for the {engine-name} history database size.
 |Network Interface |1 Network Interface Card (NIC) with bandwidth of at least 1 Gbps. |1 Network Interface Card (NIC) with bandwidth of at least 1 Gbps.
 |===

--- a/source/documentation/planning_and_prerequisites_guide/topics/con-Directory_Server_Support.adoc
+++ b/source/documentation/planning_and_prerequisites_guide/topics/con-Directory_Server_Support.adoc
@@ -2,7 +2,7 @@
 [id="directory-server-support"]
 = Directory Server Support
 
-During installation, {virt-product-fullname} {engine-name} creates a default *admin* user in a default *internal* domain. This account is intended for use when initially configuring the environment, and for troubleshooting. You can create additional users on the *internal* domain using `ovirt-aaa-jdbc-tool`. User accounts created on local domains are known as local users. See link:{URL_virt_product_docs}{URL_format}administration_guide/index#sect-administering_user_tasks_from_the_commandline[Administering User Tasks From the Command Line] in the _Administration Guide_.
+During installation, {virt-product-fullname} {engine-name} creates a default *admin* user in a default *internal* domain. This account is intended for use when initially configuring the environment, and for troubleshooting. You can create additional users on the *internal* domain using `ovirt-aaa-jdbc-tool`. User accounts created on local domains are known as local users. See link:{URL_virt_product_docs}{URL_format}administration_guide/index#sect-Administering_User_Tasks_From_the_commandline[Administering User Tasks From the Command Line] in the _Administration Guide_.
 
 You can also attach an external directory server to your {virt-product-fullname} environment and use it as an external domain. User accounts created on external domains are known as directory users. Attachment of more than one directory server to the {engine-name} is also supported.
 

--- a/source/documentation/planning_and_prerequisites_guide/topics/con-General_Recommendations.adoc
+++ b/source/documentation/planning_and_prerequisites_guide/topics/con-General_Recommendations.adoc
@@ -6,11 +6,11 @@
 
 * Avoid running any service that {virt-product-fullname} depends on as a virtual machine in the same environment. If this is done, it must be planned carefully to minimize downtime, if the virtual machine containing that service incurs downtime.
 
-* Ensure the bare-metal host or virtual machine that the {virt-product-fullname} {engine-name} will be installed on has enough entropy. Values below 200 can cause the {engine-name} setup to fail. To check the entropy value, run `cat /proc/sys/kernel/random/entropy_avail`. To increase entropy, install the `rng-tools` package and follow the steps in link:https://access.redhat.com/solutions/1395493[How can I customize rngd service startup?].
+* Ensure the bare-metal host or virtual machine that the {virt-product-fullname} {engine-name} will be installed on has enough entropy. Values below 200 can cause the {engine-name} setup to fail. To check the entropy value, run `cat /proc/sys/kernel/random/entropy_avail`. 
 
 * You can automate the deployment of hosts and virtual machines using PXE, Kickstart, Satellite, CloudForms, Ansible, or a combination thereof. However, installing a self-hosted engine using PXE is not supported. See:
 
-** link:{URL_virt_product_docs}{URL_format}installing_{URL_product_virt}_as_a_standalone_manager_with_local_databases/index#Automating_RHVH_Deployment[Automating {hypervisor-fullname} Deployment] for the additional requirements for automated {hypervisor-shortname} deployment using PXE and Kickstart.
+** link:{URL_virt_product_docs}{URL_format}installing_{URL_product_virt}_as_a_standalone_manager_with_local_databases/index#Automating_RHVH_Deployment_SM_localDB_deploy[Automating {hypervisor-fullname} Deployment] for the additional requirements for automated {hypervisor-shortname} deployment using PXE and Kickstart.
 ** Performing a Standard Installation.
 ** Performing an Advanced Installation.
 

--- a/source/documentation/planning_and_prerequisites_guide/topics/con-Infrastructure_Considerations.adoc
+++ b/source/documentation/planning_and_prerequisites_guide/topics/con-Infrastructure_Considerations.adoc
@@ -17,8 +17,7 @@ You can also host the Data Warehouse service and the Data Warehouse database sep
 *{engine-name} database*:: To host the {engine-name} database on the {engine-name}, select `Local` when prompted by `engine-setup`.
 +
 To host the {engine-name} database on a remote machine, see link:{URL_virt_product_docs}{URL_format}installing_{URL_product_virt}_as_a_standalone_manager_with_remote_databases/index#Preparing_a_Remote_PostgreSQL_Database_install_RHVM[Preparing a Remote PostgreSQL Database] in _Installing {virt-product-fullname} as a standalone {engine-name} with remote databases_ before running `engine-setup` on the {engine-name}.
-+
-To migrate the {engine-name} database post-installation, see link:{URL_virt_product_docs}{URL_format}administration_guide/index#Migrating_the_Engine_Database_to_a_Remote_Server_Database[Migrating the Engine Database to a Remote Server Database] in the _Administration Guide_.
+
 
 *Websocket proxy*:: To host the websocket proxy on the {engine-name}, select `Yes` when prompted by `engine-setup`.
 

--- a/source/documentation/planning_and_prerequisites_guide/topics/con-Storage_Types.adoc
+++ b/source/documentation/planning_and_prerequisites_guide/topics/con-Storage_Types.adoc
@@ -8,12 +8,6 @@ A storage domain can be made of either block devices (iSCSI or Fibre Channel) or
 
 By default, GlusterFS domains and local storage domains support 4K block size. 4K block size can provide better performance, especially when using large files, and it is also necessary when you use tools that require 4K compatibility, such as VDO.
 
-ifdef::rhv-doc[]
-[NOTE]
-====
-GlusterFS Storage is deprecated, and will no longer be supported in future releases.
-====
-endif::rhv-doc[]
 
 [IMPORTANT]
 ====
@@ -35,7 +29,7 @@ As NFS exports are grown to accommodate more storage needs, {virt-product-fullna
 
 See:
 
-* link:{URL_virt_product_docs}{URL_format}administration_guide/index#sect-preparing_and_adding_nfs_storage[Preparing and Adding NFS Storage] in the _Administration Guide_.
+* link:{URL_virt_product_docs}{URL_format}administration_guide/index#sect-Preparing_and_Adding_NFS_Storage[Preparing and Adding NFS Storage] in the _Administration Guide_.
 
 [id="iscsi"]
 == iSCSI
@@ -68,7 +62,7 @@ To use Fibre Channel over Ethernet (FCoE) in {virt-product-fullname}, you must e
 
 See:
 
-* link:{URL_virt_product_docs}{URL_format}administration_guide/index#how_to_set_up_rhvm_to_use_fcoe[How to Set Up {virt-product-fullname} {engine-name} to Use FCoE] in the _Administration Guide_.
+* link:{URL_virt_product_docs}{URL_format}administration_guide/index#How_to_Set_Up_RHVM_to_Use_FCoE[How to Set Up {virt-product-fullname} {engine-name} to Use FCoE] in the _Administration Guide_.
 
 [id="rhhi"]
 == oVirt Hyperconverged Infrastructure


### PR DESCRIPTION

Changes proposed in this pull request: 

- Remove reference to obsolete (and missing) sizing guide
- Updated reference from EL 8 to EL 9
- Replaced reference to Red Hat HA products
- Cleaned up references to RHEL
- Added references to CentOS Stream and AlmaLinux
- Fixed internal document section references for virt-viewer
- Updated attribute for supported Linux to be EL 9 or later, rather then 8.7
- Removed swap space reference to restricted red hat doco
- Fixed memory optimization section reference
- Added replacement links for Q35 machine type and PCI (PCIE) references
- Removed red hat link for disabling IPV6 and just left it as do not disable IPV6
- Removed RHV engine firewall section
- Fixed section link for kdump fencing for engine
- removed the RHV firewall section for the Database Server
- Corrected the section references for the the Database server firewall rules
- Added documentation on how to update MTU replacing link to Red Hat material
- Fixed links for NFS
- Fixed links for FCoE
- Fixed references to CLI actions for user management in the directory management section
- Removed the engine database migration as there is no corresponding element in the current documentation
- Removed the rngd service links to red hat as the information is available elsewhere
- Fixed reference for automated engine installation

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): @gocallag 

This pull request needs review by: @dupondje 
