### PR TITLE
Avoid to hide content with authors box

### DIFF
--- a/source/_sass/lib/site.sass
+++ b/source/_sass/lib/site.sass
@@ -140,6 +140,13 @@ header.post-header
   float: left
   clear: none
   width: min-content
+  // Below md breakpoint, drop float so the author box stacks above #content instead of overlapping.
+  @media screen and (max-width: 1600px)
+    float: none
+    width: 100%
+    max-width: 100%
+    clear: both
+    margin-bottom: 1.5rem
 
 .navForMobileHack
   left: 102px


### PR DESCRIPTION
Bug fix

Fixes issue #3081

Changes proposed in this pull request:

Just a workaround using style to avoid authors box hiding content when not running full screen with recent monitors.

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): @sandrobonazzola 

This pull request needs review by: @JasperB-TeamBlue 
