### PR TITLE
ui: fix hyperlinks to the mailing list

### DIFF
--- a/data/navigation.yml
+++ b/data/navigation.yml
@@ -3,5 +3,5 @@
 - Documentation: /documentation/
 - Developers: /develop/
 - Community: /community/
-- Forum: //lists.ovirt.org/archives/
+- Forum: //lists.ovirt.org/
 - Blog: //blogs.ovirt.org/

--- a/source/community/about/mailing-lists.md
+++ b/source/community/about/mailing-lists.md
@@ -6,6 +6,7 @@ authors:
   - dneary
   - quaid
   - theron
+  - Jasper Berton
 ---
 
 # Mailing lists
@@ -14,14 +15,14 @@ There are many mailing lists in the oVirt project - mostly referenced on [the oV
 
 ## User-oriented lists
 
-*   [Announce](https://lists.ovirt.org/archives/list/announce@ovirt.org):@ovirt.org/ Announcements about the oVirt project
+*   [Announce](https://lists.ovirt.org/hyperkitty/list/announce@ovirt.org/):@ovirt.org/ Announcements about the oVirt project
 *   [Users](/community/users-list.html):@ovirt.org/ The best place for oVirt user issues - installation, configuration, storage integration, use-cases
 
 ## Developer-oriented list
 
-*   [Devel](https://lists.ovirt.org/archives/list/devel@ovirt.org):@ovirt.org/ Project-wide developer-related issues. Anything which requires the feedback or awareness of developers within the oVirt project should go here.
+*   [Devel](https://lists.ovirt.org/hyperkitty/list/devel@ovirt.org/):@ovirt.org/ Project-wide developer-related issues. Anything which requires the feedback or awareness of developers within the oVirt project should go here.
 
 ## Project governance and management
 
-*   [Board](https://lists.ovirt.org/archives/list/board@ovirt.org):@ovirt.org/ Discussions amongst the Board for all business
-*   [Infra](https://lists.ovirt.org/archives/list/infra@ovirt.org):@ovirt.org/ List for oVirt.org Infrastructure team
+*   [Board](https://lists.ovirt.org/hyperkitty/list/board@ovirt.org/):@ovirt.org/ Discussions amongst the Board for all business
+*   [Infra](https://lists.ovirt.org/hyperkitty/list/infra@ovirt.org/):@ovirt.org/ List for oVirt.org Infrastructure team

--- a/source/community/becoming-an-infrastructure-team-member.md
+++ b/source/community/becoming-an-infrastructure-team-member.md
@@ -15,7 +15,7 @@ This page describes the process for becoming a member of the Infrastructure team
 
 The Infrastructure team primarily uses three resources to get stuff done:
 
-* [The infra mailing list](https://lists.ovirt.org/archives/list/infra@ovirt.org/) for asynchronous communication
+* [The infra mailing list](https://lists.ovirt.org/hyperkitty/list/infra@ovirt.org/) for asynchronous communication
 * [The infra ticketing system](https://issues.redhat.com/projects/CPDEVOPS/summary) for issue tracking
 
 In general, the team hangs out on the general `#ovirt` IRC channel on OFTC (`irc.oftc.net`).

--- a/source/community/index.md
+++ b/source/community/index.md
@@ -44,7 +44,7 @@ There are a few ways to engage with the oVirt Community:
 
 - [Events](/events/)
 - [Archived Conferences Presentations](archived_conferences_presentations.html)
-- [Forums / Mailing lists](https://lists.ovirt.org/archives/)
+- [Forums / Mailing lists](https://lists.ovirt.org)
 - [oVirt Facebook group](https://www.facebook.com/groups/ovirt.openvirtualization/)
 - [Twitter](https://twitter.com/ovirt)
 - IRC -- `#ovirt` on `irc.oftc.net`

--- a/source/community/users-list.md
+++ b/source/community/users-list.md
@@ -7,7 +7,7 @@ no_container: true
 
 # Users list
 
-The [users mailing list](https://lists.ovirt.org/archives/list/users@ovirt.org/) is the main place for getting help, asking questions, consulting about setup design/hardware/configuration/performance etc., and of course sharing your experience.
+The [users mailing list](https://lists.ovirt.org/hyperkitty/list/users@ovirt.org/) is the main place for getting help, asking questions, consulting about setup design/hardware/configuration/performance etc., and of course sharing your experience.
 
 ## Getting help
 

--- a/source/develop/developer-guide/migrating_to_github.md
+++ b/source/develop/developer-guide/migrating_to_github.md
@@ -26,7 +26,7 @@ The procedure for activating the mirroring is described within the [oVirt Infra 
 In order to deactivate the mirroring, the procedure must be reverted. As a pre-requisite you need to have gerrit administrator rights. If you are missing these rights, either:
 
 * Open a ticket on [the infra ticketing system](https://issues.redhat.com/projects/CPDEVOPS/summary)
-* Or ask on the [devel@ovirt.org](https://lists.ovirt.org/archives/list/devel@ovirt.org/) mailing list
+* Or ask on the [devel@ovirt.org](https://lists.ovirt.org/hyperkitty/list/devel@ovirt.org/) mailing list
 * Or ask for [joining the oVirt infrastructure team](/develop/infra/infrastructure.html)
 
 If you have a user with admin permission on Gerrit:
@@ -225,7 +225,7 @@ If you choose to add the `config.yml` within the `ISSUE_TEMPLATE` folder, you ca
 blank_issues_enabled: true
 contact_links:
   - name: oVirt Mailing Lists
-    url: https://lists.ovirt.org/archives/
+    url: https://lists.ovirt.org/
     about: Join us on the mailing list for more conversations and community support
   - name: oVirt User Documentation
     url: https://ovirt.org/documentation/

--- a/source/develop/developer-guide/readme_template.md
+++ b/source/develop/developer-guide/readme_template.md
@@ -27,5 +27,5 @@ If you find a documentation issue on the oVirt website, please navigate to the p
 
 ## Still need help?
 
-If you have any other questions or suggestions, you can join and contact us on the [oVirt Users forum / mailing list](https://lists.ovirt.org/admin/lists/users.ovirt.org/).
+If you have any other questions or suggestions, you can join and contact us on the [oVirt Users forum / mailing list](https://lists.ovirt.org/hyperkitty/list/users@ovirt.org/).
 ```

--- a/source/develop/index.md
+++ b/source/develop/index.md
@@ -26,8 +26,8 @@ If you have no spare resources for providing a shared storage, you can configure
 
 Please follow the [user documentation](/documentation/index.html) for deploying your system.
 
-Sign up for the [devel@ovirt.org](https://lists.ovirt.org/archives/list/devel@ovirt.org/) mailing list and send us an email saying how you would like to contribute.
-Visit our [mailing lists](https://lists.ovirt.org/archives/) page for other oVirt mailing lists to sign up for.
+Sign up for the [devel@ovirt.org](https://lists.ovirt.org/hyperkitty/list/devel@ovirt.org/) mailing list and send us an email saying how you would like to contribute.
+Visit our [mailing lists](https://lists.ovirt.org/) page for other oVirt mailing lists to sign up for.
 
 For fluent, real time communication, you can [join us on IRC](/community/about/contact.html#irc) or [join us on Matrix](/community/about/contact.html#matrix).
 
@@ -52,7 +52,7 @@ Within oVirt project several teams are taking care of different aspects of the s
 - Virtualization: responsible for VM lifecycle, System and host level scheduling / SLA
 - User Experience: responsible for UI Infra and overall UX consistency.
 
-The teams are discussing their work on [devel@ovirt.org](https://lists.ovirt.org/archives/list/devel@ovirt.org/) mailing list so to join a team
+The teams are discussing their work on [devel@ovirt.org](https://lists.ovirt.org/hyperkitty/list/devel@ovirt.org/) mailing list so to join a team
 you should start getting involved in these conversations.
 
 ## Contributing Code
@@ -63,7 +63,7 @@ Contributions of all types are gladly accepted!
 
 There are many repositories (sub-projects) within oVirt, details about the public repositories can be found over at the [oVirt GitHub Project](https://github.com/orgs/oVirt/repositories?type=public). 
 
-If you are looking for some task to pick up, you can ask for it on [devel@ovirt.org](https://lists.ovirt.org/archives/list/devel@ovirt.org/) mailing list.
+If you are looking for some task to pick up, you can ask for it on [devel@ovirt.org](https://lists.ovirt.org/hyperkitty/list/devel@ovirt.org/) mailing list.
 As an alternative you can look at open tickets on [oVirt GitHub issues](https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aovirt+archived%3Afalse) and once you choose what to work on
 please comment on the ticket you are looking into it. If the ticket has already an assignee, please get in touch with the assignee before starting to work on the ticket.
 
@@ -75,6 +75,6 @@ You can find us on both our [Mailing lists](/community/about/mailing-lists.html)
 ## Setting up a development environment
 
 Each subproject should have instructions on how to setup your development environment to be able to develop and test your changes.
-If you don't find adequate documentation and you need help, please contact us on [IRC](/community/about/contact.html#irc), on [Matrix](/community/about/contact.html#matrix) or on the [devel@ovirt.org](https://lists.ovirt.org/archives/list/devel@ovirt.org/) mailing list.
+If you don't find adequate documentation and you need help, please contact us on [IRC](/community/about/contact.html#irc), on [Matrix](/community/about/contact.html#matrix) or on the [devel@ovirt.org](https://lists.ovirt.org/hyperkitty/list/devel@ovirt.org/) mailing list.
 
 </section>

--- a/source/develop/infra/infrastructure-team-meetings.md
+++ b/source/develop/infra/infrastructure-team-meetings.md
@@ -558,7 +558,7 @@ This page is for tracking agenda, notes, logs, and etc. about each oVirt Infrast
 
 ### 2013-01-07
 
-*[Minutes](https://lists.ovirt.org/pipermail/infra/2013-January/001800.html)*
+*[Minutes](https://lists.ovirt.org/hyperkitty/list/users@ovirt.org/thread/5VNSWQUXWKKJWS2BVIYWVUGLLLWTDFQR/)
 
 *   New hosting design
     -   Review & discuss & improve upon draft: new_hosting_design_Jan_2013
@@ -820,7 +820,7 @@ This page is for tracking agenda, notes, logs, and etc. about each oVirt Infrast
 
 ### 2012-07-31
 
-*[Minutes](https://lists.ovirt.org/pipermail/infra/2012-July/000745.html)*
+*[Minutes]
 
 **Agenda**
 

--- a/source/develop/infra/infrastructure.md
+++ b/source/develop/infra/infrastructure.md
@@ -90,7 +90,7 @@ to the new [infra ticketing system](https://issues.redhat.com/projects/CPDEVOPS/
 
 The main thing is to communicate with us if you have any questions, are interested in learning more, or want to participate in supporting oVirt infrastructure.
 
-*   [Mailing list infra@ovirt.org](https://lists.ovirt.org/archives/list/infra@ovirt.org/)
+*   [Mailing list infra@ovirt.org](https://lists.ovirt.org/hyperkitty/list/infra@ovirt.org/)
 *   [IRC channel #ovirt on OFTC](irc://irc.oftc.net/#ovirt)
 
 ### Meetings
@@ -99,7 +99,7 @@ The main thing is to communicate with us if you have any questions, are interest
 
 ### Decision process
 
-* The Infra team generally follows the principle that if it wasn't discussed on the [mailing list](https://lists.ovirt.org/archives/list/infra@ovirt.org/) it didn't really happen.
+* The Infra team generally follows the principle that if it wasn't discussed on the [mailing list](https://lists.ovirt.org/hyperkitty/list/infra@ovirt.org/) it didn't really happen.
 * This means all important or broad-reaching decisions are discussed and decided on the mailing list.
 * The team uses the same [collaborative decision process](https://blogs.apache.org/comdev/entry/how_apache_projects_use_consensus) that other oVirt teams use, with some lightweight elements added to move along minor votes
   * +1 is a vote in favor of a proposition

--- a/source/develop/release-management/features/network/device-custom-properties.md
+++ b/source/develop/release-management/features/network/device-custom-properties.md
@@ -149,7 +149,7 @@ As this is a 3.3 feature, all 3.2 (and down) cluster related entities should not
 
 ## Documentation / External references
 
-*   Benoit ML asking for per-vNIC custom properties: <https://lists.ovirt.org/pipermail/users/2012-November/010857.html>
+*   Benoit ML asking for per-vNIC custom properties: <https://lists.ovirt.org/hyperkitty/list/users@ovirt.org/thread/QSQ6WCVS5EBWWRVAVEVXEGDPJI3VO6VW/>
 *   [Features/Quantum_Integration](/develop/release-management/features/network/osn-integration.html)
 *   Almost any interesting hook for [hotplug disk](https://bugzilla.redhat.com/show_bug.cgi?id=908656) is going to require per-disk triggering proprty
 

--- a/source/develop/release-management/features/network/ipv6-support.md
+++ b/source/develop/release-management/features/network/ipv6-support.md
@@ -248,7 +248,6 @@ By implementing this feature oVirt will be prepared for users that are using IPv
 ## Documentation / External references
 
 *   Presentation for Ovirt networking team [ODP](https://resources.ovirt.org/old-site-files/wiki/Ipv6-session.odp)
-*   <https://lists.ovirt.org/pipermail/users/2014-December/030135.html>
 
 ## Testing
 

--- a/source/develop/release-management/features/network/migration-network.md
+++ b/source/develop/release-management/features/network/migration-network.md
@@ -192,7 +192,7 @@ Note that the migration protocol requires Vdms-Vdsm and libvirt-libvirt communic
 
 ## Documentation / External references
 
-*   Yuval M asking to choose a network for migration data: <https://lists.ovirt.org/pipermail/users/2013-January/011301.html>
+*   Yuval M asking to choose a network for migration data: <https://lists.ovirt.org/hyperkitty/list/users@ovirt.org/thread/V2TL6QD6INFF5ZG4MSMVOFNPCWZL2YXX/>
 
 ## Comments and Discussion
 

--- a/source/develop/release-management/features/network/nicless-network.md
+++ b/source/develop/release-management/features/network/nicless-network.md
@@ -90,7 +90,7 @@ No changes will be done to the REST API, but the implementation will allow speci
 
 <!-- -->
 
-*   NAT-based host-only network requested by DHC <https://lists.ovirt.org/pipermail/users/2012-April/001751.html>
+*   NAT-based host-only network requested by DHC <https://lists.ovirt.org/hyperkitty/list/users@ovirt.org/thread/ED3I6QKRNZ6QEEPNIFVR2JPWER2GUMRQ/>
 
 
 

--- a/source/develop/release-management/features/sla/engine-high-availability.md
+++ b/source/develop/release-management/features/sla/engine-high-availability.md
@@ -8,7 +8,7 @@ authors:
 
 # Engine High Availability
 
-This page was created as a result of a [discussion](https://lists.ovirt.org/pipermail/engine-devel/2013-August/005436.html) that started at @engine_devel.
+This page was created as a result of a discussion that started at @engine_devel.
 As we are considering an active/active architecture for Engine, we'll use this page to document required features and code changes that will be required.
 
 ## Architecture

--- a/source/develop/release-management/features/virt/vmpayload.md
+++ b/source/develop/release-management/features/virt/vmpayload.md
@@ -117,8 +117,4 @@ Affected oVirt projects:
 *   Webadmin
 *   User Portal
 
-## Documentation / External references
-
-*   <https://lists.ovirt.org/pipermail/engine-devel/2012-January/000423.html>
-
 

--- a/source/develop/release-management/process/add_a_package_to_copr.md
+++ b/source/develop/release-management/process/add_a_package_to_copr.md
@@ -62,4 +62,4 @@ Once your project is ready, the last step is activating the COPR web hook. The p
 Once everything is set, you can add a badge to your sub-project README file. Get the code to do that from
 `https://copr.fedorainfracloud.org/coprs/ovirt/ovirt-master-snapshot/package/<change this with your new package name>/`.
 
-If you need help, feel free to reach out to the [devel@ovirt.org](https://lists.ovirt.org/archives/list/devel@ovirt.org/) mailing list.
+If you need help, feel free to reach out to the [devel@ovirt.org](https://lists.ovirt.org/hyperkitty/list/devel@ovirt.org/) mailing list.

--- a/source/develop/release-management/releases/3.6/index.md
+++ b/source/develop/release-management/releases/3.6/index.md
@@ -147,8 +147,8 @@ For upgrading now you just need to execute:
 
 Please refer to the following threads on users mailing list:
 
-*   [Upgrade path from Fedora 20 oVirt 3.5 to Fedora 22 oVirt 3.6 - Suggested procedure](https://lists.ovirt.org/pipermail/users/2015-November/035791.html)
-*   [Upgrade path from Fedora 20 oVirt 3.5 to Fedora 22 oVirt 3.6 - User experience](https://lists.ovirt.org/pipermail/users/2015-November/035882.html)
+*   [Upgrade path from Fedora 20 oVirt 3.5 to Fedora 22 oVirt 3.6 - Suggested procedure](https://lists.ovirt.org/hyperkitty/list/users@ovirt.org/thread/ZE3BSVONLIXXSVTNVXN5CJHSBL7TT2GU/)
+*   [Upgrade path from Fedora 20 oVirt 3.5 to Fedora 22 oVirt 3.6 - User experience](https://lists.ovirt.org/hyperkitty/list/users@ovirt.org/thread/ZMW3B7IGCOUHGOEMIYOEXOOORVP2IK2P/)
 
 ## Debian Jessie
 

--- a/source/develop/release-management/releases/3.6/release-management.md
+++ b/source/develop/release-management/releases/3.6/release-management.md
@@ -103,7 +103,7 @@ The following list is a subset of the features proposed for oVirt 3.6
 *   Drop support for Fedora <= 20
 *   [Add support for Fedora 22](/develop/release-management/features/integration/fedora-22-support.html)
 *   Add support for Ubuntu hosts
-*   No support for new features on el6. el6 hosts would be allowed only in [3.5 compatibility mode](https://lists.ovirt.org/pipermail/users/2014-September/027421.html).
+*   No support for new features on el6. el6 hosts would be allowed only in 3.5 compatibility mode.
 *   Hosted Engine support only on hosts supporting 3.6 compatibility level (EL7 and Fedora). A guide will be provided for migrating from EL6
 
 ## Tracker Bug

--- a/source/documentation/common/install/proc-Enabling_the_Red_Hat_Virtualization_Manager_Repositories.adoc
+++ b/source/documentation/common/install/proc-Enabling_the_Red_Hat_Virtualization_Manager_Repositories.adoc
@@ -107,7 +107,7 @@ If you are going to install on RHEL or derivatives please follow link:/download/
 
 [NOTE]
 ====
-As link:https://lists.ovirt.org/archives/list/users@ovirt.org/thread/DMCC5QCHL6ECXN674JOLABH36U2LVJLJ/[discussed in oVirt Users mailing list]
+As link:https://lists.ovirt.org/hyperkitty/list/users@ovirt.org/thread/DMCC5QCHL6ECXN674JOLABH36U2LVJLJ/[discussed in oVirt Users mailing list]
 we suggest the user community to use link:/develop/dev-process/install-nightly-snapshot.html[oVirt master snapshot repositories]
 ensuring that the latest fixes for the platform regressions will be promptly available.
 ====

--- a/source/documentation/common/upgrade/proc-Manually_Updating_Hosts.adoc
+++ b/source/documentation/common/upgrade/proc-Manually_Updating_Hosts.adoc
@@ -53,7 +53,7 @@ Upgrading from an older 4.5 to latest 4.5:
 
 [NOTE]
 ====
-As link:https://lists.ovirt.org/archives/list/users@ovirt.org/thread/DMCC5QCHL6ECXN674JOLABH36U2LVJLJ/[discussed in oVirt Users mailing list]
+As link:https://lists.ovirt.org/hyperkitty/list/users@ovirt.org/thread/DMCC5QCHL6ECXN674JOLABH36U2LVJLJ/[discussed in oVirt Users mailing list]
 we suggest the user community to use link:/develop/dev-process/install-nightly-snapshot.html[oVirt master snapshot repositories]
 ensuring that the latest fixes for the platform regressions will be promptly available.
 ====

--- a/source/documentation/common/upgrade/proc-Updating_Individual_Hosts.adoc
+++ b/source/documentation/common/upgrade/proc-Updating_Individual_Hosts.adoc
@@ -53,7 +53,7 @@ ifdef::ovirt-doc[]
 
 [NOTE]
 ====
-As link:https://lists.ovirt.org/archives/list/users@ovirt.org/thread/DMCC5QCHL6ECXN674JOLABH36U2LVJLJ/[discussed in oVirt Users mailing list]
+As link:https://lists.ovirt.org/hyperkitty/list/users@ovirt.org/thread/DMCC5QCHL6ECXN674JOLABH36U2LVJLJ/[discussed in oVirt Users mailing list]
 we suggest the user community to use link:/develop/dev-process/install-nightly-snapshot.html[oVirt master snapshot repositories]
 ensuring that the latest fixes for the platform regressions will be promptly available.
 ====

--- a/source/documentation/common/upgrade/proc-Updating_the_Red_Hat_Virtualization_Manager.adoc
+++ b/source/documentation/common/upgrade/proc-Updating_the_Red_Hat_Virtualization_Manager.adoc
@@ -24,7 +24,7 @@ ifdef::minor_updates[]
 
 [NOTE]
 ====
-As link:https://lists.ovirt.org/archives/list/users@ovirt.org/thread/DMCC5QCHL6ECXN674JOLABH36U2LVJLJ/[discussed in oVirt Users mailing list]
+As link:https://lists.ovirt.org/hyperkitty/list/users@ovirt.org/thread/DMCC5QCHL6ECXN674JOLABH36U2LVJLJ/[discussed in oVirt Users mailing list]
 we suggest the user community to use link:/develop/dev-process/install-nightly-snapshot.html[oVirt master snapshot repositories]
 ensuring that the latest fixes for the platform regressions will be promptly available.
 ====

--- a/source/documentation/common/upgrade/proc-Upgrading_hosts_to_4-5.adoc
+++ b/source/documentation/common/upgrade/proc-Upgrading_hosts_to_4-5.adoc
@@ -37,7 +37,7 @@ If you are going to install on RHEL or derivatives please follow link:/download/
 
 [NOTE]
 ====
-As link:https://lists.ovirt.org/archives/list/users@ovirt.org/thread/DMCC5QCHL6ECXN674JOLABH36U2LVJLJ/[discussed in oVirt Users mailing list]
+As link:https://lists.ovirt.org/hyperkitty/list/users@ovirt.org/thread/DMCC5QCHL6ECXN674JOLABH36U2LVJLJ/[discussed in oVirt Users mailing list]
 we suggest the user community to use link:/develop/dev-process/install-nightly-snapshot.html[oVirt master snapshot repositories]
 ensuring that the latest fixes for the platform regressions will be promptly available.
 ====

--- a/source/documentation/common/upgrade/proc-Upgrading_the_Manager_to_4-5.adoc
+++ b/source/documentation/common/upgrade/proc-Upgrading_the_Manager_to_4-5.adoc
@@ -35,7 +35,7 @@ If you are going to install on RHEL or derivatives please follow link:/download/
 
 [NOTE]
 ====
-As link:https://lists.ovirt.org/archives/list/users@ovirt.org/thread/DMCC5QCHL6ECXN674JOLABH36U2LVJLJ/[discussed in oVirt Users mailing list]
+As link:https://lists.ovirt.org/hyperkitty/list/users@ovirt.org/thread/DMCC5QCHL6ECXN674JOLABH36U2LVJLJ/[discussed in oVirt Users mailing list]
 we suggest the user community to use link:/develop/dev-process/install-nightly-snapshot.html[oVirt master snapshot repositories]
 ensuring that the latest fixes for the platform regressions will be promptly available.
 ====

--- a/source/download/alternate_downloads.md
+++ b/source/download/alternate_downloads.md
@@ -44,7 +44,7 @@ As an exception you can upgrade from 4.3 to 4.5 without upgrading to 4.4 first.
 
 ## Suggestion to use nightly
 
-As [discussed in oVirt Users mailing list](https://lists.ovirt.org/archives/list/users@ovirt.org/thread/DMCC5QCHL6ECXN674JOLABH36U2LVJLJ/)
+As [discussed in oVirt Users mailing list](https://lists.ovirt.org/hyperkitty/list/users@ovirt.org/thread/DMCC5QCHL6ECXN674JOLABH36U2LVJLJ/)
 we suggest the user community to use [oVirt master snapshot repositories](/develop/dev-process/install-nightly-snapshot.html)
 ensuring that the latest fixes for the platform regressions will be promptly available.
 

--- a/source/download/index.md
+++ b/source/download/index.md
@@ -29,7 +29,7 @@ See the [Release Notes for oVirt 4.5.5](/release/4.5.5/).
 
 ## Suggestion to use nightly
 
-As [discussed in oVirt Users mailing list](https://lists.ovirt.org/archives/list/users@ovirt.org/thread/DMCC5QCHL6ECXN674JOLABH36U2LVJLJ/)
+As [discussed in oVirt Users mailing list](https://lists.ovirt.org/hyperkitty/list/users@ovirt.org/thread/DMCC5QCHL6ECXN674JOLABH36U2LVJLJ/)
 we suggest the user community to use [oVirt master snapshot repositories](/develop/dev-process/install-nightly-snapshot.html)
 ensuring that the latest fixes for the platform regressions will be promptly available.
 

--- a/source/release/4.3.6/index.md
+++ b/source/release/4.3.6/index.md
@@ -37,7 +37,7 @@ To learn about features introduced before 4.3.6, see the
 
 ## What's New in 4.3.6?
 
-Release has been updated on [October 8th providing additional fixes](https://lists.ovirt.org/archives/list/announce@ovirt.org/thread/L7HQ3OU3PUEOJZKKZPLDOCUNMZD6UW5C/).
+Release has been updated on [October 8th providing additional fixes](https://lists.ovirt.org/hyperkitty/list/announce@ovirt.org/thread/L7HQ3OU3PUEOJZKKZPLDOCUNMZD6UW5C/).
 
 ### Release Note
 

--- a/source/release/4.5.5/index.md
+++ b/source/release/4.5.5/index.md
@@ -49,7 +49,7 @@ To learn about features introduced before 4.5.5, see the
 
 ## Suggestion to use nightly
 
-As [discussed in oVirt Users mailing list](https://lists.ovirt.org/archives/list/users@ovirt.org/thread/DMCC5QCHL6ECXN674JOLABH36U2LVJLJ/)
+As [discussed in oVirt Users mailing list](https://lists.ovirt.org/hyperkitty/list/users@ovirt.org/thread/DMCC5QCHL6ECXN674JOLABH36U2LVJLJ/)
 we suggest the user community to use [oVirt master snapshot repositories](/develop/dev-process/install-nightly-snapshot.html)
 ensuring that the latest fixes for the platform regressions will be promptly available.
 


### PR DESCRIPTION
[ Bug fix]

Fixes [issue](https://github.com/oVirt/ovirt-site/issues/3211).

Changes proposed in this pull request:

 Due to the needed move of the mailing list the hyperlinks were broken.
 For most of the mentioned archived posts a new hyperlink was able to be found.
 Some were removed due to it being impossible to trace it back which mail thread it was linked to.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): (please @mention yourself to sign)
@JasperB-TeamBlue 

This pull request needs review by: (please @mention the reviewer if relevant)
@peter-boden 
