### PR TITLE
Update GPG key import docs for oVirt 4.5

### DIFF
--- a/source/download/rpms_and_gpg.md
+++ b/source/download/rpms_and_gpg.md
@@ -49,24 +49,23 @@ by any mirror or website that is providing the packages. Nightly repositories wo
 For some repositories, such as repositories with stable in default configuration, yum is able to find a proper key for the repository and asks the user
 for confirmation before importing the key if the key is not already imported into the rpm database.
 
-To get the public key:
+To get the public key for oVirt 4.5:
 
-    $ gpg --recv-keys FE590CB7
-    $ gpg --list-keys --with-fingerprint FE590CB7
+    $ curl -O https://resources.ovirt.org/pub/keys/RPM-GPG-ovirt-v4
+    $ gpg --show-keys --with-fingerprint RPM-GPG-ovirt-v4
     ---
-    pub   2048R/FE590CB7 2014-03-30 [expires: 2028-04-06]
-          Key fingerprint = 31A5 D783 7FAD 7CB2 86CD  3469 AB8C 4F9D FE59 0CB7
-    uid                  oVirt <infra@ovirt.org>
-    sub   2048R/004BC303 2014-03-30 [expires: 2028-04-06]
+    pub   rsa4096 2022-11-02 [SC] [expires: 2032-10-30]
+          3C98 E81D B93D EA6D 54DE  690E 44E4 75CB 2490 1D0C
+    uid                      oVirt <infra@ovirt.org>
     ---
-    $ gpg --export --armor FE590CB7 > ovirt-infra.pub
-    # rpm --import ovirt-infra.pub
+    # rpm --import RPM-GPG-ovirt-v4
 
-Importing keys Automatically for oVirt 4.4:
+The `centos-release-ovirt45` package installs this key automatically at
+`/etc/pki/rpm-gpg/RPM-GPG-KEY-oVirt-4.5`:
 
-    dnf install https://resources.ovirt.org/pub/yum-repo/ovirt-release44.rpm
+    dnf install -y centos-release-ovirt45
 
-**Important:** yum will prompt sysadmin to acknowledge import of key, make sure key id is FE590CB7.
+**Important:** yum will prompt sysadmin to acknowledge import of key, make sure key id is 24901D0C.
 
 ### Verifying a package
 
@@ -82,7 +81,7 @@ If you do not use yum, you can check the signature of the package using the foll
 
 | Key ID     | Key Type     | Key Fingerprint                                     | Key Description | Created    | Expires    | Revoked | Notes |
 |------------|--------------|-----------------------------------------------------|-----------------|------------|------------|---------|-------|
-| `FE590CB7` | 2048-bit RSA | `31A5 D783 7FAD 7CB2 86CD 3469 AB8C 4F9D FE59 0CB7` | oVirt           | 2014-03-30 | 2028-04-06 |         |       |
+| `FE590CB7` | 2048-bit RSA | `31A5 D783 7FAD 7CB2 86CD 3469 AB8C 4F9D FE59 0CB7` | oVirt           | 2014-03-30 | 2028-04-06 |         | Legacy (oVirt 4.4 and older, EOL) |
 |------------|--------------|-----------------------------------------------------|-----------------|------------|------------|---------|-------|
-| `24901D0C` | 4096-bit RSA | `3C98 E81D B93D EA6D 54DE 690E 44E4 75CB 2490 1D0C` | oVirt           | 2022-11-02 | 2032-10-30 |         |       |
+| `24901D0C` | 4096-bit RSA | `3C98 E81D B93D EA6D 54DE 690E 44E4 75CB 2490 1D0C` | oVirt           | 2022-11-02 | 2032-10-30 |         | Current (oVirt 4.5) |
 {: .bordered}


### PR DESCRIPTION
[Bug fix]

  Fixes issue #3114

  Changes proposed in this pull request:

  - The *Importing Keys Manually* section pointed at the legacy `FE590CB7`
    key (2048-bit, oVirt 4.4 and older). oVirt 4.5 packages are signed with
    `24901D0C` (4096-bit), so the example now imports that key from
    `https://resources.ovirt.org/pub/keys/RPM-GPG-ovirt-v4`.
  - Replaced the EOL `ovirt-release44.rpm` automatic-import step with
    `centos-release-ovirt45`, which ships the key at
    `/etc/pki/rpm-gpg/RPM-GPG-KEY-oVirt-4.5`.
  - Annotated the *Currently used keys* table to mark `FE590CB7` as legacy
    (oVirt 4.4 and older) and `24901D0C` as current (oVirt 4.5).

  Notes:

  - `24901D0C` is not published to public keyservers (checked the default
    keyserver and keys.openpgp.org), so the example downloads it from
    `resources.ovirt.org` instead of using `gpg --recv-keys`.
  - The `FE590CB7` expiry (2028-04-06) in the table is left unchanged — it
    is correct; the key's expiry was extended over time
    (`RPM-GPG-ovirt` 2016 → `-v2` 2021 → `-v3` 2028).

  I confirm that this pull request was submitted according to the [contribution
  guidelines](https://github.com/oVirt/ovirt-site/blob/main/CONTRIBUTING.md): @MaoliWolf

  This pull request needs review by: @dupondje @JasperB-TeamBlue